### PR TITLE
feat: dev-environment commands (cwm-setup/link/verify/joomla-install)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added — dev-environment commands lifted from Proclaim
+
+- `bin/cwm-setup` + `scripts/setup.php` — interactive wizard that captures one or
+  more Joomla install paths, URLs, target versions, DB creds, and admin creds.
+  Writes a per-developer `build.properties` (INI sections) in the consuming repo.
+- `bin/cwm-link` + `scripts/link.php` — symlinks the project tree into every
+  configured Joomla install. Auto-derives the standard set of links from
+  `extension.*` and `manifests.extensions[]` (component admin/site/media,
+  library `lib_X` → `libraries/X` + manifest mirror, `plugins/<group>/<element>`,
+  `modules/[admin]/<name>`); explicit `dev.links[]` and `dev.internalLinks[]`
+  entries are merged in. **All symlinks are created with relative paths** so
+  the dev tree is portable across machines and CI (cwmconnect PR #88/#89 hit
+  the absolute-path footgun directly).
+- `bin/cwm-link-check` — verifies every expected symlink without recreating it.
+  Exits non-zero on drift so CI can gate on a known-good state.
+- `bin/cwm-clean` — removes every dev symlink. Real files / directories at the
+  link paths are left alone — only items that are currently symlinks are touched.
+- `bin/cwm-verify` — confirms each install has every project sub-extension
+  registered in `#__extensions`. Reads each manifest XML to discover
+  type/element/folder/namespace; uses PDO so it does not need to bootstrap
+  Joomla. Pass `--fix` to reconcile drift (UPDATE state, INSERT missing
+  libraries/plugins, run library install SQL). Components are flagged but
+  never auto-inserted — install via the Extension Manager so the rest of the
+  install lifecycle runs.
+- `bin/cwm-joomla-install` — downloads the Joomla full-package release into
+  every configured install path. Per-install version comes from
+  `build.properties`; pass a positional argument to override globally.
+  `--force` wipes the directory first.
+- `bin/cwm-joomla-latest` — prints the latest stable tag from the
+  `joomla/joomla-cms` releases feed.
+- `src/Dev/` — `InstallConfig`, `PropertiesReader`, `LinkResolver`, `Linker`,
+  `ExtensionVerifier`, `JoomlaInstaller`. The bash/PHP scripts are thin
+  wrappers over these classes.
+- `templates/build.properties.tmpl` — copied into a consuming repo as
+  `build.properties.tmpl` (or `build.dist.properties`) and committed; each
+  developer copies it to `build.properties` (gitignored) and edits.
+- `templates/cwm-build.config.json.tmpl` — extended with a `dev:` block
+  documenting `internalLinks[]`, `links[]`, and the `deriveLinks: false`
+  escape hatch for projects with non-standard layouts.
+
+#### Configuration split
+
+Two files now drive the dev surface:
+
+- `cwm-build.config.json` (committed) — what the project IS. Adds an optional
+  `dev:` block describing extra symlinks and repo-internal mirror links.
+  No secrets.
+- `build.properties` (gitignored, INI sections) — where the developer's local
+  Joomla installs live. DB and admin passwords stay out of source control.
+
+The `PropertiesReader` also accepts Proclaim's legacy flat
+`builder.joomla_paths=...` / `builder.j5dev.url=...` layout, so projects
+migrating from Proclaim can drop the new toolchain in without rewriting their
+`build.properties` first.
+
 ### Changed (breaking)
 
 - Removed `ars.changelogUrl` from the config schema. Modern Akeeba ARS (verified against v7.4.x source) has no `changelogurl` field on the `#__ars_updatestreams` table — Joomla's changelog mechanism reads `<changelogurl>` from the **installed extension manifest** instead. The PATCH call in `ars-publish.sh` that previously tried to set this on the update stream was a no-op against modern ARS and has been removed. The URL now lives at `changelog.url` (was `ars.changelogUrl`) and is meant to be referenced by the manifest XML, not pushed to ARS.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Across `Proclaim`, `lib_cwmscripture`, `CWMScriptureLinks`, and `plg_task_cwmscr
 
 | Surface | What | Where |
 |---|---|---|
-| **CLI tools** | `cwm-release`, `cwm-bump`, `cwm-package`, `cwm-sync-configs`, `cwm-sync-languages`, `cwm-ars-publish`, `cwm-changelog`, `cwm-init` | `bin/` |
+| **CLI tools** | `cwm-release`, `cwm-bump`, `cwm-package`, `cwm-sync-configs`, `cwm-sync-languages`, `cwm-ars-publish`, `cwm-changelog`, `cwm-init`, `cwm-setup`, `cwm-link`, `cwm-link-check`, `cwm-clean`, `cwm-verify`, `cwm-joomla-install`, `cwm-joomla-latest` | `bin/` |
 | **Scripts** | Generic 8-step release pipeline, multi-manifest version bumper, config syncer | `scripts/` |
 | **PHP library** | `ProjectConfig`, `ManifestReader`, `PackageBuilder`, `ArsPublisher`, `Bumper` | `src/` (PSR-4 `CWM\BuildTools\`) |
 | **Reusable GH Actions** | `joomla-package-ci.yml`, `joomla-library-ci.yml` (called via `workflow_call`) | `.github/workflows/` |
@@ -28,10 +28,18 @@ Add as a Composer dev dependency:
 {
   "require-dev": { "cwm/build-tools": "^1.0" },
   "scripts": {
-    "release":      "vendor/bin/cwm-release",
-    "bump-version": "vendor/bin/cwm-bump",
-    "package":      "vendor/bin/cwm-package",
-    "sync-configs": "vendor/bin/cwm-sync-configs"
+    "release":         "vendor/bin/cwm-release",
+    "bump-version":    "vendor/bin/cwm-bump",
+    "package":         "vendor/bin/cwm-package",
+    "sync-configs":    "vendor/bin/cwm-sync-configs",
+
+    "setup":           "vendor/bin/cwm-setup",
+    "link":            "vendor/bin/cwm-link",
+    "link-check":      "vendor/bin/cwm-link-check",
+    "clean":           "vendor/bin/cwm-clean",
+    "verify":          "vendor/bin/cwm-verify",
+    "joomla-install":  "vendor/bin/cwm-joomla-install",
+    "joomla-latest":   "vendor/bin/cwm-joomla-latest"
   }
 }
 ```
@@ -123,6 +131,55 @@ Project-specific rule overrides go in the wrapper, not by forking the base.
 
 `cwm-build-tools` itself uses semver. Projects pin to a major (`^1.0`). Breaking changes get a major bump. Bug fixes and new pipeline steps land as patches/minors and projects pick them up via `composer update`.
 
+## Local dev environment
+
+`cwm-setup`, `cwm-link`, `cwm-link-check`, `cwm-clean`, `cwm-verify`,
+`cwm-joomla-install`, and `cwm-joomla-latest` form the **dev-environment**
+surface — separate from the release pipeline. They let a contributor point
+the repo at one or more local Joomla installs (J5, J6, J7, ...), keep the
+extension symlinked into each one, verify the extensions table is in sync,
+and bootstrap fresh Joomla checkouts.
+
+Two files drive this surface:
+
+| File | Committed? | Purpose |
+|---|---|---|
+| `cwm-build.config.json` | yes | What the project IS — extension layout, manifest paths, optional `dev:` block (link rules, repo-internal mirror links). No secrets. |
+| `build.properties` | **no — gitignore it** | Where the developer's local Joomla installs live: paths, URLs, target versions, DB credentials, admin credentials. Per-developer. |
+
+A new contributor's first run looks like:
+
+```bash
+cp vendor/cwm/build-tools/templates/build.properties.tmpl build.properties
+composer setup            # interactive wizard — fills in real values
+composer joomla-install   # optional: download Joomla into each path
+composer link             # symlink the project into each install
+composer verify            # confirm extensions registered, fix drift
+```
+
+Day-to-day:
+
+```bash
+composer link-check        # are my dev symlinks still healthy?
+composer clean             # remove every dev symlink (clean install test)
+composer joomla-latest     # what's the newest Joomla?
+```
+
+Symlinks are derived automatically from the project's
+`manifests.extensions[]` plus the top-level `extension` block — components
+get `admin/` + `site/` + `media/` mirrored, libraries get
+`libraries/<name>` + the manifest stub under
+`administrator/manifests/libraries/`, plugins land at
+`plugins/<group>/<element>`, modules at `modules/[admin]/<name>`. Anything
+that doesn't fit those rules (cross-repo libs, language file overrides,
+submodules) goes in `dev.links[]` explicitly. Fully custom layouts can set
+`dev.deriveLinks: false` and list every link by hand.
+
+**All symlinks are created with relative paths** so the dev tree remains
+portable across machines and CI. (Earlier toolchains baked absolute paths
+in, which broke every machine except the one the symlinks were originally
+created on.)
+
 ## Per-project config: `cwm-build.config.json`
 
 ```json
@@ -150,9 +207,26 @@ Project-specific rule overrides go in the wrapper, not by forking the base.
   "github": {
     "owner": "Joomla-Bible-Study",
     "repo": "CWMScriptureLinks"
+  },
+  "dev": {
+    "deriveLinks": true,
+    "internalLinks": [
+      { "source": "yourextension.xml",        "link": "admin/yourextension.xml" },
+      { "source": "yourextension.script.php", "link": "admin/yourextension.script.php" }
+    ],
+    "links": [
+      {
+        "source": "language/admin/en-GB/en-GB.com_yourextension.ini",
+        "target": "{joomlaPath}/administrator/language/en-GB/en-GB.com_yourextension.ini"
+      }
+    ]
   }
 }
 ```
+
+`dev.*` is consumed by the local-dev commands only — release-pipeline
+commands ignore it. `{joomlaPath}` in `dev.links[].target` is substituted at
+runtime with each install's path from `build.properties`.
 
 See `examples/` for full per-extension-type setups (library, content-plugin, package).
 

--- a/bin/cwm-clean
+++ b/bin/cwm-clean
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# cwm-clean — remove every dev symlink cwm-link created. Useful when you
+# want a Joomla install back to a clean state for fresh-install testing.
+#
+# Real files / directories at the link paths are left alone — only items
+# that are currently symlinks are removed.
+#
+# Usage from a consuming project:
+#   composer clean
+#   composer clean -- --verbose
+#
+set -euo pipefail
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec php "${TOOLS_DIR}/scripts/clean.php" "$@"

--- a/bin/cwm-joomla-install
+++ b/bin/cwm-joomla-install
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# cwm-joomla-install — download and extract Joomla into every configured
+# install path. Per-install version comes from build.properties; pass a
+# positional argument to override globally.
+#
+# Usage from a consuming project:
+#   composer joomla-install
+#   composer joomla-install -- 5.4.2
+#   composer joomla-install -- 5.4.2 --force
+#
+set -euo pipefail
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec php "${TOOLS_DIR}/scripts/joomla-install.php" "$@"

