### PR TITLE
feat(build-assets): add parameterized build-assets.js template (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `templates/build-assets.js` — generic version of Proclaim's
+  `build/build-assets.js` that copies images, mirrors a manually-managed
+  vendor source tree, and cherry-picks files/dirs out of npm packages in
+  `node_modules/`. Driven by a new `assets:` block in
+  `cwm-build.config.json`; supports CSS minification (`minifyCss: true`),
+  pre-clean of a destination subdir (`cleanDest`), and filename glob
+  filters on directory copies (`match: "*.umd.js"`). Schema paths are
+  source-tree paths so adopting this template doesn't require manifest
+  changes — the `<media folder=…>` element keeps controlling install-time
+  destination as before. Wire from `package.json` `build:assets`.
+  Reported in #7.
+
 - `cwm-joomla-cms-deps` binary + `scripts/joomla-cms-deps.php` — generic
   version of the Proclaim-side `build/joomla-cms-deps.php` that clones
   `joomla-cms` source for unit tests to require directly. New optional
@@ -32,7 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   binary is for CWM-family releases. Wire into release step 8 by setting
   `announcement.command: "cwm-article"` in `cwm-build.config.json`. Reported
   in #7.
-
 - `cwm-release`: pre-flight steps before the version bump now (a) `git fetch
   origin --prune --tags`, (b) `git pull --ff-only origin <release-branch>` and
   abort with guidance if local has diverged, (c) `git submodule update --init

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Across `Proclaim`, `lib_cwmscripture`, `CWMScriptureLinks`, and `plg_task_cwmscr
 | **Scripts** | Generic 8-step release pipeline, multi-manifest version bumper, config syncer | `scripts/` |
 | **PHP library** | `ProjectConfig`, `ManifestReader`, `PackageBuilder`, `ArsPublisher`, `Bumper` | `src/` (PSR-4 `CWM\BuildTools\`) |
 | **Reusable GH Actions** | `joomla-package-ci.yml`, `joomla-library-ci.yml` (called via `workflow_call`) | `.github/workflows/` |
-| **Synced config templates** | `.gitignore` block, `.editorconfig`, `.php-cs-fixer.base.php`, `phpunit.xml` boilerplate, `eslint.config.base.mjs`, `rollup.config.js`, `build-css.js`, `vendor-check.js`, `vendor-update.js`, `versions.json.tmpl` | `templates/` |
+| **Synced config templates** | `.gitignore` block, `.editorconfig`, `.php-cs-fixer.base.php`, `phpunit.xml` boilerplate, `eslint.config.base.mjs`, `rollup.config.js`, `build-css.js`, `build-assets.js`, `vendor-check.js`, `vendor-update.js`, `versions.json.tmpl` | `templates/` |
 
 ## Distribution
 

--- a/examples/package/cwm-build.config.json
+++ b/examples/package/cwm-build.config.json
@@ -36,5 +36,36 @@
     "announcement": {
         "command": "cwm-article",
         "bulletsDir": "build"
+    },
+    "_assets_comment": "Paths in the assets block are SOURCE-TREE paths, not install-time paths. They should match what the project's existing build/build-assets.js wrote to before adopting this template — typically media/images and media/vendor/<pkg> at the project root. The manifest's <media folder=...> element controls where these end up at install time.",
+    "assets": {
+        "images":            { "from": "build/media_source/images", "to": "media/images" },
+        "vendorMediaSource": { "from": "build/media_source/vendor", "to": "media/vendor" },
+        "vendorOutputDir":   "media/vendor",
+        "packages": [
+            {
+                "name": "chart.js",
+                "files": [
+                    { "from": "dist/chart.umd.min.js", "to": "chart.js/chart.umd.min.js" }
+                ]
+            },
+            {
+                "name": "@fancyapps/ui",
+                "cleanDest": "fancybox",
+                "files": [
+                    { "from": "dist/fancybox/fancybox.umd.js", "to": "fancybox/fancybox.umd.js" },
+                    { "from": "dist/fancybox/fancybox.css",    "to": "fancybox/fancybox.css", "minifyCss": true }
+                ],
+                "dirs": [
+                    { "from": "dist/fancybox/l10n", "to": "fancybox/l10n", "match": "*.umd.js" }
+                ]
+            },
+            {
+                "name": "sortablejs",
+                "files": [
+                    { "from": "Sortable.min.js", "to": "sortable/Sortable.min.js" }
+                ]
+            }
+        ]
     }
 }

--- a/templates/build-assets.js
+++ b/templates/build-assets.js
@@ -1,0 +1,302 @@
+"use strict";
+
+/**
+ * Shared asset-copy script for CWM Joomla extensions.
+ *
+ * Lifted from a copy in Proclaim — only the package list and output dirs
+ * differed. Now parameterized via the `assets` block of cwm-build.config.json.
+ *
+ * Operations (each section optional):
+ *   1. Copy a source images directory into the project's media tree.
+ *   2. Mirror manually-managed vendor subdirectories that live outside
+ *      node_modules (e.g. an upstream lib not on npm).
+ *   3. For each npm package, cherry-pick specific files and directories
+ *      out of node_modules — with optional CSS minification, optional
+ *      pre-clean, and optional filename glob filter on directory copies.
+ *
+ * Usage from a consuming project's package.json:
+ *   "build:assets": "node vendor/cwm/build-tools/templates/build-assets.js"
+ *
+ * Config block (`cwm-build.config.json`):
+ *   "assets": {
+ *       "images":             { "from": "build/media_source/images", "to": "media/myext/images" },
+ *       "vendorMediaSource":  { "from": "build/media_source/vendor", "to": "media/myext/vendor" },
+ *       "vendorOutputDir":    "media/myext/vendor",
+ *       "packages": [
+ *           {
+ *               "name": "chart.js",
+ *               "files": [
+ *                   { "from": "dist/chart.umd.min.js", "to": "chart.js/chart.umd.min.js" }
+ *               ]
+ *           },
+ *           {
+ *               "name": "@fancyapps/ui",
+ *               "cleanDest": "fancybox",
+ *               "files": [
+ *                   { "from": "dist/fancybox/fancybox.umd.js", "to": "fancybox/fancybox.umd.js" },
+ *                   { "from": "dist/fancybox/fancybox.css",    "to": "fancybox/fancybox.css", "minifyCss": true }
+ *               ],
+ *               "dirs": [
+ *                   { "from": "dist/fancybox/l10n", "to": "fancybox/l10n", "match": "*.umd.js" }
+ *               ]
+ *           }
+ *       ]
+ *   }
+ *
+ * Path conventions:
+ *   - `images.from` / `images.to`            relative to cwd
+ *   - `vendorMediaSource.from` / `to`        relative to cwd
+ *   - `vendorOutputDir`                      relative to cwd
+ *   - `packages[i].files[j].from`            relative to node_modules/<package.name>/
+ *   - `packages[i].files[j].to`              relative to vendorOutputDir
+ *   - `packages[i].dirs[j].from` / `to`      same convention
+ *   - `packages[i].cleanDest`                relative to vendorOutputDir
+ *
+ * Optional fields:
+ *   - `minifyCss`   on a file entry  — also writes a `.min.css` sibling via csso
+ *   - `match`       on a dir entry   — `*.ext` glob restricting which files copy
+ *   - `cleanDest`   on a package     — wipes vendorOutputDir/<cleanDest> first
+ *
+ * `csso` is required from the consumer's node_modules (consumer adds it to
+ * devDependencies — same posture as build-css.js).
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+const CONFIG_PATH = process.env.CWM_BUILD_CONFIG
+    ? path.resolve(process.cwd(), process.env.CWM_BUILD_CONFIG)
+    : path.resolve(process.cwd(), 'cwm-build.config.json');
+
+if (!fs.existsSync(CONFIG_PATH)) {
+    console.error(`Error: ${CONFIG_PATH} not found.`);
+    console.error('Run from the project root, or set CWM_BUILD_CONFIG to the config path.');
+    process.exit(1);
+}
+
+let config;
+
+try {
+    config = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+} catch (err) {
+    console.error(`Error: ${CONFIG_PATH} is not valid JSON: ${err.message}`);
+    process.exit(1);
+}
+
+const assets = config.assets;
+
+if (!assets) {
+    console.error('Error: cwm-build.config.json has no `assets` block. Nothing to do.');
+    process.exit(1);
+}
+
+const cwd          = process.cwd();
+const nodeModules  = path.resolve(cwd, 'node_modules');
+
+// --- Helpers ------------------------------------------------------------
+
+/**
+ * Recursively copy a directory. Mirrors Proclaim's existing behavior:
+ * creates the destination if missing, walks every entry, recurses on subdirs.
+ *
+ * @param {string} src  Absolute source directory.
+ * @param {string} dest Absolute destination directory.
+ * @param {{match?: RegExp}} [opts]  When `match` is set, only files whose
+ *                                   basename tests true against the regex
+ *                                   are copied (subdirectories still recurse).
+ */
+function copyDir(src, dest, opts = {}) {
+    if (!fs.existsSync(dest)) {
+        fs.mkdirSync(dest, { recursive: true });
+    }
+
+    const entries = fs.readdirSync(src, { withFileTypes: true });
+
+    entries.forEach(entry => {
+        const srcPath  = path.join(src, entry.name);
+        const destPath = path.join(dest, entry.name);
+
+        if (entry.isDirectory()) {
+            copyDir(srcPath, destPath, opts);
+            return;
+        }
+
+        if (opts.match && !opts.match.test(entry.name)) {
+            return;
+        }
+
+        fs.copyFileSync(srcPath, destPath);
+    });
+}
+
+/**
+ * Copy a single file, creating parent directories as needed.
+ */
+function copyFile(src, dest) {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+}
+
+/**
+ * Recursively remove a directory and all its contents.
+ * No-op when the directory doesn't exist.
+ */
+function cleanDir(dir) {
+    if (fs.existsSync(dir)) {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+}
+
+/**
+ * Copy a CSS file and write a `.min.css` sibling alongside it via csso.
+ * `csso` is loaded lazily so projects without CSS minification don't need it.
+ */
+let cssoCache = null;
+
+function copyCssWithMin(src, dest) {
+    if (!cssoCache) {
+        try {
+            cssoCache = require('csso');
+        } catch (err) {
+            console.error('Error: `csso` is required for `minifyCss: true` entries. Add it to devDependencies.');
+            process.exit(1);
+        }
+    }
+
+    copyFile(src, dest);
+
+    const css     = fs.readFileSync(src, 'utf8');
+    const minDest = dest.replace(/\.css$/, '.min.css');
+
+    fs.writeFileSync(minDest, cssoCache.minify(css).css);
+}
+
+/**
+ * Convert a `*.ext` glob to a RegExp that tests basenames.
+ * Only the trailing-`*` form is supported — anything fancier should be
+ * handled in JavaScript by the consumer's own build script.
+ */
+function compileMatch(glob) {
+    if (!glob) {
+        return null;
+    }
+
+    const escaped = glob
+        .replace(/[.+?^${}()|[\]\\]/g, '\\$&')   // escape regex meta
+        .replace(/\*/g, '.*');                    // expand glob *
+
+    return new RegExp(`^${escaped}$`);
+}
+
+// --- Operations ---------------------------------------------------------
+
+// 1. Images
+if (assets.images && assets.images.from && assets.images.to) {
+    const fromAbs = path.resolve(cwd, assets.images.from);
+    const toAbs   = path.resolve(cwd, assets.images.to);
+
+    if (fs.existsSync(fromAbs)) {
+        console.log(`Copying images from ${assets.images.from} to ${assets.images.to}...`);
+        copyDir(fromAbs, toAbs);
+    } else {
+        console.log(`Skipping images: source dir ${assets.images.from} not found.`);
+    }
+}
+
+// 2. Manually-managed vendor mirror (auto-discover subdirs)
+if (assets.vendorMediaSource && assets.vendorMediaSource.from && assets.vendorMediaSource.to) {
+    const fromAbs = path.resolve(cwd, assets.vendorMediaSource.from);
+    const toAbs   = path.resolve(cwd, assets.vendorMediaSource.to);
+
+    if (fs.existsSync(fromAbs)) {
+        console.log(`Copying media_source vendor from ${assets.vendorMediaSource.from}...`);
+
+        const subEntries = fs.readdirSync(fromAbs, { withFileTypes: true });
+
+        subEntries.forEach(entry => {
+            if (!entry.isDirectory()) {
+                return;
+            }
+
+            copyDir(
+                path.join(fromAbs, entry.name),
+                path.join(toAbs, entry.name)
+            );
+            console.log(`  Copied vendor/${entry.name} (from media_source)`);
+        });
+    }
+}
+
+// 3. npm package cherry-pick
+const packages       = Array.isArray(assets.packages) ? assets.packages : [];
+const vendorOutDirCfg = assets.vendorOutputDir;
+
+if (packages.length > 0) {
+    if (!vendorOutDirCfg) {
+        console.error('Error: `assets.packages` is set but `assets.vendorOutputDir` is missing.');
+        process.exit(1);
+    }
+
+    if (!fs.existsSync(nodeModules)) {
+        console.error(`Error: ${nodeModules} not found. Run 'npm install' before build:assets.`);
+        process.exit(1);
+    }
+}
+
+const vendorOutAbs = vendorOutDirCfg ? path.resolve(cwd, vendorOutDirCfg) : null;
+
+console.log('Copying vendor libraries from node_modules...');
+
+packages.forEach(pkg => {
+    if (!pkg.name) {
+        console.error('Error: every entry in `assets.packages` must have a `name`.');
+        process.exit(1);
+    }
+
+    const pkgRoot = path.join(nodeModules, pkg.name);
+
+    if (!fs.existsSync(pkgRoot)) {
+        console.error(`Error: ${pkg.name} not found in node_modules. Run 'npm install'.`);
+        process.exit(1);
+    }
+
+    if (pkg.cleanDest) {
+        cleanDir(path.join(vendorOutAbs, pkg.cleanDest));
+    }
+
+    (pkg.files || []).forEach(file => {
+        if (!file.from || !file.to) {
+            console.error(`Error: ${pkg.name}: every files[] entry needs both \`from\` and \`to\`.`);
+            process.exit(1);
+        }
+
+        const src  = path.join(pkgRoot, file.from);
+        const dest = path.join(vendorOutAbs, file.to);
+
+        if (file.minifyCss) {
+            copyCssWithMin(src, dest);
+        } else {
+            copyFile(src, dest);
+        }
+    });
+
+    (pkg.dirs || []).forEach(dir => {
+        if (!dir.from || !dir.to) {
+            console.error(`Error: ${pkg.name}: every dirs[] entry needs both \`from\` and \`to\`.`);
+            process.exit(1);
+        }
+
+        const src  = path.join(pkgRoot, dir.from);
+        const dest = path.join(vendorOutAbs, dir.to);
+
+        if (!fs.existsSync(src)) {
+            return;
+        }
+
+        copyDir(src, dest, { match: compileMatch(dir.match) });
+    });
+
+    console.log(`  Copied ${pkg.name}`);
+});
+
+console.log('Asset copy complete.');


