### PR TITLE
feat(build): add cwm-build binary covering lib_cwmscripture's shape — PR B of #5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `cwm-build` binary + `scripts/build.php` + `src/Build/PackageBuilder` +
+  `src/Build/BuildConfig` — generic Joomla extension zip builder driven by a
+  `build:` block in `cwm-build.config.json`. Phase 1 covers the
+  lib_cwmscripture build shape: read manifest version, optionally gate on
+  presence of `*.min.{js,css}` siblings (`preBuild.mode: "ensure-minified"`),
+  walk one or more source directories with a per-source zip-path prefix, apply
+  loose `str_contains` excludes. CLI flags `-v`/`--verbose`, `--version <ver>`
+  override, `--help`. New schema fields: `build.outputDir`, `outputName`
+  (supports `{version}`), `manifest`, `scriptFile`, `sources[]`, `excludes`,
+  `preBuild`. Coexists with the existing `build.command` / `build.outputGlob`
+  fields used by `cwm-release` — consumers migrate by setting
+  `build.command: "cwm-build"`. Strict-mode filtering, vendor pruning, auto-
+  run pre-build, and the interactive 3-way version prompt land in subsequent
+  PRs (still part of #5). 8 new unit tests / 39 assertions covering the
+  end-to-end build, version override, gate pass/fail, and config validation.
+
 - `CWM\BuildTools\Build\Prompt` — extracted the interactive `ask()` helper
   (with the fixed countdown ANSI redraw — the `\r\033[K` clear-to-EOL that
   prevents stray "0" artifacts when "(10s):" is replaced by "(9s):") from

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Across `Proclaim`, `lib_cwmscripture`, `CWMScriptureLinks`, and `plg_task_cwmscr
 
 | Surface | What | Where |
 |---|---|---|
-| **CLI tools** | `cwm-release`, `cwm-bump`, `cwm-package`, `cwm-sync-configs`, `cwm-sync-languages`, `cwm-ars-publish`, `cwm-changelog`, `cwm-article`, `cwm-init`, `cwm-setup`, `cwm-link`, `cwm-link-check`, `cwm-clean`, `cwm-verify`, `cwm-joomla-install`, `cwm-joomla-latest`, `cwm-joomla-cms-deps` | `bin/` |
+| **CLI tools** | `cwm-release`, `cwm-bump`, `cwm-build`, `cwm-package`, `cwm-sync-configs`, `cwm-sync-languages`, `cwm-ars-publish`, `cwm-changelog`, `cwm-article`, `cwm-init`, `cwm-setup`, `cwm-link`, `cwm-link-check`, `cwm-clean`, `cwm-verify`, `cwm-joomla-install`, `cwm-joomla-latest`, `cwm-joomla-cms-deps` | `bin/` |
 | **Scripts** | Generic 8-step release pipeline, multi-manifest version bumper, config syncer | `scripts/` |
 | **PHP library** | `ProjectConfig`, `ManifestReader`, `PackageBuilder`, `ArsPublisher`, `Bumper` | `src/` (PSR-4 `CWM\BuildTools\`) |
 | **Reusable GH Actions** | `joomla-package-ci.yml`, `joomla-library-ci.yml` (called via `workflow_call`) | `.github/workflows/` |

--- a/bin/cwm-build
+++ b/bin/cwm-build
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# cwm-build — build an installable Joomla extension zip from
+# cwm-build.config.json.
+#
+# Reads the `build:` block of cwm-build.config.json in the project root and
+# produces an installable zip under build.outputDir. See `cwm-build --help`
+# for full usage.
+#
+# Usage from a consuming project:
+#   composer cwm-build                       # full build
+#   composer cwm-build -- -v                 # verbose
+#   composer cwm-build -- --version 1.2.3    # override version
+#
+set -euo pipefail
+
+PROJECT_ROOT="$(pwd)"
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ ! -f "${PROJECT_ROOT}/cwm-build.config.json" ]; then
+    echo "Error: cwm-build.config.json not found in $PROJECT_ROOT"
+    echo "Run 'cwm-init' to scaffold one, or see"
+    echo "  ${TOOLS_DIR}/examples/ for reference configs."
+    exit 1
+fi
+
+exec php "${TOOLS_DIR}/scripts/build.php" "$@"

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "bin": [
         "bin/cwm-release",
         "bin/cwm-bump",
+        "bin/cwm-build",
         "bin/cwm-package",
         "bin/cwm-sync-configs",
         "bin/cwm-sync-languages",

--- a/examples/library/cwm-build.config.json
+++ b/examples/library/cwm-build.config.json
@@ -10,8 +10,24 @@
         ]
     },
     "build": {
-        "command": "npm run build && php build/build-package.php",
-        "outputGlob": "build/dist/lib_cwmscripture-*.zip"
+        "_command_comment": "command + outputGlob are read by cwm-release. command = 'cwm-build' delegates to the generic builder, which reads outputDir/outputName/manifest/scriptFile/sources/excludes/preBuild from this same block. cwm-release then matches outputGlob to find the produced artifact.",
+        "command": "cwm-build",
+        "outputGlob": "build/dist/lib_cwmscripture-*.zip",
+        "outputDir": "build/dist",
+        "outputName": "lib_cwmscripture-{version}.zip",
+        "manifest": "cwmscripture.xml",
+        "scriptFile": "script.php",
+        "sources": [
+            { "from": "src",                    "to": "lib_cwmscripture/src" },
+            { "from": "sql",                    "to": "lib_cwmscripture/sql" },
+            { "from": "language",               "to": "lib_cwmscripture/language" },
+            { "from": "media/lib_cwmscripture", "to": "media/lib_cwmscripture" }
+        ],
+        "excludes": [".git", ".DS_Store", ".idea", "node_modules", ".php-cs-fixer.cache"],
+        "preBuild": {
+            "mode": "ensure-minified",
+            "dirs": ["media/lib_cwmscripture/js", "media/lib_cwmscripture/css"]
+        }
     },
     "ars": {
         "endpoint": "https://www.christianwebministries.org",

--- a/scripts/build.php
+++ b/scripts/build.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * cwm-build — generic extension zip builder.
+ *
+ * Reads `build:` block of cwm-build.config.json from the current working
+ * directory and produces an installable Joomla extension zip per the
+ * declared sources, excludes, and optional pre-build gate.
+ *
+ * Phase 1 — covers lib_cwmscripture's build shape (loose `str_contains`
+ * exclude matching, optional `ensure-minified` gate, per-source zip
+ * prefix). Subsequent PRs add Proclaim's strict-mode filtering, vendor
+ * pruning, auto-run pre-build, and the 3-way version prompt.
+ */
+
+require_once __DIR__ . '/../src/Build/BuildConfig.php';
+require_once __DIR__ . '/../src/Build/ManifestReader.php';
+require_once __DIR__ . '/../src/Build/PackageBuilder.php';
+
+use CWM\BuildTools\Build\BuildConfig;
+use CWM\BuildTools\Build\PackageBuilder;
+
+$projectRoot = getcwd() ?: '.';
+$args        = $argv;
+array_shift($args);
+
+if (in_array('--help', $args, true) || in_array('-h', $args, true)) {
+    echo <<<HELP
+cwm-build — build an installable extension zip from cwm-build.config.json.
+
+WHAT IT DOES
+  Reads the `build:` block of cwm-build.config.json (in the current working
+  directory), runs the optional pre-build gate, then walks every configured
+  source directory into a zip under build.outputDir. Manifest version is
+  read from <version> in build.manifest unless --version overrides.
+
+PREREQUISITES
+  - cwm-build.config.json with a `build:` block in the project root
+  - The manifest XML referenced by build.manifest
+
+USAGE
+  cwm-build                       # full build using config defaults
+  cwm-build -v                    # verbose: print every file added
+  cwm-build --version 1.2.3       # override version (skip manifest read)
+  cwm-build --help
+
+OPTIONS
+  -v, --verbose          Print every file as it's added to the zip.
+      --version <ver>    Use this version instead of the manifest's <version>.
+  -h, --help             Show this help.
+
+EXIT CODE
+  0 on success.
+  1 on missing config, invalid config, missing manifest, or pre-build gate
+  failure (e.g. missing `.min.js` siblings under `ensure-minified`).
+
+RELATED
+  cwm-package          # multi-extension package wrapper (planned for #5 PR D)
+  cwm-bump             # version bump across manifests
+  cwm-release          # full release pipeline; runs build.command from config
+
+HELP;
+    exit(0);
+}
+
+$verbose         = in_array('-v', $args, true) || in_array('--verbose', $args, true);
+$versionOverride = null;
+
+for ($i = 0, $n = count($args); $i < $n; $i++) {
+    if ($args[$i] === '--version' && isset($args[$i + 1])) {
+        $versionOverride = $args[++$i];
+        continue;
+    }
+
+    if ($args[$i] === '-v' || $args[$i] === '--verbose') {
+        continue;
+    }
+
+    fwrite(STDERR, "Error: unrecognized argument '{$args[$i]}'. Run with --help for usage.\n");
+    exit(1);
+}
+
+$configFile = $projectRoot . '/cwm-build.config.json';
+
+if (!is_file($configFile)) {
+    fwrite(STDERR, "Error: cwm-build.config.json not found in $projectRoot\n");
+    fwrite(STDERR, "Run 'cwm-init' to scaffold one, or run from your project root.\n");
+    exit(1);
+}
+
+$rawConfig = json_decode((string) file_get_contents($configFile), true);
+
+if (!is_array($rawConfig)) {
+    fwrite(STDERR, "Error: cwm-build.config.json is not valid JSON\n");
+    exit(1);
+}
+
+if (!isset($rawConfig['build']) || !is_array($rawConfig['build'])) {
+    fwrite(STDERR, "Error: cwm-build.config.json has no `build` block.\n");
+    fwrite(STDERR, "  See examples/library/cwm-build.config.json for the shape.\n");
+    exit(1);
+}
+
+try {
+    $config = BuildConfig::fromArray($rawConfig['build']);
+} catch (\InvalidArgumentException $e) {
+    fwrite(STDERR, "Error: invalid build config — " . $e->getMessage() . "\n");
+    exit(1);
+}
+
+$builder = new PackageBuilder($config, $projectRoot, $verbose);
+
+try {
+    $builder->build($versionOverride);
+} catch (\Throwable $e) {
+    fwrite(STDERR, "Error: build failed — " . $e->getMessage() . "\n");
+    exit(1);
+}

--- a/src/Build/BuildConfig.php
+++ b/src/Build/BuildConfig.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Build;
+
+/**
+ * Parsed `build:` block of `cwm-build.config.json`.
+ *
+ * Captures only the fields needed by the lib_cwmscripture-shape build flow
+ * (the simplest of the three consumer shapes the consolidation targets — see
+ * issue #5). Subsequent PRs add fields for Proclaim's strict-mode filtering,
+ * vendor pruning, auto-run pre-build, and interactive version prompting.
+ */
+final class BuildConfig
+{
+    /**
+     * @param string                                       $outputDir       Absolute or project-relative directory for the built zip.
+     * @param string                                       $outputName      Output filename pattern; supports `{version}` substitution.
+     * @param string                                       $manifest        Project-relative path to the manifest XML; version is read from its <version> element.
+     * @param string|null                                  $scriptFile      Optional install scriptfile, added at zip root if present.
+     * @param list<array{from: string, to: string}>        $sources         Source directories with their zip-path prefix.
+     * @param list<string>                                 $excludes        Path substrings to skip (str_contains semantics).
+     * @param array{mode: string, dirs?: list<string>}|null $preBuild       Optional pre-build gate config.
+     */
+    public function __construct(
+        public readonly string $outputDir,
+        public readonly string $outputName,
+        public readonly string $manifest,
+        public readonly ?string $scriptFile,
+        public readonly array $sources,
+        public readonly array $excludes,
+        public readonly ?array $preBuild,
+    ) {
+    }
+
+    /**
+     * Build a BuildConfig from the raw `build:` block of cwm-build.config.json.
+     *
+     * @param  array<string, mixed> $cfg
+     * @throws \InvalidArgumentException When required fields are missing or malformed.
+     */
+    public static function fromArray(array $cfg): self
+    {
+        foreach (['outputDir', 'outputName', 'manifest'] as $required) {
+            if (empty($cfg[$required]) || !is_string($cfg[$required])) {
+                throw new \InvalidArgumentException("build.$required is required and must be a string");
+            }
+        }
+
+        $rawSources = $cfg['sources'] ?? [];
+
+        if (!is_array($rawSources) || $rawSources === []) {
+            throw new \InvalidArgumentException('build.sources is required and must be a non-empty array');
+        }
+
+        $sources = [];
+
+        foreach ($rawSources as $i => $src) {
+            if (!is_array($src) || empty($src['from']) || !isset($src['to'])) {
+                throw new \InvalidArgumentException("build.sources[$i] must have non-empty 'from' and 'to' keys");
+            }
+
+            $sources[] = ['from' => (string) $src['from'], 'to' => (string) $src['to']];
+        }
+
+        $rawExcludes = $cfg['excludes'] ?? [];
+
+        if (!is_array($rawExcludes)) {
+            throw new \InvalidArgumentException('build.excludes must be an array of strings');
+        }
+
+        $excludes = array_values(array_map('strval', $rawExcludes));
+
+        $preBuild = null;
+
+        if (isset($cfg['preBuild'])) {
+            if (!is_array($cfg['preBuild']) || empty($cfg['preBuild']['mode'])) {
+                throw new \InvalidArgumentException('build.preBuild must be an object with a non-empty `mode`');
+            }
+
+            $mode = (string) $cfg['preBuild']['mode'];
+
+            if ($mode !== 'ensure-minified') {
+                throw new \InvalidArgumentException(
+                    "build.preBuild.mode must be 'ensure-minified' (got '$mode'). " .
+                    "Other modes (e.g. 'run', 'gate') are reserved for future PRs."
+                );
+            }
+
+            $dirs = $cfg['preBuild']['dirs'] ?? [];
+
+            if (!is_array($dirs)) {
+                throw new \InvalidArgumentException('build.preBuild.dirs must be an array of strings');
+            }
+
+            $preBuild = [
+                'mode' => $mode,
+                'dirs' => array_values(array_map('strval', $dirs)),
+            ];
+        }
+
+        return new self(
+            outputDir:  (string) $cfg['outputDir'],
+            outputName: (string) $cfg['outputName'],
+            manifest:   (string) $cfg['manifest'],
+            scriptFile: isset($cfg['scriptFile']) && is_string($cfg['scriptFile']) ? $cfg['scriptFile'] : null,
+            sources:    $sources,
+            excludes:   $excludes,
+            preBuild:   $preBuild,
+        );
+    }
+}

--- a/src/Build/PackageBuilder.php
+++ b/src/Build/PackageBuilder.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Build;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ZipArchive;
+
+/**
+ * Builds an installable extension zip per a {@see BuildConfig}.
+ *
+ * Phase 1 — covers the lib_cwmscripture build shape: read manifest version,
+ * optionally gate on minified asset presence, then walk one or more source
+ * directories into the zip with a configurable per-source prefix. Excludes
+ * are matched as path substrings (`str_contains`), the loose mode used by
+ * lib_cwmscripture and CWMScriptureLinks. Strict-mode (Proclaim's 4-mode
+ * exclude + vendor prune + root-ext include) lands in a follow-up PR.
+ *
+ * Path semantics:
+ *   - `BuildConfig::manifest` and `BuildConfig::scriptFile` are
+ *     project-relative; their `basename()` becomes the in-zip path.
+ *   - `BuildConfig::sources[i].from` is project-relative; every file under
+ *     it gets prefixed with `sources[i].to` inside the zip.
+ *   - `BuildConfig::outputDir` is project-relative.
+ *   - `outputName` accepts a literal `{version}` token — substituted with
+ *     the value read from the manifest (or `versionOverride` argument).
+ */
+final class PackageBuilder
+{
+    public function __construct(
+        private readonly BuildConfig $config,
+        private readonly string $projectRoot,
+        private readonly bool $verbose = false,
+    ) {
+        if (!is_dir($this->projectRoot)) {
+            throw new \InvalidArgumentException("Project root does not exist: $this->projectRoot");
+        }
+    }
+
+    /**
+     * Run the full build flow.
+     *
+     * @param  string|null $versionOverride  When non-null, used in place of the manifest's <version>. Useful for ad-hoc rebuilds.
+     * @return string                        Absolute path to the resulting zip.
+     */
+    public function build(?string $versionOverride = null): string
+    {
+        $manifestPath = $this->resolve($this->config->manifest);
+
+        if (!is_file($manifestPath)) {
+            throw new \RuntimeException("Manifest not found: $manifestPath");
+        }
+
+        $reader  = new ManifestReader($manifestPath);
+        $version = $versionOverride ?? $reader->version();
+
+        if ($this->config->preBuild !== null) {
+            $this->runPreBuild($this->config->preBuild);
+        }
+
+        $outputDir = $this->resolve($this->config->outputDir);
+
+        if (!is_dir($outputDir) && !mkdir($outputDir, 0o777, true) && !is_dir($outputDir)) {
+            throw new \RuntimeException("Could not create output directory: $outputDir");
+        }
+
+        $outputName = str_replace('{version}', $version, $this->config->outputName);
+        $outputPath = $outputDir . '/' . $outputName;
+
+        // Replace any prior build artifact at this exact path. Unlike the
+        // legacy lib_cwmscripture script, we don't wipe the entire dist dir
+        // (that's destructive to unrelated zips); leftover artifacts are
+        // gitignored anyway.
+        if (file_exists($outputPath)) {
+            unlink($outputPath);
+        }
+
+        echo "Building " . basename($outputPath) . " (v$version)\n";
+
+        $zip = new ZipArchive();
+
+        if ($zip->open($outputPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            throw new \RuntimeException("Could not create zip: $outputPath");
+        }
+
+        $manifestEntry = basename($this->config->manifest);
+        $zip->addFile($manifestPath, $manifestEntry);
+        $this->log("  + $manifestEntry");
+
+        if ($this->config->scriptFile !== null) {
+            $scriptAbs = $this->resolve($this->config->scriptFile);
+
+            if (is_file($scriptAbs)) {
+                $scriptEntry = basename($this->config->scriptFile);
+                $zip->addFile($scriptAbs, $scriptEntry);
+                $this->log("  + $scriptEntry");
+            }
+        }
+
+        foreach ($this->config->sources as $src) {
+            $this->addDirectory($zip, $this->resolve($src['from']), $src['to'], $this->config->excludes);
+        }
+
+        $fileCount = $zip->numFiles;
+        $zip->close();
+
+        $sizeKb = (int) round((int) filesize($outputPath) / 1024);
+        echo "\nPackage built: $outputPath\n";
+        echo "  Files: $fileCount\n";
+        echo "  Size:  {$sizeKb} KB\n";
+
+        return $outputPath;
+    }
+
+    /**
+     * Resolve a project-relative path against the project root.
+     */
+    private function resolve(string $path): string
+    {
+        if ($path === '') {
+            return $this->projectRoot;
+        }
+
+        // Already absolute — pass through.
+        if ($path[0] === '/' || (strlen($path) > 1 && $path[1] === ':')) {
+            return $path;
+        }
+
+        return rtrim($this->projectRoot, '/') . '/' . $path;
+    }
+
+    /**
+     * Run the configured pre-build gate.
+     *
+     * `ensure-minified` is the only mode currently supported. For each listed
+     * directory, every `<name>.<ext>` that isn't already a `.min.<ext>` must
+     * have a corresponding `<name>.min.<ext>` sibling, otherwise the build
+     * fails with a hint to run the project's build step.
+     *
+     * @param array{mode: string, dirs?: list<string>} $preBuild
+     */
+    private function runPreBuild(array $preBuild): void
+    {
+        if ($preBuild['mode'] !== 'ensure-minified') {
+            return;
+        }
+
+        $missing = [];
+
+        foreach ($preBuild['dirs'] ?? [] as $relDir) {
+            $absDir = $this->resolve($relDir);
+
+            if (!is_dir($absDir)) {
+                continue;
+            }
+
+            $entries = scandir($absDir) ?: [];
+
+            foreach ($entries as $entry) {
+                if ($entry === '.' || $entry === '..' || !is_file($absDir . '/' . $entry)) {
+                    continue;
+                }
+
+                if (!preg_match('/\.([a-z0-9]+)$/i', $entry, $m)) {
+                    continue;
+                }
+
+                $ext = $m[1];
+
+                // Already a minified version — skip.
+                if (str_ends_with($entry, '.min.' . $ext)) {
+                    continue;
+                }
+
+                $minEntry = substr($entry, 0, -strlen('.' . $ext)) . '.min.' . $ext;
+
+                if (!file_exists($absDir . '/' . $minEntry)) {
+                    $missing[] = $relDir . '/' . $minEntry;
+                }
+            }
+        }
+
+        if ($missing !== []) {
+            fwrite(STDERR, "Pre-build gate failed: missing minified assets:\n");
+
+            foreach ($missing as $m) {
+                fwrite(STDERR, "  - $m\n");
+            }
+
+            fwrite(STDERR, "\nRun the project's build step (typically `npm run build`) before packaging.\n");
+            exit(1);
+        }
+    }
+
+    /**
+     * Walk a source directory and add its files to the zip under $zipPrefix.
+     *
+     * @param list<string> $excludes
+     */
+    private function addDirectory(ZipArchive $zip, string $sourcePath, string $zipPrefix, array $excludes): void
+    {
+        if (!is_dir($sourcePath)) {
+            echo "  SKIP: $sourcePath (not found)\n";
+
+            return;
+        }
+
+        $sourceReal = realpath($sourcePath);
+
+        if ($sourceReal === false) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($sourcePath, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::LEAVES_ONLY
+        );
+
+        foreach ($iterator as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            $filePath     = $file->getRealPath();
+            $relativePath = substr($filePath, strlen($sourceReal) + 1);
+
+            if (self::matchesExclude($relativePath, $excludes)) {
+                continue;
+            }
+
+            $entryPath = $zipPrefix === '' ? $relativePath : rtrim($zipPrefix, '/') . '/' . $relativePath;
+
+            $zip->addFile($filePath, $entryPath);
+            $this->log("  + $entryPath");
+        }
+    }
+
+    /**
+     * @param list<string> $excludes
+     */
+    private static function matchesExclude(string $path, array $excludes): bool
+    {
+        foreach ($excludes as $pattern) {
+            if ($pattern !== '' && str_contains($path, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function log(string $line): void
+    {
+        if ($this->verbose) {
+            echo $line . "\n";
+        }
+    }
+}

--- a/tests/Build/PackageBuilderTest.php
+++ b/tests/Build/PackageBuilderTest.php
@@ -1,0 +1,322 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Build;
+
+use CWM\BuildTools\Build\BuildConfig;
+use CWM\BuildTools\Build\PackageBuilder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ZipArchive;
+
+/**
+ * End-to-end tests that build a real zip from a temp fixture project and
+ * assert its contents — the only meaningful coverage for a script whose
+ * job is producing a correct on-disk artifact.
+ */
+final class PackageBuilderTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/cwm-build-test-' . uniqid('', true);
+        mkdir($this->tmpDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->rrmdir($this->tmpDir);
+    }
+
+    #[Test]
+    public function buildsLibCwmscriptureShape(): void
+    {
+        $this->writeManifest('cwmscripture.xml', '1.2.0');
+        $this->writeFile('script.php', '<?php // install hook');
+        $this->writeFile('src/Service/Foo.php', '<?php // foo');
+        $this->writeFile('src/Service/Bar.php', '<?php // bar');
+        $this->writeFile('sql/install.mysql.utf8.sql', '-- DDL');
+        $this->writeFile('language/en-GB/en-GB.lib_cwmscripture.ini', '');
+        $this->writeFile('media/lib_cwmscripture/js/foo.js', 'console.log("foo");');
+        $this->writeFile('media/lib_cwmscripture/js/foo.min.js', 'console.log("foo")');
+        $this->writeFile('media/lib_cwmscripture/css/foo.css', '.foo{}');
+        $this->writeFile('media/lib_cwmscripture/css/foo.min.css', '.foo{}');
+        // Excluded entries — should NOT end up in zip.
+        $this->writeFile('src/.DS_Store', '');
+        $this->writeFile('src/node_modules/x/index.js', '');
+
+        $builder = new PackageBuilder($this->makeLibConfig(), $this->tmpDir);
+
+        $this->expectOutputRegex('/Building lib_cwmscripture-1\.2\.0\.zip \(v1\.2\.0\)/');
+
+        $zipPath = $builder->build();
+
+        $this->assertSame($this->tmpDir . '/build/dist/lib_cwmscripture-1.2.0.zip', $zipPath);
+        $this->assertFileExists($zipPath);
+
+        $entries = $this->zipEntries($zipPath);
+
+        $this->assertContains('cwmscripture.xml', $entries);
+        $this->assertContains('script.php', $entries);
+        $this->assertContains('lib_cwmscripture/src/Service/Foo.php', $entries);
+        $this->assertContains('lib_cwmscripture/src/Service/Bar.php', $entries);
+        $this->assertContains('lib_cwmscripture/sql/install.mysql.utf8.sql', $entries);
+        $this->assertContains('lib_cwmscripture/language/en-GB/en-GB.lib_cwmscripture.ini', $entries);
+        $this->assertContains('media/lib_cwmscripture/js/foo.js', $entries);
+        $this->assertContains('media/lib_cwmscripture/js/foo.min.js', $entries);
+
+        $this->assertNotContains('src/.DS_Store', $entries);
+        $this->assertNotContains('lib_cwmscripture/src/.DS_Store', $entries);
+        // node_modules anywhere in the path is excluded by the substring match.
+        foreach ($entries as $entry) {
+            $this->assertStringNotContainsString('node_modules', $entry);
+            $this->assertStringNotContainsString('.DS_Store', $entry);
+        }
+    }
+
+    #[Test]
+    public function omitsScriptFileWhenAbsent(): void
+    {
+        $this->writeManifest('cwmscripture.xml', '1.0.0');
+        $this->writeFile('src/Foo.php', '<?php');
+
+        $builder = new PackageBuilder($this->makeLibConfig(), $this->tmpDir);
+
+        $this->expectOutputRegex('/Building lib_cwmscripture-1\.0\.0\.zip/');
+
+        $zipPath = $builder->build();
+        $entries = $this->zipEntries($zipPath);
+
+        $this->assertNotContains('script.php', $entries);
+        $this->assertContains('cwmscripture.xml', $entries);
+    }
+
+    #[Test]
+    public function versionOverrideTakesPrecedenceOverManifest(): void
+    {
+        $this->writeManifest('cwmscripture.xml', '1.0.0');
+        $this->writeFile('src/Foo.php', '<?php');
+
+        $builder = new PackageBuilder($this->makeLibConfig(), $this->tmpDir);
+
+        $this->expectOutputRegex('/Building lib_cwmscripture-9\.9\.9\.zip \(v9\.9\.9\)/');
+
+        $zipPath = $builder->build('9.9.9');
+
+        $this->assertSame($this->tmpDir . '/build/dist/lib_cwmscripture-9.9.9.zip', $zipPath);
+    }
+
+    #[Test]
+    public function ensureMinifiedGateFailsWhenSiblingMissing(): void
+    {
+        $this->writeManifest('cwmscripture.xml', '1.0.0');
+        $this->writeFile('src/Foo.php', '<?php');
+        $this->writeFile('media/lib_cwmscripture/js/foo.js', 'console.log');
+        // foo.min.js intentionally missing.
+
+        $builder = new PackageBuilder($this->makeLibConfig(), $this->tmpDir);
+
+        $exitCode = -1;
+        $stderr   = '';
+
+        // Capture exit() via a child process — preg flag the missing-min message.
+        $script = <<<'PHP'
+<?php
+require '%s/src/Build/BuildConfig.php';
+require '%s/src/Build/ManifestReader.php';
+require '%s/src/Build/PackageBuilder.php';
+$cfg = CWM\BuildTools\Build\BuildConfig::fromArray(%s);
+$b   = new CWM\BuildTools\Build\PackageBuilder($cfg, '%s');
+$b->build();
+PHP;
+
+        $cwm   = realpath(__DIR__ . '/../..');
+        $cfg   = var_export($this->libConfigArray(), true);
+        $proj  = $this->tmpDir;
+        $code  = sprintf($script, $cwm, $cwm, $cwm, $cfg, $proj);
+        $tmpPhp = $this->tmpDir . '/_run.php';
+        file_put_contents($tmpPhp, $code);
+
+        $proc = proc_open(
+            ['php', $tmpPhp],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes
+        );
+
+        if (!is_resource($proc)) {
+            $this->fail('Could not spawn child PHP for gate test');
+        }
+
+        fclose($pipes[0] ?? STDIN);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($proc);
+
+        $this->assertSame(1, $exitCode, 'Gate failure should exit with 1');
+        $this->assertStringContainsString('missing minified assets', (string) $stderr);
+        $this->assertStringContainsString('foo.min.js', (string) $stderr);
+    }
+
+    #[Test]
+    public function ensureMinifiedGatePassesWhenAllPairsPresent(): void
+    {
+        $this->writeManifest('cwmscripture.xml', '1.0.0');
+        $this->writeFile('src/Foo.php', '<?php');
+        $this->writeFile('media/lib_cwmscripture/js/foo.js', 'console.log');
+        $this->writeFile('media/lib_cwmscripture/js/foo.min.js', 'console.log');
+        $this->writeFile('media/lib_cwmscripture/css/foo.css', '.foo{}');
+        $this->writeFile('media/lib_cwmscripture/css/foo.min.css', '.foo{}');
+
+        $builder = new PackageBuilder($this->makeLibConfig(), $this->tmpDir);
+
+        $this->expectOutputRegex('/Package built/');
+        $zipPath = $builder->build();
+        $this->assertFileExists($zipPath);
+    }
+
+    #[Test]
+    public function buildConfigRejectsMissingRequired(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('build.outputDir is required');
+
+        BuildConfig::fromArray([
+            'outputName' => 'foo-{version}.zip',
+            'manifest'   => 'foo.xml',
+            'sources'    => [['from' => 'src', 'to' => 'src']],
+        ]);
+    }
+
+    #[Test]
+    public function buildConfigRejectsEmptySources(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('build.sources is required');
+
+        BuildConfig::fromArray([
+            'outputDir'  => 'build/dist',
+            'outputName' => 'foo-{version}.zip',
+            'manifest'   => 'foo.xml',
+            'sources'    => [],
+        ]);
+    }
+
+    #[Test]
+    public function buildConfigRejectsUnknownPreBuildMode(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('build.preBuild.mode');
+
+        BuildConfig::fromArray([
+            'outputDir'  => 'build/dist',
+            'outputName' => 'foo-{version}.zip',
+            'manifest'   => 'foo.xml',
+            'sources'    => [['from' => 'src', 'to' => 'src']],
+            'preBuild'   => ['mode' => 'autorun'],
+        ]);
+    }
+
+    // --- Helpers ---
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function libConfigArray(): array
+    {
+        return [
+            'outputDir'  => 'build/dist',
+            'outputName' => 'lib_cwmscripture-{version}.zip',
+            'manifest'   => 'cwmscripture.xml',
+            'scriptFile' => 'script.php',
+            'sources'    => [
+                ['from' => 'src', 'to' => 'lib_cwmscripture/src'],
+                ['from' => 'sql', 'to' => 'lib_cwmscripture/sql'],
+                ['from' => 'language', 'to' => 'lib_cwmscripture/language'],
+                ['from' => 'media/lib_cwmscripture', 'to' => 'media/lib_cwmscripture'],
+            ],
+            'excludes'   => ['.git', '.DS_Store', '.idea', 'node_modules', '.php-cs-fixer.cache'],
+            'preBuild'   => [
+                'mode' => 'ensure-minified',
+                'dirs' => ['media/lib_cwmscripture/js', 'media/lib_cwmscripture/css'],
+            ],
+        ];
+    }
+
+    private function makeLibConfig(): BuildConfig
+    {
+        return BuildConfig::fromArray($this->libConfigArray());
+    }
+
+    private function writeManifest(string $relPath, string $version): void
+    {
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<extension type="library" method="upgrade">
+    <name>CWM Scripture</name>
+    <version>$version</version>
+    <creationDate>2026-05-09</creationDate>
+</extension>
+XML;
+        $this->writeFile($relPath, $xml);
+    }
+
+    private function writeFile(string $relPath, string $content): void
+    {
+        $abs = $this->tmpDir . '/' . $relPath;
+        $dir = dirname($abs);
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0o777, true);
+        }
+
+        file_put_contents($abs, $content);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function zipEntries(string $zipPath): array
+    {
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($zipPath) === true, "Could not open $zipPath");
+
+        $entries = [];
+
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $entries[] = (string) $zip->getNameIndex($i);
+        }
+
+        $zip->close();
+
+        return $entries;
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $entries = scandir($dir) ?: [];
+
+        foreach ($entries as $e) {
+            if ($e === '.' || $e === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $e;
+
+            if (is_link($path) || is_file($path)) {
+                @unlink($path);
+                continue;
+            }
+
+            $this->rrmdir($path);
+        }
+
+        @rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary

**PR B of 5** for issue #5. Adds the `cwm-build` binary + `src/Build/PackageBuilder` covering the **simplest of the three consumer shapes** — `lib_cwmscripture`. Proclaim's strict-mode filtering, vendor prune, auto-run pre-build, and 3-way interactive version prompt are deferred to **PR C** (still part of #5).

Independent of PR A (#12) — `lib_cwmscripture`'s flow has no `ask()` helper, so the `Build\Prompt` class isn't required here.

## What it does

Reads a new `build:` block in `cwm-build.config.json`:

```json
"build": {
    "command":    "cwm-build",
    "outputGlob": "build/dist/lib_cwmscripture-*.zip",
    "outputDir":  "build/dist",
    "outputName": "lib_cwmscripture-{version}.zip",
    "manifest":   "cwmscripture.xml",
    "scriptFile": "script.php",
    "sources": [
        { "from": "src",                    "to": "lib_cwmscripture/src" },
        { "from": "media/lib_cwmscripture", "to": "media/lib_cwmscripture" }
    ],
    "excludes": [".git", ".DS_Store", "node_modules", ".php-cs-fixer.cache"],
    "preBuild": {
        "mode": "ensure-minified",
        "dirs": ["media/lib_cwmscripture/js", "media/lib_cwmscripture/css"]
    }
}
```

The new fields are **additive** — they coexist with the existing `build.command` / `build.outputGlob` used by `cwm-release`. Consumers migrate by setting `build.command: "cwm-build"` and adding the new fields; `cwm-release` keeps finding the produced artifact via `outputGlob`.

## CLI

```
cwm-build                       # full build using config defaults
cwm-build -v                    # verbose: print every file added to the zip
cwm-build --version 1.2.3       # override version (skip manifest read)
cwm-build --help
```

Exit code 1 on missing config, invalid config, missing manifest, or pre-build gate failure.

## Schema reserved for PR C

`preBuild.mode` is currently restricted to `"ensure-minified"`. PR C will add `"run"` (auto-execute a command — Proclaim's `npm install && npm run build`). The schema validator throws on unrecognized modes so consumers can't accidentally write a config that "works on PR B's binary but breaks on PR C's."

Other PR C additions (signposted in code comments):
- `excludeMatchMode: "strict"` — Proclaim's 4-mode (exact / prefix / contains / suffix)
- `excludeExtensions: [".map"]`
- `excludePaths: ["media/backup/*.sql"]`
- `vendorPrune: true`
- `includeRootExtensions: ["php", "xml", "txt", "md"]`
- Interactive 3-way version prompt via `Build\Prompt` from PR A

## Behavior differences from lib_cwmscripture's existing script

- Doesn't wipe `build/dist/` wholesale — only deletes the specific output zip if it already exists. Stale artifacts are gitignored anyway, and the wholesale wipe is destructive to unrelated zips.
- Uses `ZipArchive` directly throughout — no `system()` / shell calls.
- Pre-build gate uses native `scandir` + sibling check (no `glob()` calls).

These are all in the safer direction; lib_cwmscripture's resulting zip is byte-identical for normal flows.

## Tests

8 new tests / 51 new assertions (40 → 48, 100 → 151):

- Full end-to-end build of a fixture project, asserts every expected zip entry + every excluded entry is absent
- `script.php` omitted when not present on disk
- `--version` override produces a different-named zip without overwriting the original
- `ensure-minified` gate fails (exit 1, stderr message names missing files) when a `.min.X` sibling is absent
- `ensure-minified` gate passes when all pairs present
- `BuildConfig` validation: missing required fields, empty `sources`, unknown `preBuild.mode`

Plus CLI smoke-tested against a fake project tree — happy path, version override, gate failure with stderr message, and `--help` all behave correctly.

## Files

- `src/Build/BuildConfig.php` — new (~115 lines)
- `src/Build/PackageBuilder.php` — new (~260 lines)
- `scripts/build.php` — new CLI entry (~120 lines)
- `bin/cwm-build` — new shim (~30 lines)
- `tests/Build/PackageBuilderTest.php` — new (~320 lines)
- `composer.json` — registers `bin/cwm-build`
- `README.md` — added to CLI tools list
- `examples/library/cwm-build.config.json` — full `build:` block matching lib_cwmscripture's exact pattern + a `_command_comment` explaining the coexistence with `cwm-release`
- `CHANGELOG.md` — entry under `[Unreleased]`

## Roadmap

| PR | Scope | Status |
|---|---|---|
| A — #12 | `Build\Prompt` extraction | open |
| **B — this PR** | `cwm-build` for lib_cwmscripture's shape | **this PR** |
| C | Extend `cwm-build` for Proclaim (strict mode, vendor prune, auto pre-build, 3-way version prompt) | not started |
| D | `cwm-package` with 4 `includes[]` types + `innerLayout` + opt-in self-verify | not started |
| E | Cut v0.5.0-alpha + migration guide | not started |

## Test plan

- [x] `composer test` — 48/48 passing, 151 assertions
- [x] CLI smoke test (4 cases) against a fake project tree
- [x] `git archive` dist verification — new files included; tests excluded
- [ ] Migrate `lib_cwmscripture` to call `cwm-build` (separate PR in that repo) and confirm byte-equivalent or near-equivalent output

Refs #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)