--- a/bin/cwm-joomla-latest
+++ b/bin/cwm-joomla-latest
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# cwm-joomla-latest — print the latest stable Joomla release tag from the
+# joomla/joomla-cms GitHub releases feed. Pair with cwm-joomla-install to
+# bump a dev install to the newest release.
+#
+# Usage from a consuming project:
+#   composer joomla-latest
+#
+set -euo pipefail
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec php "${TOOLS_DIR}/scripts/joomla-latest.php" "$@"

--- a/bin/cwm-link
+++ b/bin/cwm-link
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# cwm-link — symlink the project files into every configured Joomla install,
+# so live edits in the repo show up immediately under the Joomla site.
+#
+# Reads cwm-build.config.json (project layout) and build.properties (install
+# paths). Symlinks are created with relative paths so the dev tree remains
+# portable across machines and CI.
+#
+# Usage from a consuming project:
+#   composer link
+#   composer link -- --verbose
+#
+set -euo pipefail
+
+PROJECT_ROOT="$(pwd)"
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ ! -f "${PROJECT_ROOT}/cwm-build.config.json" ]; then
+    echo "Error: cwm-build.config.json not found in $PROJECT_ROOT"
+    exit 1
+fi
+
+exec php "${TOOLS_DIR}/scripts/link.php" "$@"

--- a/bin/cwm-link-check
+++ b/bin/cwm-link-check
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# cwm-link-check — verify symlinks created by cwm-link are still healthy,
+# without recreating them. Exits non-zero on any drift so CI can gate on it.
+#
+# Usage from a consuming project:
+#   composer link-check
+#   composer link-check -- --verbose
+#
+set -euo pipefail
+
+PROJECT_ROOT="$(pwd)"
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ ! -f "${PROJECT_ROOT}/cwm-build.config.json" ]; then
+    echo "Error: cwm-build.config.json not found in $PROJECT_ROOT"
+    exit 1
+fi
+
+exec php "${TOOLS_DIR}/scripts/link-check.php" "$@"

--- a/bin/cwm-setup
+++ b/bin/cwm-setup
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# cwm-setup — interactive wizard that writes build.properties for the
+# consuming project's local dev environment.
+#
+# Walks the user through one or more Joomla installs, capturing path, URL,
+# default version, DB credentials, and admin credentials. The resulting file
+# is gitignored — it carries secrets and per-developer state.
+#
+# Usage from a consuming project:
+#   composer setup
+#
+set -euo pipefail
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec php "${TOOLS_DIR}/scripts/setup.php" "$@"

--- a/bin/cwm-verify
+++ b/bin/cwm-verify
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# cwm-verify — confirm each Joomla install has every project sub-extension
+# (libraries, plugins, modules, the component) registered in #__extensions
+# and in the expected enabled/locked state.
+#
+# Connects to each install's DB via the credentials in its configuration.php.
+# Pass --fix to reconcile drift (UPDATE state, INSERT missing libraries /
+# plugins). Components are flagged but never auto-inserted — install them
+# via the Extension Manager so the rest of the lifecycle runs.
+#
+# Usage from a consuming project:
+#   composer verify
+#   composer verify -- --fix
+#   composer verify -- --verbose
+#
+set -euo pipefail
+
+PROJECT_ROOT="$(pwd)"
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ ! -f "${PROJECT_ROOT}/cwm-build.config.json" ]; then
+    echo "Error: cwm-build.config.json not found in $PROJECT_ROOT"
+    exit 1
+fi
+
+exec php "${TOOLS_DIR}/scripts/verify.php" "$@"

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,14 @@
         "bin/cwm-ars-list",
         "bin/cwm-ars-create-stream",
         "bin/cwm-changelog",
-        "bin/cwm-init"
+        "bin/cwm-init",
+        "bin/cwm-setup",
+        "bin/cwm-link",
+        "bin/cwm-link-check",
+        "bin/cwm-clean",
+        "bin/cwm-verify",
+        "bin/cwm-joomla-install",
+        "bin/cwm-joomla-latest"
     ],
     "config": {
         "sort-packages": true,

--- a/scripts/clean.php
+++ b/scripts/clean.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Remove every symlink cwm-link would have created.
+ *
+ * Useful when you want a Joomla install back to a clean state for a fresh
+ * install test.
+ */
+
+require_once __DIR__ . '/../src/Dev/InstallConfig.php';
+require_once __DIR__ . '/../src/Dev/PropertiesReader.php';
+require_once __DIR__ . '/../src/Dev/LinkResolver.php';
+require_once __DIR__ . '/../src/Dev/Linker.php';
+
+use CWM\BuildTools\Dev\LinkResolver;
+use CWM\BuildTools\Dev\Linker;
+use CWM\BuildTools\Dev\PropertiesReader;
+
+$projectRoot = getcwd() ?: '.';
+
+if (in_array('--help', $argv, true) || in_array('-h', $argv, true)) {
+    echo <<<HELP
+cwm-clean — remove every symlink cwm-link would create.
+
+Walks each configured install and unlinks anything that is currently a
+symlink at the expected target path. Real files / directories at those
+paths are left alone.
+
+Options:
+  -v, --verbose    Print every removed link.
+
+HELP;
+
+    exit(0);
+}
+
+$verbose = in_array('-v', $argv, true) || in_array('--verbose', $argv, true);
+
+$config = loadConfig($projectRoot);
+$reader = new PropertiesReader($projectRoot . '/build.properties');
+
+if (!$reader->exists()) {
+    echo "build.properties not found — nothing to clean.\n";
+
+    exit(0);
+}
+
+$resolver = new LinkResolver($projectRoot, $config);
+$linker   = new Linker($verbose);
+$removed  = 0;
+
+foreach ($resolver->internalLinks() as $pair) {
+    if ($linker->unlink($pair['target'])) {
+        $removed++;
+
+        if ($verbose) {
+            echo "Removed: {$pair['target']}\n";
+        }
+    }
+}
+
+foreach ($reader->installs() as $install) {
+    if (!is_dir($install->path)) {
+        continue;
+    }
+
+    $count = 0;
+
+    foreach ($resolver->externalLinks($install->path) as $pair) {
+        if ($linker->unlink($pair['target'])) {
+            $count++;
+
+            if ($verbose) {
+                echo "  Removed: {$pair['target']}\n";
+            }
+        }
+    }
+
+    echo "Cleaned {$install->path} ({$count} link" . ($count === 1 ? '' : 's') . ")\n";
+    $removed += $count;
+}
+
+echo "\nRemoved {$removed} symlink(s).\n";
+
+/**
+ * @return array<string, mixed>
+ */
+function loadConfig(string $projectRoot): array
+{
+    $configFile = $projectRoot . '/cwm-build.config.json';
+
+    if (!is_file($configFile)) {
+        return [];
+    }
+
+    $config = json_decode((string) file_get_contents($configFile), true);
+
+    return is_array($config) ? $config : [];
+}

--- a/scripts/joomla-install.php
+++ b/scripts/joomla-install.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Download and extract a Joomla full-package release into each configured
+ * install path. Skips paths that already contain files unless --force.
+ *
+ *   composer joomla-install              # use each install's configured version
+ *   composer joomla-install -- 5.4.2     # override version
+ *   composer joomla-install -- --force   # overwrite existing directory
+ */
+
+require_once __DIR__ . '/../src/Dev/InstallConfig.php';
+require_once __DIR__ . '/../src/Dev/PropertiesReader.php';
+require_once __DIR__ . '/../src/Dev/JoomlaInstaller.php';
+
+use CWM\BuildTools\Dev\JoomlaInstaller;
+use CWM\BuildTools\Dev\PropertiesReader;
+
+$projectRoot = getcwd() ?: '.';
+
+if (in_array('--help', $argv, true) || in_array('-h', $argv, true)) {
+    echo <<<HELP
+cwm-joomla-install — download a Joomla release into every configured install.
+
+Reads build.properties for install paths and per-install version. Each
+non-empty positional argument that is not a flag is treated as a version
+override applied to all installs.
+
+Options:
+      --force       Wipe the install path before extracting
+
+HELP;
+
+    exit(0);
+}
+
+$force = in_array('--force', $argv, true);
+
+$override = null;
+
+foreach (array_slice($argv, 1) as $arg) {
+    if ($arg !== '' && $arg[0] !== '-') {
+        $override = $arg;
+
+        break;
+    }
+}
+
+$reader = new PropertiesReader($projectRoot . '/build.properties');
+
+if (!$reader->exists()) {
+    fwrite(STDERR, "build.properties not found. Run 'composer setup' first.\n");
+
+    exit(1);
+}
+
+$installs  = $reader->installs();
+$installer = new JoomlaInstaller();
+
+if ($installs === []) {
+    fwrite(STDERR, "No Joomla installs configured in build.properties.\n");
+
+    exit(1);
+}
+
+foreach ($installs as $install) {
+    $version = $override ?? $install->version;
+
+    if ($version === null || $version === '') {
+        echo "Skipping {$install->path}: no version configured (set [{$install->id}] version=...).\n";
+
+        continue;
+    }
+
+    if (is_dir($install->path) && (new \FilesystemIterator($install->path))->valid()) {
+        if (!$force) {
+            echo "Skipping {$install->path}: directory not empty (pass --force to wipe).\n";
+
+            continue;
+        }
+
+        emptyDirectory($install->path);
+    }
+
+    try {
+        $installer->install($version, $install->path);
+    } catch (\Throwable $e) {
+        echo "ERROR ({$install->path}): " . $e->getMessage() . "\n";
+    }
+}
+
+function emptyDirectory(string $path): void
+{
+    $iterator = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+        \RecursiveIteratorIterator::CHILD_FIRST,
+    );
+
+    foreach ($iterator as $entry) {
+        if ($entry->isDir() && !$entry->isLink()) {
+            @rmdir($entry->getPathname());
+        } else {
+            @unlink($entry->getPathname());
+        }
+    }
+}

--- a/scripts/joomla-latest.php
+++ b/scripts/joomla-latest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Print the latest stable Joomla version from the joomla-cms releases feed.
+ *
+ *   composer joomla-latest
+ */
+
+require_once __DIR__ . '/../src/Dev/JoomlaInstaller.php';
+
+use CWM\BuildTools\Dev\JoomlaInstaller;
+
+if (in_array('--help', $argv, true) || in_array('-h', $argv, true)) {
+    echo <<<HELP
+cwm-joomla-latest — print the latest stable Joomla version.
+
+Queries the joomla/joomla-cms GitHub releases API and prints the tag name
+plus published timestamp. Use the version with cwm-joomla-install.
+
+HELP;
+
+    exit(0);
+}
+
+try {
+    $latest = (new JoomlaInstaller())->latest();
+} catch (\Throwable $e) {
+    fwrite(STDERR, "Error: " . $e->getMessage() . "\n");
+
+    exit(1);
+}
+
+echo "Latest Joomla: {$latest['tag']}\n";
+
+if ($latest['publishedAt'] !== '') {
+    echo "Published:     {$latest['publishedAt']}\n";
+}
+
+echo "\nInstall with: composer joomla-install -- {$latest['tag']}\n";