### PR DESCRIPTION
## Summary

Third and final migration from #7. Adds `templates/build-assets.js` — generic version of Proclaim's `build/build-assets.js` driven by a new `assets:` block in `cwm-build.config.json`.

## Schema

```json
"assets": {
    "images":            { "from": "build/media_source/images", "to": "media/images" },
    "vendorMediaSource": { "from": "build/media_source/vendor", "to": "media/vendor" },
    "vendorOutputDir":   "media/vendor",
    "packages": [
        { "name": "chart.js",
          "files": [ { "from": "dist/chart.umd.min.js", "to": "chart.js/chart.umd.min.js" } ] },
        { "name": "@fancyapps/ui",
          "cleanDest": "fancybox",
          "files": [
              { "from": "dist/fancybox/fancybox.umd.js", "to": "fancybox/fancybox.umd.js" },
              { "from": "dist/fancybox/fancybox.css",    "to": "fancybox/fancybox.css", "minifyCss": true }
          ],
          "dirs": [ { "from": "dist/fancybox/l10n", "to": "fancybox/l10n", "match": "*.umd.js" } ] },
        { "name": "sortablejs",
          "files": [ { "from": "Sortable.min.js", "to": "sortable/Sortable.min.js" } ] }
    ]
}
```

Each section is optional. Path conventions: `images.from/to` and `vendorMediaSource.from/to` are relative to cwd; `packages[i].files[j].from` is relative to `node_modules/<package.name>/`; `packages[i].files[j].to` is relative to `vendorOutputDir`.

