### PR TITLE
feat(release): add pre-flight git pull + submodule sync (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `cwm-release`: pre-flight steps before the version bump now (a) `git fetch
+  origin --prune --tags`, (b) `git pull --ff-only origin <release-branch>` and
+  abort with guidance if local has diverged, (c) `git submodule update --init
+  --recursive` to match working trees to recorded pointers, and (d) warn when
+  a submodule pointer isn't at a tagged release commit (non-blocking — shipping
+  an untagged snapshot is sometimes intentional, but should be deliberate).
+  Catches the "I forgot to pull" and "submodule working tree on a different
+  commit than recorded" failure modes that surfaced during the Proclaim 10.3.2
+  release. Reported in #6.
+
 ## [0.4.1-alpha] - 2026-05-08
 
 Fixes and scaffolder completion driven by the first end-to-end consumer

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -65,6 +65,44 @@ if [ -n "$(git status --porcelain)" ]; then
     exit 1
 fi
 
+# --- Pre-flight: sync with origin ---
+# Catches the "I forgot to pull" failure mode where the release builds from
+# stale parent state, and the "submodule working tree on a different commit
+# than recorded" failure mode where the package silently embeds an unintended
+# snapshot. Both happened during the Proclaim 10.3.2 release pass (issue #6).
+echo "[pre-flight] Fetching origin..."
+git fetch origin --prune --tags
+
+echo "[pre-flight] Pulling ${RELEASE_BRANCH} (fast-forward only)..."
+if ! git pull --ff-only origin "$RELEASE_BRANCH"; then
+    echo ""
+    echo "Error: Local ${RELEASE_BRANCH} has diverged from origin/${RELEASE_BRANCH}."
+    echo "Resolve manually before running release."
+    echo "  Inspect: git status && git log @{u}.."
+    echo "  Rebase:  git pull --rebase origin ${RELEASE_BRANCH}"
+    exit 1
+fi
+
+# `submodule update` is a no-op when no submodules are configured.
+echo "[pre-flight] Syncing submodules to recorded pointers..."
+git submodule update --init --recursive
+
+# Warn (don't block) when a submodule pointer isn't at a tagged release commit.
+# Shipping an untagged snapshot is sometimes intentional, but it should be a
+# deliberate choice — surface it loudly.
+if [ -f .gitmodules ]; then
+    git submodule foreach --quiet '
+        ptr=$(git rev-parse HEAD)
+        if ! git describe --exact-match --tags "$ptr" >/dev/null 2>&1; then
+            short=$(echo "$ptr" | cut -c1-8)
+            echo "  WARNING: submodule $name pointer ${short} is not at a tagged release."
+            echo "           The package will embed a snapshot, not a tagged version."
+            echo "           If this is unintentional, release the submodule first."
+        fi
+    '
+fi
+echo ""
+
 # --- Get version ---
 if [ -n "${1:-}" ]; then
     VERSION="$1"


### PR DESCRIPTION
## Summary

Adds three pre-flight steps to `cwm-release` between the existing pre-checks (branch + clean tree) and the version bump:

1. `git fetch origin --prune --tags`
2. `git pull --ff-only origin "$RELEASE_BRANCH"` — aborts with guidance (`git status`, `git log @{u}..`, `git pull --rebase`) when local has diverged.
3. `git submodule update --init --recursive` — no-op when `.gitmodules` is absent.
4. `git submodule foreach` warning (non-blocking) when a submodule pointer isn't at a tagged release commit.

Catches the "I forgot to pull" and "submodule working tree on a different commit than recorded" failure modes that surfaced during the Proclaim 10.3.2 release pass. Untagged submodule pointers warn loudly but don't block — shipping an untagged snapshot is sometimes intentional, but should be a deliberate choice.

The optional repo-identity check from the issue (lowest priority per the issue itself) is deferred — the three steps above already cover both incidents from that release.

Closes #6.

## Test plan

- [x] `bash -n scripts/release.sh` — syntax check
- [x] `composer test` — full PHPUnit suite (40/40, 100 assertions)
- [ ] Smoke test against a throwaway clone with diverged main → pull --ff-only aborts cleanly
- [ ] Smoke test in a repo with submodules on a non-tagged commit → warning surfaces, release continues
- [ ] Real release pass on a CWM extension to confirm the new lines render correctly in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)