--- a/scripts/link-check.php
+++ b/scripts/link-check.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Verify that every symlink cwm-link would create still resolves correctly.
+ *
+ * Exits non-zero on any drift so CI can gate on a known-good link state.
+ */
+
+require_once __DIR__ . '/../src/Dev/InstallConfig.php';
+require_once __DIR__ . '/../src/Dev/PropertiesReader.php';
+require_once __DIR__ . '/../src/Dev/LinkResolver.php';
+require_once __DIR__ . '/../src/Dev/Linker.php';
+
+use CWM\BuildTools\Dev\LinkResolver;
+use CWM\BuildTools\Dev\Linker;
+use CWM\BuildTools\Dev\PropertiesReader;
+
+$projectRoot = getcwd() ?: '.';
+
+if (in_array('--help', $argv, true) || in_array('-h', $argv, true)) {
+    echo <<<HELP
+cwm-link-check — verify symlinks without recreating them.
+
+Reports MISSING / STALE / WRONG / BROKEN links. Exits 1 if any issues
+are found.
+
+Options:
+  -v, --verbose    Also print healthy links.
+
+HELP;
+
+    exit(0);
+}
+
+$verbose = in_array('-v', $argv, true) || in_array('--verbose', $argv, true);
+
+$config = loadConfig($projectRoot);
+$reader = new PropertiesReader($projectRoot . '/build.properties');
+
+if (!$reader->exists()) {
+    fwrite(STDERR, "build.properties not found. Run 'composer setup' first.\n");
+
+    exit(1);
+}
+
+$resolver = new LinkResolver($projectRoot, $config);
+$linker   = new Linker($verbose);
+$issues   = 0;
+
+echo "Internal links:\n";
+
+foreach ($resolver->internalLinks() as $pair) {
+    $issues += reportLink($linker->check($pair['source'], $pair['target']), $verbose);
+}
+
+foreach ($reader->installs() as $install) {
+    echo "\nInstall: {$install->path}\n";
+
+    if (!is_dir($install->path)) {
+        echo "  MISSING: install path does not exist\n";
+        $issues++;
+
+        continue;
+    }
+
+    foreach ($resolver->externalLinks($install->path) as $pair) {
+        $issues += reportLink($linker->check($pair['source'], $pair['target']), $verbose);
+    }
+}
+
+echo "\n";
+
+if ($issues === 0) {
+    echo "All symlinks are healthy.\n";
+
+    exit(0);
+}
+
+echo "{$issues} issue(s) found. Run 'composer link' to recreate.\n";
+
+exit(1);
+
+function reportLink(array $result, bool $verbose): int
+{
+    if ($result['status'] === 'ok') {
+        if ($verbose) {
+            echo "  OK:      {$result['link']}\n";
+        }
+
+        return 0;
+    }
+
+    $label = match ($result['status']) {
+        'missing' => 'MISSING',
+        'stale'   => 'STALE',
+        'broken'  => 'BROKEN',
+        'wrong'   => 'WRONG',
+        default   => strtoupper($result['status']),
+    };
+
+    $extra = isset($result['message']) ? " ({$result['message']})" : '';
+    echo "  {$label}: {$result['link']}{$extra}\n";
+
+    return 1;
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function loadConfig(string $projectRoot): array
+{
+    $configFile = $projectRoot . '/cwm-build.config.json';
+
+    if (!is_file($configFile)) {
+        fwrite(STDERR, "cwm-build.config.json not found in {$projectRoot}\n");
+
+        exit(1);
+    }
+
+    $config = json_decode((string) file_get_contents($configFile), true);
+
+    if (!is_array($config)) {
+        fwrite(STDERR, "cwm-build.config.json is not valid JSON.\n");
+
+        exit(1);
+    }
+
+    return $config;
+}

--- a/scripts/link.php
+++ b/scripts/link.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Create symlinks from this project into every configured Joomla install.
+ *
+ * Reads:
+ *   - cwm-build.config.json (project structure → derived links + dev.links[])
+ *   - build.properties      (Joomla install paths)
+ *
+ * All symlinks are relative to the link's parent directory so the project
+ * remains portable across machines and CI.
+ */
+
+require_once __DIR__ . '/../src/Dev/InstallConfig.php';
+require_once __DIR__ . '/../src/Dev/PropertiesReader.php';
+require_once __DIR__ . '/../src/Dev/LinkResolver.php';
+require_once __DIR__ . '/../src/Dev/Linker.php';
+
+use CWM\BuildTools\Dev\LinkResolver;
+use CWM\BuildTools\Dev\Linker;
+use CWM\BuildTools\Dev\PropertiesReader;
+
+$projectRoot = getcwd() ?: '.';
+
+if (in_array('--help', $argv, true) || in_array('-h', $argv, true)) {
+    echo <<<HELP
+cwm-link — symlink this project's files into every configured Joomla install.
+
+Reads cwm-build.config.json (for the project layout) and build.properties
+(for install paths). Existing files at the link path are removed and
+replaced. Symlinks are always created with relative paths.
+
+Options:
+  -v, --verbose    Print every link as it is created.
+
+HELP;
+
+    exit(0);
+}
+
+$verbose = in_array('-v', $argv, true) || in_array('--verbose', $argv, true);
+
+$config = loadConfig($projectRoot);
+$reader = new PropertiesReader($projectRoot . '/build.properties');
+
+if (!$reader->exists()) {
+    fwrite(STDERR, "build.properties not found. Run 'composer setup' first.\n");
+
+    exit(1);
+}
+
+$installs = $reader->installs();
+
+if ($installs === []) {
+    fwrite(STDERR, "No Joomla installs configured in build.properties.\n");
+
+    exit(1);
+}
+
+$resolver = new LinkResolver($projectRoot, $config);
+$linker   = new Linker($verbose);
+
+foreach ($resolver->internalLinks() as $pair) {
+    $linker->link($pair['source'], $pair['target']);
+}
+
+$linkedInstalls = 0;
+
+foreach ($installs as $install) {
+    if (!is_dir($install->path)) {
+        echo "WARNING: Path not found, skipping: {$install->path}\n";
+
+        continue;
+    }
+
+    echo "\nLinking against: {$install->path}\n";
+
+    $links = $resolver->externalLinks($install->path);
+
+    if ($links === []) {
+        echo "  (no links derived — check dev.links[] / manifests.extensions[])\n";
+
+        continue;
+    }
+
+    foreach ($links as $pair) {
+        $linker->link($pair['source'], $pair['target']);
+    }
+
+    if (!$verbose) {
+        echo "  Created " . count($links) . " links.\n";
+    }
+
+    $linkedInstalls++;
+}
+
+echo "\nDone. Linked into {$linkedInstalls} install(s).\n";
+
+/**
+ * @return array<string, mixed>
+ */
+function loadConfig(string $projectRoot): array
+{
+    $configFile = $projectRoot . '/cwm-build.config.json';
+
+    if (!is_file($configFile)) {
+        fwrite(STDERR, "cwm-build.config.json not found in {$projectRoot}\n");
+
+        exit(1);
+    }
+
+    $config = json_decode((string) file_get_contents($configFile), true);
+
+    if (!is_array($config)) {
+        fwrite(STDERR, "cwm-build.config.json is not valid JSON.\n");
+
+        exit(1);
+    }
+
+    return $config;
+}

--- a/scripts/setup.php
+++ b/scripts/setup.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Interactive setup wizard for build.properties.
+ *
+ * Prompts for one or more Joomla install paths and per-install URL / version
+ * / DB / admin credentials, then writes the result via PropertiesReader.
+ *
+ * Reads cwm-build.config.json from the current working directory only to
+ * surface a sensible default install id list when none exist yet.
+ *
+ * Usage (from a consuming project):
+ *   composer setup
+ *   composer setup -- --help
+ */
+
+require_once __DIR__ . '/../src/Dev/InstallConfig.php';
+require_once __DIR__ . '/../src/Dev/PropertiesReader.php';
+
+use CWM\BuildTools\Dev\InstallConfig;
+use CWM\BuildTools\Dev\PropertiesReader;
+
+$projectRoot = getcwd();
+
+if ($projectRoot === false) {
+    fwrite(STDERR, "Could not resolve current working directory.\n");
+
+    exit(1);
+}
+
+if (in_array('--help', $argv, true) || in_array('-h', $argv, true)) {
+    echo <<<HELP
+cwm-setup — populate build.properties for the local dev environment.
+
+Walks you through:
+  - One or more Joomla install paths (J5, J6, future J7)
+  - Per-install URL, target version, DB credentials, admin credentials
+
+Writes build.properties in the current working directory. The file is
+gitignored — secrets stay on your machine.
+
+Re-running re-prompts with the existing values as defaults, so it doubles
+as an editor.
+
+HELP;
+
+    exit(0);
+}
+
+$reader        = new PropertiesReader($projectRoot . '/build.properties');
+$existingList  = $reader->exists() ? $reader->installs() : [];
+$existingById  = [];
+
+foreach ($existingList as $cfg) {
+    $existingById[$cfg->id] = $cfg;
+}
+
+echo "=== cwm-build-tools dev setup ===\n\n";
+echo "Configure one or more Joomla installs to develop against.\n";
+echo "Press Enter on a blank install id to finish.\n\n";
+
+$installs   = [];
+$defaultIds = $existingList !== []
+    ? array_values(array_map(static fn (InstallConfig $c): string => $c->id, $existingList))
+    : ['j5', 'j6'];
+$index      = 0;
+
+while (true) {
+    $defaultId = $defaultIds[$index] ?? '';
+    $id        = ask("Install id #" . ($index + 1) . " (e.g. j5, j6, j7)", $defaultId === '' ? null : $defaultId);
+
+    if ($id === null || $id === '') {
+        break;
+    }
+
+    if (!preg_match('/^[a-z0-9][a-z0-9_-]*$/i', $id)) {
+        echo "  Invalid id — use letters, digits, dash or underscore.\n";
+
+        continue;
+    }
+
+    $existing = $existingById[$id] ?? null;
+
+    $path = ask("  Joomla path", $existing?->path ?? '');
+
+    if ($path === null || $path === '') {
+        echo "  A path is required — skipping this install.\n";
+
+        continue;
+    }
+
+    $url     = ask("  Dev URL (optional)", $existing?->url ?? "https://{$id}-dev.local");
+    $version = ask("  Default Joomla version", $existing?->version ?? '5.4.2');
+
+    $dbHost = ask("  DB host", $existing?->dbHost() ?? 'localhost');
+    $dbUser = ask("  DB user", $existing?->dbUser() ?? '');
+    $dbPass = ask("  DB password", $existing?->dbPass() ?? '');
+    $dbName = ask("  DB name", $existing?->dbName() ?? '');
+
+    $adminUser  = ask("  Admin user", $existing?->adminUser() ?? 'admin');
+    $adminPass  = ask("  Admin password", $existing?->adminPass() ?? 'admin');
+    $adminEmail = ask("  Admin email", $existing?->adminEmail() ?? 'admin@example.com');
+
+    $installs[] = new InstallConfig(
+        id:      $id,
+        path:    $path,
+        url:     $url ?: null,
+        version: $version ?: null,
+        db:      [
+            'host' => $dbHost ?: 'localhost',
+            'user' => $dbUser ?? '',
+            'pass' => $dbPass ?? '',
+            'name' => $dbName ?? '',
+        ],
+        admin:   [
+            'user'  => $adminUser ?: 'admin',
+            'pass'  => $adminPass ?: 'admin',
+            'email' => $adminEmail ?: 'admin@example.com',
+        ],
+    );
+
+    $index++;
+    echo "\n";
+}
+
+if ($installs === []) {
+    echo "No installs configured. Nothing written.\n";
+
+    exit(0);
+}
+
+$reader->write($installs);
+
+echo "Wrote " . count($installs) . " install(s) to {$reader->path()}.\n";
+echo "  Ids: " . implode(', ', array_map(static fn (InstallConfig $c): string => $c->id, $installs)) . "\n\n";
+
+echo "Make sure 'build.properties' is gitignored — never commit it.\n";
+
+function ask(string $question, ?string $default = null): ?string
+{
+    $prompt = $question . ($default !== null ? " [{$default}]" : '') . ': ';
+    echo $prompt;
+
+    $handle = fopen('php://stdin', 'rb');
+
+    if ($handle === false) {
+        return $default;
+    }
+
+    $line = fgets($handle);
+    fclose($handle);
+
+    if ($line === false) {
+        return $default;
+    }
+
+    $line = trim($line);
+
+    return $line === '' ? $default : $line;
+}

--- a/scripts/verify.php
+++ b/scripts/verify.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Verify each configured Joomla install has every project sub-extension
+ * registered in its #__extensions table. Optionally fix drift.
+ *
+ *   composer verify              # report only
+ *   composer verify -- --fix     # report + reconcile
+ *   composer verify -- -v        # also list OK rows
+ */
+
+require_once __DIR__ . '/../src/Dev/InstallConfig.php';
+require_once __DIR__ . '/../src/Dev/PropertiesReader.php';
+require_once __DIR__ . '/../src/Dev/ExtensionVerifier.php';
+
+use CWM\BuildTools\Dev\ExtensionVerifier;
+use CWM\BuildTools\Dev\PropertiesReader;
+
+$projectRoot = getcwd() ?: '.';
+
+if (in_array('--help', $argv, true) || in_array('-h', $argv, true)) {
+    echo <<<HELP
+cwm-verify — confirm each Joomla install has the project's sub-extensions
+registered in #__extensions.
+
+Reads cwm-build.config.json (manifests.extensions[] + extension.*) and
+build.properties (install paths). Connects to each install's DB via the
+credentials in its configuration.php.
+
+Options:
+      --fix         Reconcile drift (UPDATE state, INSERT missing libs/plugins)
+  -v, --verbose     Print OK rows in addition to drift
+
+HELP;
+
+    exit(0);
+}
+
+$verbose   = in_array('-v', $argv, true) || in_array('--verbose', $argv, true);
+$reconcile = in_array('--fix', $argv, true);
+
+$config = loadConfig($projectRoot);
+$reader = new PropertiesReader($projectRoot . '/build.properties');
+
+if (!$reader->exists()) {
+    fwrite(STDERR, "build.properties not found. Run 'composer setup' first.\n");
+
+    exit(1);
+}
+
+$installs = $reader->installs();
+
+if ($installs === []) {
+    fwrite(STDERR, "No Joomla installs configured in build.properties.\n");
+
+    exit(1);
+}
+
+$verifier = new ExtensionVerifier($projectRoot, $config, $verbose);
+$totals   = ['ok' => 0, 'fixed' => 0, 'errors' => 0];
+
+foreach ($installs as $install) {
+    $result = $verifier->verify($install, $reconcile);
+
+    foreach ($totals as $k => $_) {
+        $totals[$k] += $result[$k];
+    }
+}
+
+echo "\nTotal: {$totals['ok']} OK, {$totals['fixed']} fixed, {$totals['errors']} error(s).\n";
+
+exit($totals['errors'] > 0 ? 1 : 0);
+
+/**
+ * @return array<string, mixed>
+ */
+function loadConfig(string $projectRoot): array
+{
+    $configFile = $projectRoot . '/cwm-build.config.json';
+
+    if (!is_file($configFile)) {
+        fwrite(STDERR, "cwm-build.config.json not found in {$projectRoot}\n");
+
+        exit(1);
+    }
+
+    $config = json_decode((string) file_get_contents($configFile), true);
+
+    if (!is_array($config)) {
+        fwrite(STDERR, "cwm-build.config.json is not valid JSON.\n");
+
+        exit(1);
+    }
+
+    return $config;
+}

--- a/src/Dev/ExtensionVerifier.php
+++ b/src/Dev/ExtensionVerifier.php
@@ -1,0 +1,430 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Dev;
+
+/**
+ * Verifies that every extension declared in a project's
+ * cwm-build.config.json (manifests.extensions[] + the top-level extension)
+ * is registered in the #__extensions table of each configured Joomla DB.
+ *
+ * The verifier reads each manifest XML to discover (type, element, folder,
+ * library_name, etc.) — projects do not need to duplicate that data into the
+ * config file.
+ *
+ * Two modes:
+ *   - report:    print OK / MISSING / WRONG-STATE for each extension/install pair.
+ *   - reconcile: same, but try to UPDATE enabled/locked drift and (for
+ *                libraries) INSERT a missing row + run install SQL.
+ *
+ * Component rows are not auto-inserted — they should be installed via the
+ * Extension Manager so the rest of the install lifecycle (params, schema
+ * version) runs.
+ */
+final class ExtensionVerifier
+{
+    public function __construct(
+        private readonly string $projectRoot,
+        /** @var array<string, mixed> */
+        private readonly array $config,
+        private readonly bool $verbose = false,
+    ) {
+    }
+
+    /**
+     * Verify against one Joomla install. Reads configuration.php from
+     * $install->path to discover the DB, connects, then walks expected
+     * extensions.
+     *
+     * @return array{ok: int, fixed: int, errors: int}
+     */
+    public function verify(InstallConfig $install, bool $reconcile = true): array
+    {
+        echo "\n=== Verifying: {$install->path} ===\n";
+
+        if (!is_dir($install->path)) {
+            echo "  ERROR: Path does not exist\n";
+
+            return ['ok' => 0, 'fixed' => 0, 'errors' => 1];
+        }
+
+        $db = $this->loadJoomlaDbConfig($install->path);
+
+        if ($db === null) {
+            echo "  ERROR: Could not read configuration.php at {$install->path}\n";
+
+            return ['ok' => 0, 'fixed' => 0, 'errors' => 1];
+        }
+
+        try {
+            $pdo = new \PDO(
+                'mysql:host=' . $db['host'] . ';dbname=' . $db['db'] . ';charset=utf8mb4',
+                $db['user'],
+                $db['password'],
+                [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION],
+            );
+        } catch (\PDOException $e) {
+            echo '  ERROR: DB connection failed: ' . $e->getMessage() . "\n";
+
+            return ['ok' => 0, 'fixed' => 0, 'errors' => 1];
+        }
+
+        $prefix       = $db['dbprefix'];
+        $hasNamespace = $this->hasNamespaceColumn($pdo, $prefix);
+        $expected     = $this->expectedExtensions();
+
+        $ok     = 0;
+        $fixed  = 0;
+        $errors = 0;
+
+        foreach ($expected as $ext) {
+            $row = $this->lookup($pdo, $prefix, $ext);
+
+            if ($row !== null) {
+                $drift = $this->computeDrift($row, $ext);
+
+                if ($drift === []) {
+                    if ($this->verbose) {
+                        echo "  OK:     {$ext['name']} ({$ext['type']})\n";
+                    }
+                    $ok++;
+
+                    continue;
+                }
+
+                if (!$reconcile) {
+                    echo "  DRIFT:  {$ext['name']} — needs " . implode(', ', $drift) . "\n";
+                    $errors++;
+
+                    continue;
+                }
+
+                $sql  = "UPDATE {$prefix}extensions SET " . implode(', ', $drift)
+                    . ' WHERE extension_id = ' . (int) $row['extension_id'];
+                $pdo->prepare($sql)->execute();
+                echo "  FIXED:  {$ext['name']} — " . implode(', ', $drift) . "\n";
+                $fixed++;
+
+                continue;
+            }
+
+            if (!$reconcile) {
+                echo "  MISS:   {$ext['name']} ({$ext['type']})\n";
+                $errors++;
+
+                continue;
+            }
+
+            $action = match ($ext['type']) {
+                'library' => $this->insertLibrary($pdo, $prefix, $ext, $hasNamespace),
+                'plugin'  => $this->insertPlugin($pdo, $prefix, $ext, $hasNamespace),
+                default   => null,
+            };
+
+            if ($action === 'added') {
+                echo "  ADDED:  {$ext['name']} ({$ext['type']})\n";
+                $fixed++;
+            } else {
+                echo "  MISS:   {$ext['name']} ({$ext['type']}) — install via Extension Manager\n";
+                $errors++;
+            }
+        }
+
+        echo "  Summary: {$ok} OK, {$fixed} fixed, {$errors} errors\n";
+
+        return ['ok' => $ok, 'fixed' => $fixed, 'errors' => $errors];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function expectedExtensions(): array
+    {
+        $out = [];
+
+        $extension = $this->config['extension'] ?? null;
+
+        if (is_array($extension) && ($extension['type'] ?? null) === 'component') {
+            $name = (string) ($extension['name'] ?? '');
+
+            if ($name !== '') {
+                $out[] = [
+                    'type'      => 'component',
+                    'element'   => $name,
+                    'folder'    => '',
+                    'name'      => $name,
+                    'enabled'   => 1,
+                    'locked'    => 0,
+                    'namespace' => null,
+                ];
+            }
+        }
+
+        foreach ($this->config['manifests']['extensions'] ?? [] as $manifest) {
+            $type    = (string) ($manifest['type'] ?? '');
+            $manPath = $this->projectRoot . '/' . ltrim((string) ($manifest['path'] ?? ''), '/');
+
+            if (!is_file($manPath)) {
+                continue;
+            }
+
+            $row = $this->describeManifest($type, $manPath);
+
+            if ($row !== null) {
+                $out[] = $row;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function describeManifest(string $type, string $manifestPath): ?array
+    {
+        $previous = libxml_use_internal_errors(true);
+
+        try {
+            $xml = simplexml_load_file($manifestPath);
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
+
+        if (!$xml instanceof \SimpleXMLElement) {
+            return null;
+        }
+
+        $rawName   = trim((string) $xml->name);
+        $namespace = trim((string) ($xml->namespace ?? ''));
+
+        return match ($type) {
+            'library' => $this->describeLibrary($xml, $manifestPath, $namespace),
+            'plugin'  => $this->describePlugin($xml, $manifestPath, $rawName, $namespace),
+            default   => null,
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function describeLibrary(\SimpleXMLElement $xml, string $manifestPath, string $namespace): array
+    {
+        $libraryName = trim((string) ($xml->libraryname ?? ''));
+        $name        = trim((string) $xml->name);
+
+        if ($libraryName === '' && $name !== '') {
+            $libraryName = preg_replace('/^lib_/', '', strtolower($name)) ?? $name;
+        }
+
+        $row = [
+            'type'      => 'library',
+            'element'   => $libraryName,
+            'folder'    => '',
+            'name'      => $name !== '' ? $name : "lib_{$libraryName}",
+            'enabled'   => 1,
+            'locked'    => 1,
+            'namespace' => $namespace !== '' ? $namespace : null,
+        ];
+
+        $sqlInstall = \dirname($manifestPath) . '/sql/install.mysql.utf8.sql';
+
+        if (is_file($sqlInstall)) {
+            $row['installSql'] = $sqlInstall;
+        }
+
+        return $row;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function describePlugin(\SimpleXMLElement $xml, string $manifestPath, string $rawName, string $namespace): array
+    {
+        $folder  = trim((string) ($xml['group'] ?? ''));
+        $element = pathinfo($manifestPath, PATHINFO_FILENAME);
+
+        return [
+            'type'      => 'plugin',
+            'element'   => $element,
+            'folder'    => $folder,
+            'name'      => $rawName !== '' ? $rawName : "plg_{$folder}_{$element}",
+            'enabled'   => 1,
+            'locked'    => 0,
+            'namespace' => $namespace !== '' ? $namespace : null,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function lookup(\PDO $pdo, string $prefix, array $ext): ?array
+    {
+        $sql    = "SELECT extension_id, enabled, locked FROM {$prefix}extensions WHERE type = ? AND element = ?";
+        $params = [$ext['type'], $ext['element']];
+
+        if ($ext['type'] === 'plugin' && ($ext['folder'] ?? '') !== '') {
+            $sql .= ' AND folder = ?';
+            $params[] = $ext['folder'];
+        }
+
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function computeDrift(array $row, array $ext): array
+    {
+        $sets = [];
+
+        if ((int) $row['enabled'] !== (int) $ext['enabled']) {
+            $sets[] = 'enabled = ' . (int) $ext['enabled'];
+        }
+
+        if ((int) $ext['locked'] === 1 && (int) $row['locked'] !== 1) {
+            $sets[] = 'locked = 1';
+        }
+
+        return $sets;
+    }
+
+    private function insertLibrary(\PDO $pdo, string $prefix, array $ext, bool $hasNamespace): string
+    {
+        $manifest = json_encode([
+            'name'        => $ext['name'],
+            'libraryname' => $ext['element'],
+        ], JSON_UNESCAPED_SLASHES);
+
+        if ($hasNamespace) {
+            $stmt = $pdo->prepare(
+                "INSERT INTO {$prefix}extensions "
+                . '(name, type, element, folder, client_id, enabled, access, locked, manifest_cache, params, custom_data, namespace) '
+                . "VALUES (?, 'library', ?, '', 0, 1, 1, ?, ?, '{}', '', ?)"
+            );
+            $stmt->execute([$ext['name'], $ext['element'], (int) $ext['locked'], $manifest, $ext['namespace'] ?? '']);
+        } else {
+            $stmt = $pdo->prepare(
+                "INSERT INTO {$prefix}extensions "
+                . '(name, type, element, folder, client_id, enabled, access, locked, manifest_cache, params, custom_data) '
+                . "VALUES (?, 'library', ?, '', 0, 1, 1, ?, ?, '{}', '')"
+            );
+            $stmt->execute([$ext['name'], $ext['element'], (int) $ext['locked'], $manifest]);
+        }
+
+        if (isset($ext['installSql']) && is_file($ext['installSql'])) {
+            $sql        = (string) file_get_contents($ext['installSql']);
+            $sql        = str_replace('#__', $prefix, $sql);
+            $statements = array_filter(array_map('trim', explode(';', $sql)));
+
+            foreach ($statements as $statement) {
+                if ($statement === '' || str_starts_with($statement, '--')) {
+                    continue;
+                }
+
+                try {
+                    $pdo->prepare($statement)->execute();
+                } catch (\PDOException $e) {
+                    if ($this->verbose) {
+                        echo '    NOTE: ' . substr($e->getMessage(), 0, 100) . "\n";
+                    }
+                }
+            }
+        }
+
+        return 'added';
+    }
+
+    private function insertPlugin(\PDO $pdo, string $prefix, array $ext, bool $hasNamespace): string
+    {
+        if ($hasNamespace) {
+            $stmt = $pdo->prepare(
+                "INSERT INTO {$prefix}extensions "
+                . '(name, type, element, folder, client_id, enabled, access, locked, manifest_cache, params, custom_data, namespace) '
+                . "VALUES (?, 'plugin', ?, ?, 0, ?, 1, 0, '{}', '{}', '', ?)"
+            );
+            $stmt->execute([
+                $ext['name'],
+                $ext['element'],
+                $ext['folder'],
+                (int) $ext['enabled'],
+                $ext['namespace'] ?? '',
+            ]);
+        } else {
+            $stmt = $pdo->prepare(
+                "INSERT INTO {$prefix}extensions "
+                . '(name, type, element, folder, client_id, enabled, access, locked, manifest_cache, params, custom_data) '
+                . "VALUES (?, 'plugin', ?, ?, 0, ?, 1, 0, '{}', '{}', '')"
+            );
+            $stmt->execute([
+                $ext['name'],
+                $ext['element'],
+                $ext['folder'],
+                (int) $ext['enabled'],
+            ]);
+        }
+
+        return 'added';
+    }
+
+    private function hasNamespaceColumn(\PDO $pdo, string $prefix): bool
+    {
+        $stmt = $pdo->query("SHOW COLUMNS FROM {$prefix}extensions LIKE 'namespace'");
+
+        return $stmt instanceof \PDOStatement && $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Read the Joomla DB connection info out of `<joomlaPath>/configuration.php`.
+     *
+     * Joomla's configuration.php is generated and follows a deterministic
+     * `public $key = 'value';` shape; we parse it as text rather than
+     * evaluating arbitrary PHP from disk.
+     *
+     * @return array{host: string, user: string, password: string, db: string, dbprefix: string}|null
+     */
+    private function loadJoomlaDbConfig(string $joomlaPath): ?array
+    {
+        $configFile = $joomlaPath . '/configuration.php';
+
+        if (!is_file($configFile)) {
+            return null;
+        }
+
+        $content = (string) file_get_contents($configFile);
+        $values  = [];
+
+        if (preg_match_all('/public\s+\$(\w+)\s*=\s*([\'"])(.*?)\2\s*;/s', $content, $m, PREG_SET_ORDER)) {
+            foreach ($m as $match) {
+                $values[$match[1]] = $this->unescapePhpString($match[3], $match[2]);
+            }
+        }
+
+        if (!isset($values['db'])) {
+            return null;
+        }
+
+        return [
+            'host'     => $values['host'] ?? 'localhost',
+            'user'     => $values['user'] ?? '',
+            'password' => $values['password'] ?? '',
+            'db'       => $values['db'],
+            'dbprefix' => $values['dbprefix'] ?? 'jos_',
+        ];
+    }
+
+    private function unescapePhpString(string $raw, string $quote): string
+    {
+        if ($quote === "'") {
+            return strtr($raw, ['\\\\' => '\\', "\\'" => "'"]);
+        }
+
+        return stripcslashes($raw);
+    }
+}

--- a/src/Dev/InstallConfig.php
+++ b/src/Dev/InstallConfig.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Dev;
+
+/**
+ * Configuration for one Joomla installation referenced from build.properties.
+ *
+ * Each install has a short id ("j5", "j6", "j7"), a filesystem path, an
+ * optional URL, a target Joomla version (used by cwm-joomla-install), and
+ * DB + admin credential blocks used by cwm-verify and the optional install
+ * step inside cwm-setup.
+ */
+final class InstallConfig
+{
+    /**
+     * @param  string  $id           Short identifier ("j5", "j6", ...).
+     * @param  string  $path         Absolute path to the Joomla document root.
+     * @param  string|null  $url     Public dev URL (informational; not required).
+     * @param  string|null  $version Default Joomla release tag for installer.
+     * @param  array<string, string>  $db    DB credentials (host, user, pass, name).
+     * @param  array<string, string>  $admin Admin credentials (user, pass, email).
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $path,
+        public readonly ?string $url = null,
+        public readonly ?string $version = null,
+        public readonly array $db = [],
+        public readonly array $admin = [],
+    ) {
+    }
+
+    public function dbHost(): string
+    {
+        return $this->db['host'] ?? 'localhost';
+    }
+
+    public function dbUser(): string
+    {
+        return $this->db['user'] ?? '';
+    }
+
+    public function dbPass(): string
+    {
+        return $this->db['pass'] ?? '';
+    }
+
+    public function dbName(): string
+    {
+        return $this->db['name'] ?? '';
+    }
+
+    public function adminUser(): string
+    {
+        return $this->admin['user'] ?? 'admin';
+    }
+
+    public function adminPass(): string
+    {
+        return $this->admin['pass'] ?? 'admin';
+    }
+
+    public function adminEmail(): string
+    {
+        return $this->admin['email'] ?? 'admin@example.com';
+    }
+}

--- a/src/Dev/JoomlaInstaller.php
+++ b/src/Dev/JoomlaInstaller.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Dev;
+
+/**
+ * Downloads and extracts a Joomla full-package release into a target directory.
+ *
+ * Uses the joomla/joomla-cms GitHub releases by default. Callers can pass an
+ * arbitrary URL when (e.g.) testing nightlies or release candidates.
+ */
+final class JoomlaInstaller
+{
+    private const RELEASE_URL_TEMPLATE
+        = 'https://github.com/joomla/joomla-cms/releases/download/%s/Joomla_%s-Stable-Full_Package.zip';
+
+    private const LATEST_RELEASE_API
+        = 'https://api.github.com/repos/joomla/joomla-cms/releases/latest';
+
+    public function __construct(private readonly string $userAgent = 'cwm-build-tools')
+    {
+    }
+
+    /**
+     * Returns the latest stable Joomla version tag and publish timestamp.
+     *
+     * @return array{tag: string, publishedAt: string}
+     */
+    public function latest(): array
+    {
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'header' => 'User-Agent: ' . $this->userAgent,
+            ],
+        ]);
+
+        $json = @file_get_contents(self::LATEST_RELEASE_API, false, $context);
+
+        if ($json === false) {
+            throw new \RuntimeException('Failed to query GitHub releases API.');
+        }
+
+        $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($data) || !isset($data['tag_name'])) {
+            throw new \RuntimeException('Unexpected response from GitHub releases API.');
+        }
+
+        return [
+            'tag'         => (string) $data['tag_name'],
+            'publishedAt' => (string) ($data['published_at'] ?? ''),
+        ];
+    }
+
+    public function install(string $version, string $targetPath, ?string $url = null): void
+    {
+        if (is_dir($targetPath) && (new \FilesystemIterator($targetPath))->valid()) {
+            throw new \RuntimeException(
+                "Target directory is not empty: {$targetPath}. Remove it first or pick another path."
+            );
+        }
+
+        if (!is_dir($targetPath) && !mkdir($targetPath, 0o777, true) && !is_dir($targetPath)) {
+            throw new \RuntimeException("Failed to create target directory: {$targetPath}");
+        }
+
+        $url      = $url ?? sprintf(self::RELEASE_URL_TEMPLATE, $version, $version);
+        $download = tempnam(sys_get_temp_dir(), 'cwm-joomla-') . '.zip';
+
+        echo "Downloading {$url}\n";
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'header' => 'User-Agent: ' . $this->userAgent,
+                'follow_location' => 1,
+                'max_redirects'   => 5,
+            ],
+        ]);
+
+        $bytes = @file_put_contents($download, fopen($url, 'rb', false, $context));
+
+        if ($bytes === false || $bytes === 0) {
+            @unlink($download);
+
+            throw new \RuntimeException("Download failed for {$url}");
+        }
+
+        $zip = new \ZipArchive();
+
+        if ($zip->open($download) !== true) {
+            @unlink($download);
+
+            throw new \RuntimeException("Could not open downloaded zip {$download}");
+        }
+
+        if (!$zip->extractTo($targetPath)) {
+            $zip->close();
+            @unlink($download);
+
+            throw new \RuntimeException("Failed to extract zip into {$targetPath}");
+        }
+
+        $zip->close();
+        @unlink($download);
+
+        echo "Installed Joomla {$version} to {$targetPath}\n";
+    }
+}

--- a/src/Dev/LinkResolver.php
+++ b/src/Dev/LinkResolver.php
@@ -1,0 +1,342 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Dev;
+
+/**
+ * Resolves the symlink list for a project against a given Joomla install.
+ *
+ * Two layers:
+ *
+ *   1. Auto-derive — for each entry in `manifests.extensions[]` plus the
+ *      top-level `extension` block, generate the conventional Joomla layout
+ *      mappings (admin/site/media for components, libraries/<name> +
+ *      manifests/libraries for libraries, plugins/<group>/<element> for
+ *      plugins, modules/[admin]/<name> for modules).
+ *
+ *   2. Explicit — `dev.links[]` and `dev.internalLinks[]` from the project's
+ *      cwm-build.config.json. Explicit entries are always emitted; the
+ *      consumer can disable auto-derive via `dev.deriveLinks: false` for
+ *      complex layouts (Proclaim, etc.).
+ *
+ * Targets in `dev.links[]` may use the `{joomlaPath}` placeholder.
+ *
+ * @phpstan-type LinkPair array{source: string, target: string}
+ */
+final class LinkResolver
+{
+    public function __construct(
+        private readonly string $projectRoot,
+        /** @var array<string, mixed> */
+        private readonly array $config,
+    ) {
+    }
+
+    /**
+     * Internal symlinks (within the project repo).
+     *
+     * @return list<LinkPair>
+     */
+    public function internalLinks(): array
+    {
+        $out = [];
+
+        foreach ($this->config['dev']['internalLinks'] ?? [] as $entry) {
+            $source = $this->resolveProject((string) ($entry['source'] ?? ''));
+            $link   = $this->resolveProject((string) ($entry['link'] ?? $entry['target'] ?? ''));
+
+            if ($source === '' || $link === '') {
+                continue;
+            }
+
+            $out[] = ['source' => $source, 'target' => $link];
+        }
+
+        return $out;
+    }
+
+    /**
+     * External symlinks (project files → Joomla install).
+     *
+     * @return list<LinkPair>
+     */
+    public function externalLinks(string $joomlaPath): array
+    {
+        $out = [];
+
+        if (($this->config['dev']['deriveLinks'] ?? true) !== false) {
+            foreach ($this->autoDerive($joomlaPath) as $pair) {
+                $out[] = $pair;
+            }
+        }
+
+        foreach ($this->config['dev']['links'] ?? [] as $entry) {
+            $sourceRaw = (string) ($entry['source'] ?? '');
+            $targetRaw = (string) ($entry['target'] ?? '');
+
+            if ($sourceRaw === '' || $targetRaw === '') {
+                continue;
+            }
+
+            $source = $this->resolveProject($sourceRaw);
+            $target = strtr($targetRaw, ['{joomlaPath}' => rtrim($joomlaPath, '/')]);
+            $out[]  = ['source' => $source, 'target' => $target];
+        }
+
+        return $this->dedupe($out);
+    }
+
+    /**
+     * @return iterable<LinkPair>
+     */
+    private function autoDerive(string $joomlaPath): iterable
+    {
+        $joomlaPath = rtrim($joomlaPath, '/');
+
+        // Top-level extension (the package's "headline" extension, e.g. the component).
+        $extension = $this->config['extension'] ?? null;
+
+        if (is_array($extension)) {
+            yield from $this->deriveFromTopLevel($extension, $joomlaPath);
+        }
+
+        foreach ($this->config['manifests']['extensions'] ?? [] as $manifest) {
+            $type     = (string) ($manifest['type'] ?? '');
+            $manPath  = (string) ($manifest['path'] ?? '');
+            $manFull  = $this->resolveProject($manPath);
+
+            if ($manFull === '' || !is_file($manFull)) {
+                continue;
+            }
+
+            yield from match ($type) {
+                'library'   => $this->deriveLibrary($manFull, $joomlaPath),
+                'plugin'    => $this->derivePlugin($manFull, $joomlaPath),
+                'module'    => $this->deriveModule($manFull, $joomlaPath),
+                'component' => $this->deriveComponent($manFull, $joomlaPath, $extension),
+                default     => [],
+            };
+        }
+    }
+
+    /**
+     * Components don't usually appear under manifests.extensions[] (the
+     * top-level `extension` block describes them). Drive component derivation
+     * from there.
+     *
+     * @param  array<string, mixed>  $extension
+     * @return iterable<LinkPair>
+     */
+    private function deriveFromTopLevel(array $extension, string $joomlaPath): iterable
+    {
+        if (($extension['type'] ?? null) !== 'component') {
+            return;
+        }
+
+        $name = (string) ($extension['name'] ?? '');
+
+        if ($name === '' || !str_starts_with($name, 'com_')) {
+            return;
+        }
+
+        $admin = $this->resolveProject('admin');
+        $site  = $this->resolveProject('site');
+        $media = $this->resolveProject('media');
+
+        if (is_dir($admin)) {
+            yield ['source' => $admin, 'target' => "{$joomlaPath}/administrator/components/{$name}"];
+        }
+
+        if (is_dir($site)) {
+            yield ['source' => $site, 'target' => "{$joomlaPath}/components/{$name}"];
+        }
+
+        if (is_dir($media)) {
+            yield ['source' => $media, 'target' => "{$joomlaPath}/media/{$name}"];
+        }
+    }
+
+    /**
+     * @return iterable<LinkPair>
+     */
+    private function deriveComponent(string $manifestPath, string $joomlaPath, ?array $extension): iterable
+    {
+        // Only handle the case where a component manifest is listed under
+        // manifests.extensions[]. Most projects keep it on extension.* and we
+        // already covered that in deriveFromTopLevel.
+        if ($extension !== null && ($extension['type'] ?? null) === 'component') {
+            return;
+        }
+
+        $xml = $this->loadManifest($manifestPath);
+
+        if ($xml === null) {
+            return;
+        }
+
+        $name = strtolower(trim((string) $xml->name));
+
+        if ($name === '' || !str_starts_with($name, 'com_')) {
+            return;
+        }
+
+        $base = \dirname($manifestPath);
+
+        foreach (['admin' => "/administrator/components/{$name}",
+                  'site'  => "/components/{$name}",
+                  'media' => "/media/{$name}"] as $sub => $tail) {
+            $src = $base . '/' . $sub;
+
+            if (is_dir($src)) {
+                yield ['source' => $src, 'target' => $joomlaPath . $tail];
+            }
+        }
+    }
+
+    /**
+     * @return iterable<LinkPair>
+     */
+    private function deriveLibrary(string $manifestPath, string $joomlaPath): iterable
+    {
+        $xml = $this->loadManifest($manifestPath);
+
+        if ($xml === null) {
+            return;
+        }
+
+        $libraryName = trim((string) ($xml->libraryname ?? ''));
+        $name        = trim((string) $xml->name);
+
+        if ($libraryName === '' && $name !== '') {
+            $libraryName = preg_replace('/^lib_/', '', strtolower($name));
+        }
+
+        if ($libraryName === '') {
+            return;
+        }
+
+        $libDir = \dirname($manifestPath);
+
+        // libraries/lib_X → joomla/libraries/X
+        yield ['source' => $libDir, 'target' => "{$joomlaPath}/libraries/{$libraryName}"];
+
+        // The library manifest itself is also expected under
+        // administrator/manifests/libraries/<name>.xml
+        yield [
+            'source' => $manifestPath,
+            'target' => "{$joomlaPath}/administrator/manifests/libraries/{$libraryName}.xml",
+        ];
+
+        // media/lib_X (if present alongside the library)
+        $mediaSrc = $libDir . '/media/lib_' . $libraryName;
+
+        if (is_dir($mediaSrc)) {
+            yield ['source' => $mediaSrc, 'target' => "{$joomlaPath}/media/lib_{$libraryName}"];
+        }
+    }
+
+    /**
+     * @return iterable<LinkPair>
+     */
+    private function derivePlugin(string $manifestPath, string $joomlaPath): iterable
+    {
+        $xml = $this->loadManifest($manifestPath);
+
+        if ($xml === null) {
+            return;
+        }
+
+        $group = trim((string) ($xml['group'] ?? ''));
+
+        if ($group === '') {
+            return;
+        }
+
+        // Element comes from the manifest filename (e.g. proclaim.xml → proclaim).
+        $element = pathinfo($manifestPath, PATHINFO_FILENAME);
+
+        if ($element === '') {
+            return;
+        }
+
+        $pluginDir = \dirname($manifestPath);
+        yield ['source' => $pluginDir, 'target' => "{$joomlaPath}/plugins/{$group}/{$element}"];
+    }
+
+    /**
+     * @return iterable<LinkPair>
+     */
+    private function deriveModule(string $manifestPath, string $joomlaPath): iterable
+    {
+        $xml = $this->loadManifest($manifestPath);
+
+        if ($xml === null) {
+            return;
+        }
+
+        $client = trim((string) ($xml['client'] ?? 'site'));
+        $name   = strtolower(trim((string) $xml->name));
+
+        if ($name === '' || !str_starts_with($name, 'mod_')) {
+            return;
+        }
+
+        $modDir = \dirname($manifestPath);
+        $tail   = $client === 'administrator'
+            ? "/administrator/modules/{$name}"
+            : "/modules/{$name}";
+
+        yield ['source' => $modDir, 'target' => $joomlaPath . $tail];
+    }
+
+    private function loadManifest(string $path): ?\SimpleXMLElement
+    {
+        $previous = libxml_use_internal_errors(true);
+
+        try {
+            $xml = simplexml_load_file($path);
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
+
+        return $xml === false ? null : $xml;
+    }
+
+    private function resolveProject(string $path): string
+    {
+        if ($path === '') {
+            return '';
+        }
+
+        if ($path[0] === '/') {
+            return $path;
+        }
+
+        return rtrim($this->projectRoot, '/') . '/' . ltrim($path, '/');
+    }
+
+    /**
+     * @param  list<LinkPair>  $links
+     * @return list<LinkPair>
+     */
+    private function dedupe(array $links): array
+    {
+        $seen = [];
+        $out  = [];
+
+        foreach ($links as $pair) {
+            $key = $pair['target'];
+
+            if (isset($seen[$key])) {
+                continue;
+            }
+
+            $seen[$key] = true;
+            $out[]      = $pair;
+        }
+
+        return $out;
+    }
+}

--- a/src/Dev/Linker.php
+++ b/src/Dev/Linker.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Dev;
+
+/**
+ * Symlink driver. Creates and verifies relative symlinks between a project
+ * checkout and a live Joomla installation.
+ *
+ * Why relative: when an absolute path is baked into a symlink, it travels as
+ * a broken pointer the moment the repo or Joomla tree is checked out at a
+ * different prefix on a different machine (or in CI). Computing the link
+ * target relative to the link's own directory keeps things portable —
+ * cwmconnect's PR #88 / #89 had to undo absolute-path symlinks Proclaim's
+ * scripts shipped with for the same reason.
+ *
+ * @phpstan-type LinkResult array{link: string, target: string, status: string, message?: string}
+ */
+final class Linker
+{
+    public function __construct(private readonly bool $verbose = false)
+    {
+    }
+
+    /**
+     * Create a symlink from $link → $source. Replaces an existing file,
+     * directory, or stale symlink at $link.
+     */
+    public function link(string $source, string $link): void
+    {
+        if (!file_exists($source) && !is_link($source)) {
+            $this->warn("Target does not exist, symlink will be broken: {$source}");
+        }
+
+        clearstatcache(true, $link);
+
+        if (is_link($link)) {
+            if (!@unlink($link)) {
+                $this->warn("Failed to unlink existing symlink {$link}");
+            }
+        } elseif (file_exists($link)) {
+            if (is_dir($link)) {
+                $this->removeDirectory($link);
+            } elseif (!@unlink($link)) {
+                $this->warn("Failed to unlink existing file {$link}");
+            }
+        }
+
+        $parent = \dirname($link);
+
+        if (!is_dir($parent) && !mkdir($parent, 0o777, true) && !is_dir($parent)) {
+            $this->error("Failed to create parent directory {$parent}");
+
+            return;
+        }
+
+        // Normalise both ends so a symlinked prefix on one side (e.g. macOS
+        // /tmp → /private/tmp) does not poison the relative-path computation.
+        $realSource = realpath($source) ?: $source;
+        $realParent = realpath($parent) ?: $parent;
+        $relative   = $this->relativePath($realSource, $realParent);
+
+        if ($this->verbose) {
+            echo "Linking {$link} -> {$relative}\n";
+        }
+
+        if (!@symlink($relative, $link)) {
+            $this->error("Failed to create symlink {$link} -> {$relative}");
+            $err = error_get_last();
+
+            if ($err !== null) {
+                echo '  Details: ' . $err['message'] . "\n";
+            }
+        }
+    }
+
+    /**
+     * Verify a single symlink against its expected target. Returns one of:
+     *   ok      — link points to the right place
+     *   missing — link does not exist
+     *   stale   — a real file or directory sits at the link path
+     *   wrong   — link points somewhere unexpected
+     *   broken  — link points at a non-existent target
+     *
+     * @return array{link: string, target: string, status: string, message?: string}
+     */
+    public function check(string $source, string $link): array
+    {
+        clearstatcache(true, $link);
+
+        if (!is_link($link)) {
+            if (file_exists($link)) {
+                return ['link' => $link, 'target' => $source, 'status' => 'stale'];
+            }
+
+            return ['link' => $link, 'target' => $source, 'status' => 'missing'];
+        }
+
+        $actual         = readlink($link);
+        $resolvedActual = $actual === false
+            ? false
+            : (realpath($this->resolveAgainst($actual, \dirname($link))) ?: $actual);
+        $resolvedTarget = realpath($source) ?: $source;
+
+        if ($resolvedActual !== $resolvedTarget) {
+            return [
+                'link'    => $link,
+                'target'  => $source,
+                'status'  => 'wrong',
+                'message' => "points to {$actual}",
+            ];
+        }
+
+        if (!file_exists($link)) {
+            return ['link' => $link, 'target' => $source, 'status' => 'broken'];
+        }
+
+        return ['link' => $link, 'target' => $source, 'status' => 'ok'];
+    }
+
+    public function unlink(string $link): bool
+    {
+        clearstatcache(true, $link);
+
+        if (!is_link($link)) {
+            return false;
+        }
+
+        return @unlink($link);
+    }
+
+    /**
+     * Compute a relative path from a directory ($from) to a file or
+     * directory ($target). Both inputs must resolve to absolute paths;
+     * relatives are interpreted against getcwd().
+     */
+    public function relativePath(string $target, string $from): string
+    {
+        $target = $this->absolutise($target);
+        $from   = $this->absolutise($from);
+
+        $targetParts = explode('/', trim($target, '/'));
+        $fromParts   = explode('/', trim($from, '/'));
+
+        while ($targetParts !== [] && $fromParts !== [] && $targetParts[0] === $fromParts[0]) {
+            array_shift($targetParts);
+            array_shift($fromParts);
+        }
+
+        $up   = str_repeat('../', \count($fromParts));
+        $rest = implode('/', $targetParts);
+        $rel  = $up . $rest;
+
+        return $rel === '' ? '.' : rtrim($rel, '/');
+    }
+
+    private function absolutise(string $path): string
+    {
+        if ($path === '' || $path[0] === '/') {
+            return $path;
+        }
+
+        return rtrim(getcwd() ?: '', '/') . '/' . $path;
+    }
+
+    private function resolveAgainst(string $target, string $base): string
+    {
+        if ($target === '' || $target[0] === '/') {
+            return $target;
+        }
+
+        return rtrim($base, '/') . '/' . $target;
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $entry) {
+            /** @var \SplFileInfo $entry */
+            if ($entry->isDir() && !$entry->isLink()) {
+                @rmdir($entry->getPathname());
+            } else {
+                @unlink($entry->getPathname());
+            }
+        }
+
+        @rmdir($path);
+    }
+
+    private function warn(string $msg): void
+    {
+        echo "WARNING: {$msg}\n";
+    }
+
+    private function error(string $msg): void
+    {
+        fwrite(STDERR, "ERROR: {$msg}\n");
+    }
+}

--- a/src/Dev/PropertiesReader.php
+++ b/src/Dev/PropertiesReader.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Dev;
+
+/**
+ * Reads and writes the per-developer build.properties file.
+ *
+ * The canonical format is INI with one section per Joomla install:
+ *
+ *   ; Comma-separated list of install ids
+ *   installs = j5, j6
+ *
+ *   [j5]
+ *   path = /path/to/joomla5
+ *   url = https://j5-dev.local:8890
+ *   version = 5.4.2
+ *   db_host = localhost
+ *   db_user =
+ *   db_pass =
+ *   db_name =
+ *   admin_user = admin
+ *   admin_pass = admin
+ *   admin_email = admin@example.com
+ *
+ * Legacy fall-back (Proclaim's flat key=value layout) is also recognised:
+ *   builder.joomla_paths=/path/to/j5,/path/to/j6
+ *   builder.j5dev.url=...
+ *   builder.j5dev.db_host=...
+ * The reader maps Proclaim's `j5dev` / `j6dev` ids to `j5` / `j6` and merges
+ * `builder.joomla_paths` entries into the matching sections by position.
+ */
+final class PropertiesReader
+{
+    public function __construct(private readonly string $path)
+    {
+    }
+
+    public function exists(): bool
+    {
+        return is_file($this->path);
+    }
+
+    public function path(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * @return list<InstallConfig>
+     */
+    public function installs(): array
+    {
+        if (!$this->exists()) {
+            throw new \RuntimeException(
+                "build.properties not found at {$this->path}. Run 'composer setup' first."
+            );
+        }
+
+        $raw = parse_ini_file($this->path, true, INI_SCANNER_RAW);
+
+        if ($raw === false) {
+            throw new \RuntimeException("Could not parse {$this->path} as INI.");
+        }
+
+        // Detect format: INI-sections (preferred) vs legacy flat Proclaim style.
+        $hasSections = false;
+
+        foreach ($raw as $value) {
+            if (is_array($value)) {
+                $hasSections = true;
+
+                break;
+            }
+        }
+
+        return $hasSections
+            ? $this->fromSections($raw)
+            : $this->fromLegacyFlat($raw);
+    }
+
+    /**
+     * @param  array<string, mixed>  $raw
+     * @return list<InstallConfig>
+     */
+    private function fromSections(array $raw): array
+    {
+        $idsRaw = (string) ($raw['installs'] ?? '');
+        $ids    = array_filter(array_map('trim', explode(',', $idsRaw)));
+
+        if ($ids === []) {
+            // No explicit list — treat every section as an install.
+            $ids = array_keys(array_filter($raw, 'is_array'));
+        }
+
+        $installs = [];
+
+        foreach ($ids as $id) {
+            $section = $raw[$id] ?? null;
+
+            if (!is_array($section)) {
+                continue;
+            }
+
+            $installs[] = new InstallConfig(
+                id:      $id,
+                path:    rtrim((string) ($section['path'] ?? ''), '/'),
+                url:     ($section['url'] ?? '') === '' ? null : (string) $section['url'],
+                version: ($section['version'] ?? '') === '' ? null : (string) $section['version'],
+                db:      [
+                    'host' => (string) ($section['db_host'] ?? 'localhost'),
+                    'user' => (string) ($section['db_user'] ?? ''),
+                    'pass' => (string) ($section['db_pass'] ?? ''),
+                    'name' => (string) ($section['db_name'] ?? ''),
+                ],
+                admin:   [
+                    'user'  => (string) ($section['admin_user'] ?? 'admin'),
+                    'pass'  => (string) ($section['admin_pass'] ?? 'admin'),
+                    'email' => (string) ($section['admin_email'] ?? 'admin@example.com'),
+                ],
+            );
+        }
+
+        return $installs;
+    }
+
+    /**
+     * Compatibility path for Proclaim's `builder.joomla_paths=` + `builder.<id>.<key>=` layout.
+     *
+     * @param  array<string, mixed>  $raw
+     * @return list<InstallConfig>
+     */
+    private function fromLegacyFlat(array $raw): array
+    {
+        $pathsRaw = (string) ($raw['builder.joomla_paths']
+            ?? $raw['builder.joomla_path']
+            ?? '');
+        $dir   = trim((string) ($raw['builder.joomla_dir'] ?? ''), '/');
+        $paths = array_values(array_filter(array_map('trim', explode(',', $pathsRaw))));
+
+        if ($paths === []) {
+            return [];
+        }
+
+        // Discover ids by scanning for `builder.<id>.url` keys.
+        $ids = [];
+
+        foreach ($raw as $key => $_) {
+            if (preg_match('/^builder\.([^.]+)\.url$/', (string) $key, $m)) {
+                $ids[] = $m[1];
+            }
+        }
+
+        $ids = array_values(array_unique($ids));
+
+        // Default Proclaim ids if discovery turned up nothing.
+        if ($ids === []) {
+            $ids = ['j5dev', 'j6dev'];
+        }
+
+        $defaultVersion = (string) ($raw['joomla.version'] ?? '');
+        $installs       = [];
+
+        foreach ($paths as $i => $rawPath) {
+            $id   = $ids[$i] ?? "j{$i}";
+            $path = rtrim($rawPath, '/');
+
+            if ($dir !== '') {
+                $path .= '/' . $dir;
+            }
+
+            $prefix = "builder.{$id}";
+
+            $installs[] = new InstallConfig(
+                id:      $this->normaliseLegacyId($id),
+                path:    $path,
+                url:     ($raw["{$prefix}.url"] ?? '') === '' ? null : (string) $raw["{$prefix}.url"],
+                version: $defaultVersion === '' ? null : $defaultVersion,
+                db:      [
+                    'host' => (string) ($raw["{$prefix}.db_host"] ?? 'localhost'),
+                    'user' => (string) ($raw["{$prefix}.db_user"] ?? ''),
+                    'pass' => (string) ($raw["{$prefix}.db_pass"] ?? ''),
+                    'name' => (string) ($raw["{$prefix}.db_name"] ?? ''),
+                ],
+                admin:   [
+                    'user'  => (string) ($raw["{$prefix}.username"] ?? 'admin'),
+                    'pass'  => (string) ($raw["{$prefix}.password"] ?? 'admin'),
+                    'email' => (string) ($raw["{$prefix}.email"] ?? 'admin@example.com'),
+                ],
+            );
+        }
+
+        return $installs;
+    }
+
+    /**
+     * Map Proclaim's `j5dev` → `j5`. Leaves modern ids untouched.
+     */
+    private function normaliseLegacyId(string $id): string
+    {
+        return preg_replace('/dev$/', '', $id) ?? $id;
+    }
+
+    /**
+     * Write a fresh build.properties from a list of installs. Existing comments
+     * are not preserved — callers that want to keep a hand-edited file should
+     * write in place instead. Used by the setup wizard.
+     *
+     * @param  list<InstallConfig>  $installs
+     */
+    public function write(array $installs): void
+    {
+        $ids   = array_map(static fn (InstallConfig $i): string => $i->id, $installs);
+        $lines = [
+            '; build.properties — local Joomla installs for cwm-build-tools dev commands.',
+            '; Gitignored. Per-developer. Generated by `composer setup`.',
+            '',
+            '; Comma-separated list of install ids (must match the section names below).',
+            'installs = ' . implode(', ', $ids),
+            '',
+        ];
+
+        foreach ($installs as $install) {
+            $lines[] = "[{$install->id}]";
+            $lines[] = 'path = ' . $install->path;
+            $lines[] = 'url = ' . ($install->url ?? '');
+            $lines[] = 'version = ' . ($install->version ?? '');
+            $lines[] = 'db_host = ' . $install->dbHost();
+            $lines[] = 'db_user = ' . $install->dbUser();
+            $lines[] = 'db_pass = ' . $install->dbPass();
+            $lines[] = 'db_name = ' . $install->dbName();
+            $lines[] = 'admin_user = ' . $install->adminUser();
+            $lines[] = 'admin_pass = ' . $install->adminPass();
+            $lines[] = 'admin_email = ' . $install->adminEmail();
+            $lines[] = '';
+        }
+
+        file_put_contents($this->path, implode("\n", $lines));
+    }
+}

--- a/templates/build.properties.tmpl
+++ b/templates/build.properties.tmpl
@@ -1,0 +1,42 @@
+; build.properties — local Joomla installs for cwm-build-tools dev commands.
+;
+; This file is the per-developer mate to cwm-build.config.json:
+;   - cwm-build.config.json (committed) — what the project IS:
+;       extension layout, manifest paths, optional dev.links[].
+;   - build.properties (gitignored) — where YOUR dev environment runs:
+;       paths to your Joomla installs, DB credentials, admin credentials.
+;
+; To set up the first time:
+;   cp build.properties.tmpl build.properties
+; Then either edit by hand or run the wizard:
+;   composer setup
+;
+; ALWAYS keep this gitignored. It contains DB and admin passwords.
+
+; Comma-separated list of install ids — must match the section names below.
+; Add or remove as needed (j5, j6, j7, ...).
+installs = j5, j6
+
+[j5]
+path = /path/to/joomla5
+url = https://j5-dev.local
+version = 5.4.2
+db_host = localhost
+db_user =
+db_pass =
+db_name =
+admin_user = admin
+admin_pass = admin
+admin_email = admin@example.com
+
+[j6]
+path = /path/to/joomla6
+url = https://j6-dev.local
+version = 6.0.0
+db_host = localhost
+db_user =
+db_pass =
+db_name =
+admin_user = admin
+admin_pass = admin
+admin_email = admin@example.com

--- a/templates/cwm-build.config.json.tmpl
+++ b/templates/cwm-build.config.json.tmpl
@@ -38,5 +38,19 @@
     "announcement": {
         "bulletsDir": "build",
         "command": "bash build/cwm-article.sh"
+    },
+    "dev": {
+        "_comment": "Optional. Drives cwm-link / cwm-link-check / cwm-clean / cwm-verify.",
+        "deriveLinks": true,
+        "internalLinks": [
+            { "source": "yourextension.xml",       "link": "admin/yourextension.xml" },
+            { "source": "yourextension.script.php", "link": "admin/yourextension.script.php" }
+        ],
+        "links": [
+            {
+                "source": "language/admin/en-GB/en-GB.com_yourextension.ini",
+                "target": "{joomlaPath}/administrator/language/en-GB/en-GB.com_yourextension.ini"
+            }
+        ]
     }
 }

--- a/templates/gitignore-managed.txt
+++ b/templates/gitignore-managed.txt
@@ -19,3 +19,4 @@ Thumbs.db
 # Local env
 .env
 .env.local
+build.properties


### PR DESCRIPTION
## Summary

Lift Proclaim's project-local dev-setup commands into the shared `cwm-build-tools` repo so every CWM extension (cwmconnect, CWMScriptureLinks, CWMLivingWord, lib_cwmscripture, Proclaim itself) can drive its local Joomla dev environment through composer-script aliases — same model as `cwm-release` / `cwm-bump` / `cwm-package` / `cwm-ars-publish` / `cwm-changelog` / `cwm-sync-configs` / `cwm-sync-languages`.

Provenance: lifted from [Proclaim's `build/proclaim_build.php`](https://github.com/Joomla-Bible-Study/Proclaim/blob/main/build/proclaim_build.php) (~1400-line CLI) and parameterised so every consuming repo doesn't have to carry its own copy. Surfaced by [Joomla-Bible-Study/cwmconnect#77](https://github.com/Joomla-Bible-Study/cwmconnect/issues/77) — cwmconnect's modernization tracker has the same dev-loop pain Proclaim already solved locally.

## What ships

| Command | What it does |
|---|---|
| `cwm-setup` | Interactive wizard; writes `build.properties` (paths, URLs, versions, DB creds, admin creds) |
| `cwm-link` | Symlinks the project tree into every configured Joomla install (relative paths) |
| `cwm-link-check` | Verifies expected symlinks; exits non-zero on drift (CI-friendly) |
| `cwm-clean` | Removes every dev symlink (real files left alone) |
| `cwm-verify` | Confirms each install has every project sub-extension registered in `#__extensions`; `--fix` reconciles drift |
| `cwm-joomla-install` | Downloads + extracts Joomla into each configured install path |
| `cwm-joomla-latest` | Prints latest stable Joomla tag from the joomla-cms releases feed |

PHP classes under `CWM\BuildTools\Dev\`:
- `InstallConfig` — value object for one Joomla install
- `PropertiesReader` — INI-section format primary, Proclaim's legacy `builder.joomla_paths=` flat layout as compat fallback
- `LinkResolver` — auto-derives the standard symlink set from `extension.*` + `manifests.extensions[]`; merges in `dev.links[]` / `dev.internalLinks[]`
- `Linker` — relative-path symlink driver, normalises both ends through `realpath()` so symlinked prefixes (e.g. macOS `/tmp` → `/private/tmp`) don't poison the relative-path computation
- `ExtensionVerifier` — reads each manifest XML to discover (type, element, folder, namespace); PDO so it never bootstraps Joomla
- `JoomlaInstaller` — download + extract a Joomla full-package zip

The bash/PHP scripts in `scripts/` are thin wrappers over those classes.

## Configuration split

Two files now drive the dev surface — one shared, one per-developer:

| File | Committed? | Purpose |
|---|---|---|
| `cwm-build.config.json` | yes | What the project IS — extension layout, manifest paths, optional `dev:` block (link rules, repo-internal mirrors). No secrets. |
| `build.properties` | **no — gitignore it** | Where the developer's local Joomla installs live: paths, URLs, target versions, DB credentials, admin credentials. |

`templates/gitignore-managed.txt` adds `build.properties` to the managed block so consumers automatically pick up the gitignore on next `composer sync-configs`.

## Relative symlinks (the cwmconnect#88/#89 footgun)

Proclaim's existing build script created symlinks with **absolute** target paths (e.g. `/Users/brent/Sites/joomla5/components/com_proclaim → /Users/brent/code/Proclaim/site`), which travel as broken pointers on every machine except the one they were created on. cwmconnect's PR #88/#89 had to undo this for the cwmconnect rewrite. The new `Linker::link()` always emits relative paths and verifies it on macOS where `/tmp → /private/tmp` was previously poisoning the computation.

## Generic across extension types

`LinkResolver` auto-derives the standard symlink set from each project's existing `manifests.extensions[]` — components get `admin/` + `site/` + `media/` mirrored, libraries get `libraries/<name>` + the manifest stub under `administrator/manifests/libraries/`, plugins land at `plugins/<group>/<element>`, modules at `modules/[admin]/<name>`. Anything that doesn't fit those rules (cross-repo libs, language-file overrides, submodules) goes in `dev.links[]` explicitly. Fully custom layouts can set `dev.deriveLinks: false` and list every link by hand.

Multi-install supported (J5 + J6 + future J7) via the `installs = j5, j6, j7` list in `build.properties`.

## Out of scope (deliberate)

- No consumer migrations in this PR. cwmconnect / Proclaim / CWMScriptureLinks / CWMLivingWord / lib_cwmscripture each adopt in their own follow-up PR.
- Generic `PackageBuilder` is the existing Phase 4 roadmap item — separate work.
- `cwm-init` already exists; the wizard inside `cwm-setup` is for the **dev environment**, not the project scaffold.

## Test plan

- [x] Smoke: every new bin loads + responds to `--help`.
- [x] End-to-end on a synthetic component + module + plugin against two fake Joomla install dirs:
  - `cwm-link --verbose` creates 5 relative symlinks per install.
  - `cwm-link-check` reports all healthy.
  - `cwm-clean --verbose` removes all 10.
- [x] Legacy Proclaim flat `builder.joomla_paths=` properties: parsed correctly, link/check/clean all green.
- [x] `php -l` clean across `src/Dev/*.php` and `scripts/*.php`.
- [ ] Real-world adoption (per-consumer): cwmconnect first, then Proclaim, then the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)