## Behavior-preserving — no manifest changes required

Schema paths are **source-tree** paths (where the consumer's existing `build-assets.js` wrote to before adopting this template), not install-time paths. The manifest's `<media folder="...">` element keeps controlling install-time destination as it does today. Adopting the template means: same input → same output, just driven by config — no `proclaim.xml` change needed.

The example config uses `media/images` and `media/vendor` (matching Proclaim's existing layout) rather than the install-style `media/proclaim/images` to make this explicit. There's a comment in the example calling out the convention.

## Implementation notes

- `csso` is loaded lazily — only required when a file entry sets `minifyCss: true`. Resolved from the consumer's `node_modules` via Node's walk-up resolution (template lives at `vendor/cwm/build-tools/templates/` so the walk reaches the consumer's `node_modules/csso`).
- `match` is a tiny glob compiler — only `*.ext` patterns supported (sufficient for "filter to UMD files in a l10n dir"). Anything fancier can stay in a hand-written script.
- Errors are loud and early: missing `node_modules`, missing package, missing config field, malformed `files[]`/`dirs[]` entry — all produce a clear stderr message and exit 1.

## Files

- `templates/build-assets.js` — new (~300 lines including help/comments)
- `examples/package/cwm-build.config.json` — added `assets:` block + a `_assets_comment` field documenting the source-tree-path convention
- `CHANGELOG.md` — entry under `[Unreleased]`
- `README.md` — added `build-assets.js` to the templates list

## Out of scope

- Proclaim's `package.json` change (`"build:assets": "node vendor/cwm/build-tools/templates/build-assets.js"`) + addition of the `assets:` block to its `cwm-build.config.json` + deletion of `build/build-assets.js` — all in a separate Proclaim PR
- The other two CWM extensions (lib_cwmscripture, CWMScriptureLinks) don't currently have a `build-assets.js`, so no migration there

## Test plan

- [x] `node --check templates/build-assets.js` — syntax check
- [x] `composer test` — full PHPUnit suite (40/40, 100 assertions)
- [x] Smoke test against a fixture node_modules tree mirroring Proclaim's exact ops:
  - images dir → copied
  - manually-managed vendor mirror → copied
  - chart.js: only `chart.umd.min.js` (chart.esm.js NOT copied — verified)
  - fancybox: cleanDest wipes stale files (STALE.js removed on re-run); CSS minified to `.min.css`; l10n filter keeps only `*.umd.js` and excludes `.json`
  - intl-tel-input: CSS + JS + img dir all copied
  - sortablejs: single file copied
- [x] JSON validation of the updated example config
- [x] `git archive` dist verification — `templates/build-assets.js` and updated example shipped
- [ ] Live test inside Proclaim by switching its `package.json` `build:assets` to call the template (separate Proclaim PR)

Refs #7. Independent of #9 and #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)