### PR TITLE
feat(joomla-cms-deps): add cwm-joomla-cms-deps binary (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `cwm-joomla-cms-deps` binary + `scripts/joomla-cms-deps.php` — generic
+  version of the Proclaim-side `build/joomla-cms-deps.php` that clones
+  `joomla-cms` source for unit tests to require directly. New optional
+  config fields `testing.joomlaCmsVersion` (defaults to `5.4.3`) and
+  `testing.joomlaCmsPath` (defaults to `<cwd-parent>/joomla-cms`); CLI
+  flags `-v`/`--version` and `-p`/`--path` override either. Backward-
+  compatible with the legacy `tests.joomla_cms_path` key in
+  `build.properties` so existing Proclaim setups keep working before
+  consumers migrate. Wire from `composer.json` `post-install-cmd`.
+  Reported in #7.
+
 - `cwm-article` binary + `scripts/cwm-article.sh` — generic version of the
   Proclaim-side `build/cwm-article.sh` that posts a "<Extension> X.Y.Z
   Released" announcement to christianwebministries.org, features it, and

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Across `Proclaim`, `lib_cwmscripture`, `CWMScriptureLinks`, and `plg_task_cwmscr
 
 | Surface | What | Where |
 |---|---|---|
-| **CLI tools** | `cwm-release`, `cwm-bump`, `cwm-package`, `cwm-sync-configs`, `cwm-sync-languages`, `cwm-ars-publish`, `cwm-changelog`, `cwm-article`, `cwm-init`, `cwm-setup`, `cwm-link`, `cwm-link-check`, `cwm-clean`, `cwm-verify`, `cwm-joomla-install`, `cwm-joomla-latest` | `bin/` |
+| **CLI tools** | `cwm-release`, `cwm-bump`, `cwm-package`, `cwm-sync-configs`, `cwm-sync-languages`, `cwm-ars-publish`, `cwm-changelog`, `cwm-article`, `cwm-init`, `cwm-setup`, `cwm-link`, `cwm-link-check`, `cwm-clean`, `cwm-verify`, `cwm-joomla-install`, `cwm-joomla-latest`, `cwm-joomla-cms-deps` | `bin/` |
 | **Scripts** | Generic 8-step release pipeline, multi-manifest version bumper, config syncer | `scripts/` |
 | **PHP library** | `ProjectConfig`, `ManifestReader`, `PackageBuilder`, `ArsPublisher`, `Bumper` | `src/` (PSR-4 `CWM\BuildTools\`) |
 | **Reusable GH Actions** | `joomla-package-ci.yml`, `joomla-library-ci.yml` (called via `workflow_call`) | `.github/workflows/` |

--- a/bin/cwm-joomla-cms-deps
+++ b/bin/cwm-joomla-cms-deps
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# cwm-joomla-cms-deps — clone joomla-cms source for unit testing.
+#
+# Provides the Joomla CMS source tree that PHPUnit tests `require` directly.
+# No-op when the target directory already exists.
+#
+# Reads testing.joomlaCmsVersion / testing.joomlaCmsPath from
+# cwm-build.config.json when present, falls back to tests.joomla_cms_path
+# in build.properties, then to <cwd-parent>/joomla-cms.
+#
+# Typical wiring is from a consumer's composer.json post-install-cmd:
+#   "scripts": {
+#       "post-install-cmd": ["cwm-joomla-cms-deps"]
+#   }
+#
+# Usage:
+#   cwm-joomla-cms-deps                     # config / default
+#   cwm-joomla-cms-deps -v 5.4.5            # override version
+#   cwm-joomla-cms-deps -p ../my-joomla     # override path
+#   cwm-joomla-cms-deps --help
+#
+set -euo pipefail
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec php "${TOOLS_DIR}/scripts/joomla-cms-deps.php" "$@"

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
         "bin/cwm-clean",
         "bin/cwm-verify",
         "bin/cwm-joomla-install",
-        "bin/cwm-joomla-latest"
+        "bin/cwm-joomla-latest",
+        "bin/cwm-joomla-cms-deps"
     ],
     "config": {
         "sort-packages": true,

--- a/scripts/joomla-cms-deps.php
+++ b/scripts/joomla-cms-deps.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Ensure a Joomla CMS source clone exists for unit testing.
+ *
+ * The clone provides real Joomla classes (libraries/loader.php and friends)
+ * that PHPUnit tests can require directly — the alternative is mocking
+ * core, which (per the project's testing posture) gets brittle quickly.
+ *
+ * Resolution order for the clone path:
+ *   1. --path / -p CLI argument (explicit override)
+ *   2. testing.joomlaCmsPath in cwm-build.config.json (when present)
+ *   3. tests.joomla_cms_path in build.properties (legacy compat with the
+ *      Proclaim-style `composer install` post-install-cmd flow)
+ *   4. <cwd-parent>/joomla-cms (default — sibling of the project root)
+ *
+ * Resolution order for the branch/tag to clone:
+ *   1. --version / -v CLI argument
+ *   2. testing.joomlaCmsVersion in cwm-build.config.json
+ *   3. Hard-coded default 5.4.3 (known-stable framework v4.0 baseline)
+ *
+ * No-op when the target path already exists; otherwise runs:
+ *   git clone --depth 1 --branch <version> https://github.com/joomla/joomla-cms.git <path>
+ */
+
+$projectRoot = getcwd() ?: '.';
+
+$DEFAULT_VERSION = '5.4.3';
+$REPO_URL        = 'https://github.com/joomla/joomla-cms.git';
+
+// --- CLI parsing ---
+$args = $argv;
+array_shift($args);
+
+if (in_array('--help', $args, true) || in_array('-h', $args, true)) {
+    echo <<<HELP
+cwm-joomla-cms-deps — clone joomla-cms source for unit testing.
+
+WHAT IT DOES
+  Clones https://github.com/joomla/joomla-cms.git at a known-stable tag into
+  a sibling directory (or a configured path) so PHPUnit tests can `require`
+  real Joomla classes. No-op when the target directory already exists.
+
+PREREQUISITES
+  - git on PATH
+
+USAGE
+  cwm-joomla-cms-deps                          # use config / default
+  cwm-joomla-cms-deps -v 5.4.5                 # override version
+  cwm-joomla-cms-deps -p ../joomla-cms-canary  # override clone path
+
+OPTIONS
+  -v, --version <tag>   Joomla CMS branch or tag to clone. Default 5.4.3.
+                        Override via testing.joomlaCmsVersion in
+                        cwm-build.config.json or this CLI flag.
+  -p, --path <dir>      Clone target directory. Override via
+                        testing.joomlaCmsPath in cwm-build.config.json,
+                        tests.joomla_cms_path in build.properties, or this
+                        CLI flag. Default: <cwd-parent>/joomla-cms.
+  -h, --help            Show this help.
+
+WIRING
+  Typical use is from a consumer's composer.json post-install-cmd:
+      "scripts": {
+          "post-install-cmd": ["cwm-joomla-cms-deps"]
+      }
+
+RELATED
+  cwm-joomla-install   # download a Joomla full-package zip into install paths
+  cwm-joomla-latest    # print the latest stable Joomla version
+
+HELP;
+    exit(0);
+}
+
+$cliVersion = '';
+$cliPath    = '';
+
+for ($i = 0, $n = count($args); $i < $n; $i++) {
+    $arg = $args[$i];
+
+    if (($arg === '-v' || $arg === '--version') && isset($args[$i + 1])) {
+        $cliVersion = $args[++$i];
+        continue;
+    }
+
+    if (($arg === '-p' || $arg === '--path') && isset($args[$i + 1])) {
+        $cliPath = $args[++$i];
+        continue;
+    }
+
+    fwrite(STDERR, "Error: unrecognized argument '$arg'. Run with --help for usage.\n");
+    exit(1);
+}
+
+// --- Resolve version ---
+$version = $cliVersion;
+
+if ($version === '') {
+    $configFile = $projectRoot . '/cwm-build.config.json';
+
+    if (is_file($configFile)) {
+        $config = json_decode((string) file_get_contents($configFile), true);
+
+        if (is_array($config)) {
+            $version = (string) ($config['testing']['joomlaCmsVersion'] ?? '');
+        }
+    }
+}
+
+if ($version === '') {
+    $version = $DEFAULT_VERSION;
+}
+
+// --- Resolve clone path ---
+$joomlaDir = $cliPath;
+
+if ($joomlaDir === '') {
+    $configFile = $projectRoot . '/cwm-build.config.json';
+
+    if (is_file($configFile)) {
+        $config = json_decode((string) file_get_contents($configFile), true);
+
+        if (is_array($config)) {
+            $joomlaDir = (string) ($config['testing']['joomlaCmsPath'] ?? '');
+        }
+    }
+}
+
+if ($joomlaDir === '') {
+    // Legacy compat: read tests.joomla_cms_path from build.properties so
+    // existing Proclaim setups keep working without config-file changes.
+    $propsFile = $projectRoot . '/build.properties';
+
+    if (file_exists($propsFile)) {
+        $lines = file($propsFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
+        foreach ($lines as $line) {
+            $trimmed = trim($line);
+
+            if ($trimmed === '' || str_starts_with($trimmed, '#') || str_starts_with($trimmed, ';')) {
+                continue;
+            }
+
+            $eq = strpos($trimmed, '=');
+
+            if ($eq === false) {
+                continue;
+            }
+
+            $key   = trim(substr($trimmed, 0, $eq));
+            $value = trim(substr($trimmed, $eq + 1));
+
+            if ($key === 'tests.joomla_cms_path' && $value !== '') {
+                $joomlaDir = $value;
+                break;
+            }
+        }
+    }
+}
+
+if ($joomlaDir === '') {
+    // Default to <cwd-parent>/joomla-cms. Anyone who wants a custom location
+    // sets testing.joomlaCmsPath, tests.joomla_cms_path, or passes --path.
+    $joomlaDir = \dirname($projectRoot) . '/joomla-cms';
+}
+
+// --- Clone if missing ---
+if (!is_dir($joomlaDir)) {
+    echo "  Cloning joomla-cms {$version} into {$joomlaDir}..." . PHP_EOL;
+
+    // Array-form proc_open: no shell, no metachar interpretation. Inherit
+    // stdout/stderr so the user sees git's progress output directly.
+    $process = proc_open(
+        ['git', 'clone', '--depth', '1', '--branch', $version, $REPO_URL, $joomlaDir],
+        [
+            0 => ['file', '/dev/null', 'r'],
+            1 => STDOUT,
+            2 => STDERR,
+        ],
+        $pipes
+    );
+
+    if (!is_resource($process)) {
+        echo "  \033[31m✗ Failed to spawn git\033[0m" . PHP_EOL;
+        exit(1);
+    }
+
+    $code = proc_close($process);
+
+    if ($code !== 0) {
+        echo "  \033[31m✗ git clone failed (exit code: $code)\033[0m" . PHP_EOL;
+        exit($code);
+    }
+
+    echo "  \033[32m✓ joomla-cms cloned to $joomlaDir\033[0m" . PHP_EOL;
+}
+
+// --- Verify ---
+$loaderFile = rtrim($joomlaDir, '/') . '/libraries/loader.php';
+
+if (file_exists($loaderFile)) {
+    echo "  \033[32m✓ joomla-cms source ready (no composer install needed)\033[0m" . PHP_EOL;
+    exit(0);
+}
+
+echo "  \033[31m✗ joomla-cms clone appears incomplete — missing libraries/loader.php\033[0m" . PHP_EOL;
+exit(1);


### PR DESCRIPTION
## Summary

Second of three migrations from #7. Adds `cwm-joomla-cms-deps` binary + `scripts/joomla-cms-deps.php` — generic version of Proclaim's `build/joomla-cms-deps.php` that clones the joomla-cms source tree for unit tests to require directly.

| Resolution order | Path | Version |
| --- | --- | --- |
| 1 | `--path` / `-p` CLI arg | `--version` / `-v` CLI arg |
| 2 | `testing.joomlaCmsPath` in `cwm-build.config.json` | `testing.joomlaCmsVersion` in `cwm-build.config.json` |
| 3 | `tests.joomla_cms_path` in `build.properties` (legacy compat) | — |
| 4 | `<cwd-parent>/joomla-cms` | `5.4.3` (default) |

## Naming choice

The issue suggested `cwm-fetch-joomla-cms` but I went with **`cwm-joomla-cms-deps`** to match the existing `cwm-joomla-install` / `cwm-joomla-latest` naming pattern (and the script filename). Easy to flip during review if you prefer the issue's name.

## Implementation notes

- Uses array-form `proc_open` with inherited stdout/stderr — no shell, no metachar interpretation, and the user sees git's progress output during the clone.
- `cwm-build.config.json` is **optional**: running with no config falls through to `build.properties` and then the default. This preserves Proclaim's current post-install-cmd usage (`php build/joomla-cms-deps.php`) for ad-hoc/early-bootstrap scenarios.
- Help text follows the project's `WHAT IT DOES / PREREQUISITES / USAGE / OPTIONS / RELATED` shape from CLAUDE.md.

## Files

- `scripts/joomla-cms-deps.php` — new (parameterized port; ~210 lines including help)
- `bin/cwm-joomla-cms-deps` — new (thin shim, no config requirement)
- `composer.json` — registers `bin/cwm-joomla-cms-deps`
- `README.md` — added to CLI tools list
- `CHANGELOG.md` — entry under `[Unreleased]`

## Out of scope

- `build-assets.js` template parameterization — third PR (issue #7 third bullet)
- Proclaim-side migration (delete `build/joomla-cms-deps.php`, change post-install-cmd to call the new binary) — separate Proclaim PR

## Test plan

- [x] `php -l scripts/joomla-cms-deps.php` + `bash -n bin/cwm-joomla-cms-deps` — syntax check
- [x] `composer test` — full PHPUnit suite (40/40, 100 assertions)
- [x] Smoke tests on PHP 8.4: defaults, `cwm-build.config.json` override, CLI override, legacy `build.properties` fallback, `--help`, unrecognized arg → all behave correctly. No PHP 8.4 deprecations.
- [x] `git archive` dist verification — `bin/cwm-joomla-cms-deps` + `scripts/joomla-cms-deps.php` included
- [ ] Live clone test (no existing `joomla-cms` sibling) — picks up tag 5.4.3 cleanly

Refs #7. Independent of #9 (cwm-article migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)