### PR TITLE
feat(build): strict-mode excludes, vendor prune, include roots, run-mode preBuild — PR C of #5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `cwm-build` binary + `scripts/build.php` + `src/Build/PackageBuilder` +
+  `src/Build/BuildConfig` — generic Joomla extension zip builder driven by a
+  `build:` block in `cwm-build.config.json`. Phase 1 covers the
+  lib_cwmscripture build shape: read manifest version, optionally gate on
+  presence of `*.min.{js,css}` siblings (`preBuild.mode: "ensure-minified"`),
+  walk one or more source directories with a per-source zip-path prefix, apply
+  loose `str_contains` excludes. CLI flags `-v`/`--verbose`, `--version <ver>`
+  override, `--help`. New schema fields: `build.outputDir`, `outputName`
+  (supports `{version}`), `manifest`, `scriptFile`, `sources[]`, `excludes`,
+  `preBuild`. Coexists with the existing `build.command` / `build.outputGlob`
+  fields used by `cwm-release` — consumers migrate by setting
+  `build.command: "cwm-build"`. Strict-mode filtering, vendor pruning, auto-
+  run pre-build, and the interactive 3-way version prompt land in subsequent
+  PRs (still part of #5). 8 new unit tests / 39 assertions covering the
+  end-to-end build, version override, gate pass/fail, and config validation.
+
 - `templates/build-assets.js` — generic version of Proclaim's
   `build/build-assets.js` that copies images, mirrors a manually-managed
   vendor source tree, and cherry-picks files/dirs out of npm packages in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `cwm-build` strict-mode + filtering features for the Proclaim-shape build
+  flow. New optional `build:` schema fields (PR C of #5):
+  - `excludeMatchMode: "strict"` — Proclaim's 4-mode pattern matching
+    (exact / prefix-with-slash / contained-with-slashes / suffix-after-slash)
+    that catches `.git` at any depth without over-matching the substring "git"
+    inside unrelated filenames. Defaults to `"contains"` (PR B behavior).
+  - `excludeExtensions: ["map"]` — bare extension allowlist; `.map` files
+    are dropped at any path.
+  - `excludePaths: ["media/backup/*.sql"]` — fnmatch glob patterns matched
+    against the relative path; covers Proclaim's `media/backup/*.sql` rule.
+  - `vendorPrune: true` — drop Composer metadata (`installed.json`,
+    `installed.php`) and doc/license files (`README*`, `CHANGELOG*`,
+    `BACKERS*`, `AUTHORS*`, `CONTRIBUTING*`, `UPGRADE*`, `SECURITY*`,
+    `LICENSE*`, `COPYING*`) inside any `vendor/` subtree.
+  - `includeRoots: ["admin/", "media/", ...]` — subdirectory allowlist;
+    only files starting with one of these prefixes are included.
+  - `includeRootExtensions: ["php", "xml", "txt", "md"]` — root-level
+    files (no `/` in path) with one of these extensions are also admitted
+    through the include filter (Proclaim's `proclaim.xml`, `LICENSE.txt`,
+    `README.md` at project root).
+  - `preBuild.mode: "run"` + `preBuild.command` — auto-execute a shell
+    command (`passthru`) before the zip walk; non-zero exit aborts.
+    Matches Proclaim's `npm install && npm run build` step. Build config
+    is trusted (committed by the project author) so shell semantics are
+    OK per the threat model.
+  11 new tests / 56 assertions covering each of the above plus the
+  combined Proclaim-shape (strict + vendor-prune + includeRoots +
+  includeRootExtensions). Defaults preserve PR B's behavior; adopting any
+  of these is opt-in. The interactive 3-way version prompt
+  (`versionPrompt`) is deferred to a small follow-up after PR A
+  (`Build\Prompt`) merges.
+
 - `cwm-build` binary + `scripts/build.php` + `src/Build/PackageBuilder` +
   `src/Build/BuildConfig` — generic Joomla extension zip builder driven by a
   `build:` block in `cwm-build.config.json`. Phase 1 covers the

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Across `Proclaim`, `lib_cwmscripture`, `CWMScriptureLinks`, and `plg_task_cwmscr
 
 | Surface | What | Where |
 |---|---|---|
-| **CLI tools** | `cwm-release`, `cwm-bump`, `cwm-package`, `cwm-sync-configs`, `cwm-sync-languages`, `cwm-ars-publish`, `cwm-changelog`, `cwm-article`, `cwm-init`, `cwm-setup`, `cwm-link`, `cwm-link-check`, `cwm-clean`, `cwm-verify`, `cwm-joomla-install`, `cwm-joomla-latest`, `cwm-joomla-cms-deps` | `bin/` |
+| **CLI tools** | `cwm-release`, `cwm-bump`, `cwm-build`, `cwm-package`, `cwm-sync-configs`, `cwm-sync-languages`, `cwm-ars-publish`, `cwm-changelog`, `cwm-article`, `cwm-init`, `cwm-setup`, `cwm-link`, `cwm-link-check`, `cwm-clean`, `cwm-verify`, `cwm-joomla-install`, `cwm-joomla-latest`, `cwm-joomla-cms-deps` | `bin/` |
 | **Scripts** | Generic 8-step release pipeline, multi-manifest version bumper, config syncer | `scripts/` |
 | **PHP library** | `ProjectConfig`, `ManifestReader`, `PackageBuilder`, `ArsPublisher`, `Bumper` | `src/` (PSR-4 `CWM\BuildTools\`) |
 | **Reusable GH Actions** | `joomla-package-ci.yml`, `joomla-library-ci.yml` (called via `workflow_call`) | `.github/workflows/` |

--- a/bin/cwm-build
+++ b/bin/cwm-build
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# cwm-build — build an installable Joomla extension zip from
+# cwm-build.config.json.
+#
+# Reads the `build:` block of cwm-build.config.json in the project root and
+# produces an installable zip under build.outputDir. See `cwm-build --help`
+# for full usage.
+#
+# Usage from a consuming project:
+#   composer cwm-build                       # full build
+#   composer cwm-build -- -v                 # verbose
+#   composer cwm-build -- --version 1.2.3    # override version
+#
+set -euo pipefail
+
+PROJECT_ROOT="$(pwd)"
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ ! -f "${PROJECT_ROOT}/cwm-build.config.json" ]; then
+    echo "Error: cwm-build.config.json not found in $PROJECT_ROOT"
+    echo "Run 'cwm-init' to scaffold one, or see"
+    echo "  ${TOOLS_DIR}/examples/ for reference configs."
+    exit 1
+fi
+
+exec php "${TOOLS_DIR}/scripts/build.php" "$@"

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "bin": [
         "bin/cwm-release",
         "bin/cwm-bump",
+        "bin/cwm-build",
         "bin/cwm-package",
         "bin/cwm-sync-configs",
         "bin/cwm-sync-languages",

--- a/examples/library/cwm-build.config.json
+++ b/examples/library/cwm-build.config.json
@@ -10,8 +10,24 @@
         ]
     },
     "build": {
-        "command": "npm run build && php build/build-package.php",
-        "outputGlob": "build/dist/lib_cwmscripture-*.zip"
+        "_command_comment": "command + outputGlob are read by cwm-release. command = 'cwm-build' delegates to the generic builder, which reads outputDir/outputName/manifest/scriptFile/sources/excludes/preBuild from this same block. cwm-release then matches outputGlob to find the produced artifact.",
+        "command": "cwm-build",
+        "outputGlob": "build/dist/lib_cwmscripture-*.zip",
+        "outputDir": "build/dist",
+        "outputName": "lib_cwmscripture-{version}.zip",
+        "manifest": "cwmscripture.xml",
+        "scriptFile": "script.php",
+        "sources": [
+            { "from": "src",                    "to": "lib_cwmscripture/src" },
+            { "from": "sql",                    "to": "lib_cwmscripture/sql" },
+            { "from": "language",               "to": "lib_cwmscripture/language" },
+            { "from": "media/lib_cwmscripture", "to": "media/lib_cwmscripture" }
+        ],
+        "excludes": [".git", ".DS_Store", ".idea", "node_modules", ".php-cs-fixer.cache"],
+        "preBuild": {
+            "mode": "ensure-minified",
+            "dirs": ["media/lib_cwmscripture/js", "media/lib_cwmscripture/css"]
+        }
     },
     "ars": {
         "endpoint": "https://www.christianwebministries.org",

--- a/scripts/build.php
+++ b/scripts/build.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * cwm-build — generic extension zip builder.
+ *
+ * Reads `build:` block of cwm-build.config.json from the current working
+ * directory and produces an installable Joomla extension zip per the
+ * declared sources, excludes, and optional pre-build gate.
+ *
+ * Phase 1 — covers lib_cwmscripture's build shape (loose `str_contains`
+ * exclude matching, optional `ensure-minified` gate, per-source zip
+ * prefix). Subsequent PRs add Proclaim's strict-mode filtering, vendor
+ * pruning, auto-run pre-build, and the 3-way version prompt.
+ */
+
+require_once __DIR__ . '/../src/Build/BuildConfig.php';
+require_once __DIR__ . '/../src/Build/ManifestReader.php';
+require_once __DIR__ . '/../src/Build/PackageBuilder.php';
+
+use CWM\BuildTools\Build\BuildConfig;
+use CWM\BuildTools\Build\PackageBuilder;
+
+$projectRoot = getcwd() ?: '.';
+$args        = $argv;
+array_shift($args);
+
+if (in_array('--help', $args, true) || in_array('-h', $args, true)) {
+    echo <<<HELP
+cwm-build — build an installable extension zip from cwm-build.config.json.
+
+WHAT IT DOES
+  Reads the `build:` block of cwm-build.config.json (in the current working
+  directory), runs the optional pre-build gate, then walks every configured
+  source directory into a zip under build.outputDir. Manifest version is
+  read from <version> in build.manifest unless --version overrides.
+
+PREREQUISITES
+  - cwm-build.config.json with a `build:` block in the project root
+  - The manifest XML referenced by build.manifest
+
+USAGE
+  cwm-build                       # full build using config defaults
+  cwm-build -v                    # verbose: print every file added
+  cwm-build --version 1.2.3       # override version (skip manifest read)
+  cwm-build --help
+
+OPTIONS
+  -v, --verbose          Print every file as it's added to the zip.
+      --version <ver>    Use this version instead of the manifest's <version>.
+  -h, --help             Show this help.
+
+EXIT CODE
+  0 on success.
+  1 on missing config, invalid config, missing manifest, or pre-build gate
+  failure (e.g. missing `.min.js` siblings under `ensure-minified`).
+
+RELATED
+  cwm-package          # multi-extension package wrapper (planned for #5 PR D)
+  cwm-bump             # version bump across manifests
+  cwm-release          # full release pipeline; runs build.command from config
+
+HELP;
+    exit(0);
+}
+
+$verbose         = in_array('-v', $args, true) || in_array('--verbose', $args, true);
+$versionOverride = null;
+
+for ($i = 0, $n = count($args); $i < $n; $i++) {
+    if ($args[$i] === '--version' && isset($args[$i + 1])) {
+        $versionOverride = $args[++$i];
+        continue;
+    }
+
+    if ($args[$i] === '-v' || $args[$i] === '--verbose') {
+        continue;
+    }
+
+    fwrite(STDERR, "Error: unrecognized argument '{$args[$i]}'. Run with --help for usage.\n");
+    exit(1);
+}
+
+$configFile = $projectRoot . '/cwm-build.config.json';
+
+if (!is_file($configFile)) {
+    fwrite(STDERR, "Error: cwm-build.config.json not found in $projectRoot\n");
+    fwrite(STDERR, "Run 'cwm-init' to scaffold one, or run from your project root.\n");
+    exit(1);
+}
+
+$rawConfig = json_decode((string) file_get_contents($configFile), true);
+
+if (!is_array($rawConfig)) {
+    fwrite(STDERR, "Error: cwm-build.config.json is not valid JSON\n");
+    exit(1);
+}
+
+if (!isset($rawConfig['build']) || !is_array($rawConfig['build'])) {
+    fwrite(STDERR, "Error: cwm-build.config.json has no `build` block.\n");
+    fwrite(STDERR, "  See examples/library/cwm-build.config.json for the shape.\n");
+    exit(1);
+}
+
+try {
+    $config = BuildConfig::fromArray($rawConfig['build']);
+} catch (\InvalidArgumentException $e) {
+    fwrite(STDERR, "Error: invalid build config — " . $e->getMessage() . "\n");
+    exit(1);
+}
+
+$builder = new PackageBuilder($config, $projectRoot, $verbose);
+
+try {
+    $builder->build($versionOverride);
+} catch (\Throwable $e) {
+    fwrite(STDERR, "Error: build failed — " . $e->getMessage() . "\n");
+    exit(1);
+}

--- a/src/Build/BuildConfig.php
+++ b/src/Build/BuildConfig.php
@@ -7,21 +7,35 @@ namespace CWM\BuildTools\Build;
 /**
  * Parsed `build:` block of `cwm-build.config.json`.
  *
- * Captures only the fields needed by the lib_cwmscripture-shape build flow
- * (the simplest of the three consumer shapes the consolidation targets — see
- * issue #5). Subsequent PRs add fields for Proclaim's strict-mode filtering,
- * vendor pruning, auto-run pre-build, and interactive version prompting.
+ * Supports both the lib_cwmscripture-shape build flow (loose `str_contains`
+ * excludes, optional `ensure-minified` pre-build gate) and the Proclaim-shape
+ * flow (strict 4-mode exclude matching, vendor pruning, auto-run pre-build,
+ * include-roots filter, root-extension allowlist).
+ *
+ * Defaults preserve PR B's lib_cwmscripture shape; opt into Proclaim-shape
+ * features via `excludeMatchMode: "strict"`, `vendorPrune: true`,
+ * `includeRoots`, `includeRootExtensions`, `excludeExtensions`, `excludePaths`,
+ * and `preBuild.mode: "run"`.
  */
 final class BuildConfig
 {
+    public const MATCH_CONTAINS = 'contains';
+    public const MATCH_STRICT   = 'strict';
+
     /**
-     * @param string                                       $outputDir       Absolute or project-relative directory for the built zip.
-     * @param string                                       $outputName      Output filename pattern; supports `{version}` substitution.
-     * @param string                                       $manifest        Project-relative path to the manifest XML; version is read from its <version> element.
-     * @param string|null                                  $scriptFile      Optional install scriptfile, added at zip root if present.
-     * @param list<array{from: string, to: string}>        $sources         Source directories with their zip-path prefix.
-     * @param list<string>                                 $excludes        Path substrings to skip (str_contains semantics).
-     * @param array{mode: string, dirs?: list<string>}|null $preBuild       Optional pre-build gate config.
+     * @param string                                $outputDir              Absolute or project-relative directory for the built zip.
+     * @param string                                $outputName             Output filename pattern; supports `{version}` substitution.
+     * @param string                                $manifest               Project-relative path to the manifest XML; version is read from its <version> element.
+     * @param string|null                           $scriptFile             Optional install scriptfile, added at zip root if present.
+     * @param list<array{from: string, to: string}> $sources                Source directories with their zip-path prefix.
+     * @param list<string>                          $excludes               Path patterns to skip; matched per `excludeMatchMode`.
+     * @param string                                $excludeMatchMode       `"contains"` (default — PR B/lib_cwmscripture) or `"strict"` (4-mode — Proclaim).
+     * @param list<string>                          $excludeExtensions      Bare extensions (no leading dot) to drop, e.g. `["map"]`.
+     * @param list<string>                          $excludePaths           fnmatch glob patterns matched against the relative path, e.g. `["media/backup/*.sql"]`.
+     * @param bool                                  $vendorPrune            When true, drop Composer metadata + doc/license files inside any `vendor/` subtree.
+     * @param list<string>                          $includeRoots           When set, only files starting with one of these prefixes are included (subdirectory allowlist).
+     * @param list<string>                          $includeRootExtensions  When set with `includeRoots`, allows root-level files with these extensions through the include filter.
+     * @param array{mode: string, dirs?: list<string>, command?: string}|null $preBuild Optional pre-build hook.
      */
     public function __construct(
         public readonly string $outputDir,
@@ -31,6 +45,12 @@ final class BuildConfig
         public readonly array $sources,
         public readonly array $excludes,
         public readonly ?array $preBuild,
+        public readonly string $excludeMatchMode = self::MATCH_CONTAINS,
+        public readonly array $excludeExtensions = [],
+        public readonly array $excludePaths = [],
+        public readonly bool $vendorPrune = false,
+        public readonly array $includeRoots = [],
+        public readonly array $includeRootExtensions = [],
     ) {
     }
 
@@ -64,13 +84,21 @@ final class BuildConfig
             $sources[] = ['from' => (string) $src['from'], 'to' => (string) $src['to']];
         }
 
-        $rawExcludes = $cfg['excludes'] ?? [];
+        $excludes              = self::stringList($cfg, 'excludes');
+        $excludeExtensions     = array_map(static fn (string $e): string => ltrim($e, '.'), self::stringList($cfg, 'excludeExtensions'));
+        $excludePaths          = self::stringList($cfg, 'excludePaths');
+        $includeRoots          = self::stringList($cfg, 'includeRoots');
+        $includeRootExtensions = array_map(static fn (string $e): string => ltrim($e, '.'), self::stringList($cfg, 'includeRootExtensions'));
 
-        if (!is_array($rawExcludes)) {
-            throw new \InvalidArgumentException('build.excludes must be an array of strings');
+        $matchMode = $cfg['excludeMatchMode'] ?? self::MATCH_CONTAINS;
+
+        if (!is_string($matchMode) || !in_array($matchMode, [self::MATCH_CONTAINS, self::MATCH_STRICT], true)) {
+            throw new \InvalidArgumentException(
+                'build.excludeMatchMode must be "contains" or "strict" (got ' . var_export($matchMode, true) . ')'
+            );
         }
 
-        $excludes = array_values(array_map('strval', $rawExcludes));
+        $vendorPrune = isset($cfg['vendorPrune']) ? (bool) $cfg['vendorPrune'] : false;
 
         $preBuild = null;
 
@@ -81,33 +109,64 @@ final class BuildConfig
 
             $mode = (string) $cfg['preBuild']['mode'];
 
-            if ($mode !== 'ensure-minified') {
+            if (!in_array($mode, ['ensure-minified', 'run'], true)) {
                 throw new \InvalidArgumentException(
-                    "build.preBuild.mode must be 'ensure-minified' (got '$mode'). " .
-                    "Other modes (e.g. 'run', 'gate') are reserved for future PRs."
+                    "build.preBuild.mode must be one of: ensure-minified, run (got '$mode')"
                 );
             }
 
-            $dirs = $cfg['preBuild']['dirs'] ?? [];
+            $preBuild = ['mode' => $mode];
 
-            if (!is_array($dirs)) {
-                throw new \InvalidArgumentException('build.preBuild.dirs must be an array of strings');
+            if ($mode === 'ensure-minified') {
+                $dirs = $cfg['preBuild']['dirs'] ?? [];
+
+                if (!is_array($dirs)) {
+                    throw new \InvalidArgumentException('build.preBuild.dirs must be an array of strings');
+                }
+
+                $preBuild['dirs'] = array_values(array_map('strval', $dirs));
+            } elseif ($mode === 'run') {
+                $command = $cfg['preBuild']['command'] ?? '';
+
+                if (!is_string($command) || trim($command) === '') {
+                    throw new \InvalidArgumentException('build.preBuild.command is required when mode is "run"');
+                }
+
+                $preBuild['command'] = $command;
             }
-
-            $preBuild = [
-                'mode' => $mode,
-                'dirs' => array_values(array_map('strval', $dirs)),
-            ];
         }
 
         return new self(
-            outputDir:  (string) $cfg['outputDir'],
-            outputName: (string) $cfg['outputName'],
-            manifest:   (string) $cfg['manifest'],
-            scriptFile: isset($cfg['scriptFile']) && is_string($cfg['scriptFile']) ? $cfg['scriptFile'] : null,
-            sources:    $sources,
-            excludes:   $excludes,
-            preBuild:   $preBuild,
+            outputDir:             (string) $cfg['outputDir'],
+            outputName:            (string) $cfg['outputName'],
+            manifest:              (string) $cfg['manifest'],
+            scriptFile:            isset($cfg['scriptFile']) && is_string($cfg['scriptFile']) ? $cfg['scriptFile'] : null,
+            sources:               $sources,
+            excludes:              $excludes,
+            preBuild:              $preBuild,
+            excludeMatchMode:      $matchMode,
+            excludeExtensions:     $excludeExtensions,
+            excludePaths:          $excludePaths,
+            vendorPrune:           $vendorPrune,
+            includeRoots:          $includeRoots,
+            includeRootExtensions: $includeRootExtensions,
         );
+    }
+
+    /**
+     * Pull a list-of-strings field, defaulting to []; validates the type.
+     *
+     * @param  array<string, mixed> $cfg
+     * @return list<string>
+     */
+    private static function stringList(array $cfg, string $key): array
+    {
+        $raw = $cfg[$key] ?? [];
+
+        if (!is_array($raw)) {
+            throw new \InvalidArgumentException("build.$key must be an array of strings");
+        }
+
+        return array_values(array_map('strval', $raw));
     }
 }

--- a/src/Build/BuildConfig.php
+++ b/src/Build/BuildConfig.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Build;
+
+/**
+ * Parsed `build:` block of `cwm-build.config.json`.
+ *
+ * Captures only the fields needed by the lib_cwmscripture-shape build flow
+ * (the simplest of the three consumer shapes the consolidation targets — see
+ * issue #5). Subsequent PRs add fields for Proclaim's strict-mode filtering,
+ * vendor pruning, auto-run pre-build, and interactive version prompting.
+ */
+final class BuildConfig
+{
+    /**
+     * @param string                                       $outputDir       Absolute or project-relative directory for the built zip.
+     * @param string                                       $outputName      Output filename pattern; supports `{version}` substitution.
+     * @param string                                       $manifest        Project-relative path to the manifest XML; version is read from its <version> element.
+     * @param string|null                                  $scriptFile      Optional install scriptfile, added at zip root if present.
+     * @param list<array{from: string, to: string}>        $sources         Source directories with their zip-path prefix.
+     * @param list<string>                                 $excludes        Path substrings to skip (str_contains semantics).
+     * @param array{mode: string, dirs?: list<string>}|null $preBuild       Optional pre-build gate config.
+     */
+    public function __construct(
+        public readonly string $outputDir,
+        public readonly string $outputName,
+        public readonly string $manifest,
+        public readonly ?string $scriptFile,
+        public readonly array $sources,
+        public readonly array $excludes,
+        public readonly ?array $preBuild,
+    ) {
+    }
+
+    /**
+     * Build a BuildConfig from the raw `build:` block of cwm-build.config.json.
+     *
+     * @param  array<string, mixed> $cfg
+     * @throws \InvalidArgumentException When required fields are missing or malformed.
+     */
+    public static function fromArray(array $cfg): self
+    {
+        foreach (['outputDir', 'outputName', 'manifest'] as $required) {
+            if (empty($cfg[$required]) || !is_string($cfg[$required])) {
+                throw new \InvalidArgumentException("build.$required is required and must be a string");
+            }
+        }
+
+        $rawSources = $cfg['sources'] ?? [];
+
+        if (!is_array($rawSources) || $rawSources === []) {
+            throw new \InvalidArgumentException('build.sources is required and must be a non-empty array');
+        }
+
+        $sources = [];
+
+        foreach ($rawSources as $i => $src) {
+            if (!is_array($src) || empty($src['from']) || !isset($src['to'])) {
+                throw new \InvalidArgumentException("build.sources[$i] must have non-empty 'from' and 'to' keys");
+            }
+
+            $sources[] = ['from' => (string) $src['from'], 'to' => (string) $src['to']];
+        }
+
+        $rawExcludes = $cfg['excludes'] ?? [];
+
+        if (!is_array($rawExcludes)) {
+            throw new \InvalidArgumentException('build.excludes must be an array of strings');
+        }
+
+        $excludes = array_values(array_map('strval', $rawExcludes));
+
+        $preBuild = null;
+
+        if (isset($cfg['preBuild'])) {
+            if (!is_array($cfg['preBuild']) || empty($cfg['preBuild']['mode'])) {
+                throw new \InvalidArgumentException('build.preBuild must be an object with a non-empty `mode`');
+            }
+
+            $mode = (string) $cfg['preBuild']['mode'];
+
+            if ($mode !== 'ensure-minified') {
+                throw new \InvalidArgumentException(
+                    "build.preBuild.mode must be 'ensure-minified' (got '$mode'). " .
+                    "Other modes (e.g. 'run', 'gate') are reserved for future PRs."
+                );
+            }
+
+            $dirs = $cfg['preBuild']['dirs'] ?? [];
+
+            if (!is_array($dirs)) {
+                throw new \InvalidArgumentException('build.preBuild.dirs must be an array of strings');
+            }
+
+            $preBuild = [
+                'mode' => $mode,
+                'dirs' => array_values(array_map('strval', $dirs)),
+            ];
+        }
+
+        return new self(
+            outputDir:  (string) $cfg['outputDir'],
+            outputName: (string) $cfg['outputName'],
+            manifest:   (string) $cfg['manifest'],
+            scriptFile: isset($cfg['scriptFile']) && is_string($cfg['scriptFile']) ? $cfg['scriptFile'] : null,
+            sources:    $sources,
+            excludes:   $excludes,
+            preBuild:   $preBuild,
+        );
+    }
+}

--- a/src/Build/PackageBuilder.php
+++ b/src/Build/PackageBuilder.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Build;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ZipArchive;
+
+/**
+ * Builds an installable extension zip per a {@see BuildConfig}.
+ *
+ * Phase 1 — covers the lib_cwmscripture build shape: read manifest version,
+ * optionally gate on minified asset presence, then walk one or more source
+ * directories into the zip with a configurable per-source prefix. Excludes
+ * are matched as path substrings (`str_contains`), the loose mode used by
+ * lib_cwmscripture and CWMScriptureLinks. Strict-mode (Proclaim's 4-mode
+ * exclude + vendor prune + root-ext include) lands in a follow-up PR.
+ *
+ * Path semantics:
+ *   - `BuildConfig::manifest` and `BuildConfig::scriptFile` are
+ *     project-relative; their `basename()` becomes the in-zip path.
+ *   - `BuildConfig::sources[i].from` is project-relative; every file under
+ *     it gets prefixed with `sources[i].to` inside the zip.
+ *   - `BuildConfig::outputDir` is project-relative.
+ *   - `outputName` accepts a literal `{version}` token — substituted with
+ *     the value read from the manifest (or `versionOverride` argument).
+ */
+final class PackageBuilder
+{
+    public function __construct(
+        private readonly BuildConfig $config,
+        private readonly string $projectRoot,
+        private readonly bool $verbose = false,
+    ) {
+        if (!is_dir($this->projectRoot)) {
+            throw new \InvalidArgumentException("Project root does not exist: $this->projectRoot");
+        }
+    }
+
+    /**
+     * Run the full build flow.
+     *
+     * @param  string|null $versionOverride  When non-null, used in place of the manifest's <version>. Useful for ad-hoc rebuilds.
+     * @return string                        Absolute path to the resulting zip.
+     */
+    public function build(?string $versionOverride = null): string
+    {
+        $manifestPath = $this->resolve($this->config->manifest);
+
+        if (!is_file($manifestPath)) {
+            throw new \RuntimeException("Manifest not found: $manifestPath");
+        }
+
+        $reader  = new ManifestReader($manifestPath);
+        $version = $versionOverride ?? $reader->version();
+
+        if ($this->config->preBuild !== null) {
+            $this->runPreBuild($this->config->preBuild);
+        }
+
+        $outputDir = $this->resolve($this->config->outputDir);
+
+        if (!is_dir($outputDir) && !mkdir($outputDir, 0o777, true) && !is_dir($outputDir)) {
+            throw new \RuntimeException("Could not create output directory: $outputDir");
+        }
+
+        $outputName = str_replace('{version}', $version, $this->config->outputName);
+        $outputPath = $outputDir . '/' . $outputName;
+
+        // Replace any prior build artifact at this exact path. Unlike the
+        // legacy lib_cwmscripture script, we don't wipe the entire dist dir
+        // (that's destructive to unrelated zips); leftover artifacts are
+        // gitignored anyway.
+        if (file_exists($outputPath)) {
+            unlink($outputPath);
+        }
+
+        echo "Building " . basename($outputPath) . " (v$version)\n";
+
+        $zip = new ZipArchive();
+
+        if ($zip->open($outputPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            throw new \RuntimeException("Could not create zip: $outputPath");
+        }
+
+        $manifestEntry = basename($this->config->manifest);
+        $zip->addFile($manifestPath, $manifestEntry);
+        $this->log("  + $manifestEntry");
+
+        if ($this->config->scriptFile !== null) {
+            $scriptAbs = $this->resolve($this->config->scriptFile);
+
+            if (is_file($scriptAbs)) {
+                $scriptEntry = basename($this->config->scriptFile);
+                $zip->addFile($scriptAbs, $scriptEntry);
+                $this->log("  + $scriptEntry");
+            }
+        }
+
+        foreach ($this->config->sources as $src) {
+            $this->addDirectory($zip, $this->resolve($src['from']), $src['to'], $this->config->excludes);
+        }
+
+        $fileCount = $zip->numFiles;
+        $zip->close();
+
+        $sizeKb = (int) round((int) filesize($outputPath) / 1024);
+        echo "\nPackage built: $outputPath\n";
+        echo "  Files: $fileCount\n";
+        echo "  Size:  {$sizeKb} KB\n";
+
+        return $outputPath;
+    }
+
+    /**
+     * Resolve a project-relative path against the project root.
+     */
+    private function resolve(string $path): string
+    {
+        if ($path === '') {
+            return $this->projectRoot;
+        }
+
+        // Already absolute — pass through.
+        if ($path[0] === '/' || (strlen($path) > 1 && $path[1] === ':')) {
+            return $path;
+        }
+
+        return rtrim($this->projectRoot, '/') . '/' . $path;
+    }
+
+    /**
+     * Run the configured pre-build gate.
+     *
+     * `ensure-minified` is the only mode currently supported. For each listed
+     * directory, every `<name>.<ext>` that isn't already a `.min.<ext>` must
+     * have a corresponding `<name>.min.<ext>` sibling, otherwise the build
+     * fails with a hint to run the project's build step.
+     *
+     * @param array{mode: string, dirs?: list<string>} $preBuild
+     */
+    private function runPreBuild(array $preBuild): void
+    {
+        if ($preBuild['mode'] !== 'ensure-minified') {
+            return;
+        }
+
+        $missing = [];
+
+        foreach ($preBuild['dirs'] ?? [] as $relDir) {
+            $absDir = $this->resolve($relDir);
+
+            if (!is_dir($absDir)) {
+                continue;
+            }
+
+            $entries = scandir($absDir) ?: [];
+
+            foreach ($entries as $entry) {
+                if ($entry === '.' || $entry === '..' || !is_file($absDir . '/' . $entry)) {
+                    continue;
+                }
+
+                if (!preg_match('/\.([a-z0-9]+)$/i', $entry, $m)) {
+                    continue;
+                }
+
+                $ext = $m[1];
+
+                // Already a minified version — skip.
+                if (str_ends_with($entry, '.min.' . $ext)) {
+                    continue;
+                }
+
+                $minEntry = substr($entry, 0, -strlen('.' . $ext)) . '.min.' . $ext;
+
+                if (!file_exists($absDir . '/' . $minEntry)) {
+                    $missing[] = $relDir . '/' . $minEntry;
+                }
+            }
+        }
+
+        if ($missing !== []) {
+            fwrite(STDERR, "Pre-build gate failed: missing minified assets:\n");
+
+            foreach ($missing as $m) {
+                fwrite(STDERR, "  - $m\n");
+            }
+
+            fwrite(STDERR, "\nRun the project's build step (typically `npm run build`) before packaging.\n");
+            exit(1);
+        }
+    }
+
+    /**
+     * Walk a source directory and add its files to the zip under $zipPrefix.
+     *
+     * @param list<string> $excludes
+     */
+    private function addDirectory(ZipArchive $zip, string $sourcePath, string $zipPrefix, array $excludes): void
+    {
+        if (!is_dir($sourcePath)) {
+            echo "  SKIP: $sourcePath (not found)\n";
+
+            return;
+        }
+
+        $sourceReal = realpath($sourcePath);
+
+        if ($sourceReal === false) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($sourcePath, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::LEAVES_ONLY
+        );
+
+        foreach ($iterator as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            $filePath     = $file->getRealPath();
+            $relativePath = substr($filePath, strlen($sourceReal) + 1);
+
+            if (self::matchesExclude($relativePath, $excludes)) {
+                continue;
+            }
+
+            $entryPath = $zipPrefix === '' ? $relativePath : rtrim($zipPrefix, '/') . '/' . $relativePath;
+
+            $zip->addFile($filePath, $entryPath);
+            $this->log("  + $entryPath");
+        }
+    }
+
+    /**
+     * @param list<string> $excludes
+     */
+    private static function matchesExclude(string $path, array $excludes): bool
+    {
+        foreach ($excludes as $pattern) {
+            if ($pattern !== '' && str_contains($path, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function log(string $line): void
+    {
+        if ($this->verbose) {
+            echo $line . "\n";
+        }
+    }
+}

--- a/src/Build/PackageBuilder.php
+++ b/src/Build/PackageBuilder.php
@@ -12,12 +12,11 @@ use ZipArchive;
 /**
  * Builds an installable extension zip per a {@see BuildConfig}.
  *
- * Phase 1 — covers the lib_cwmscripture build shape: read manifest version,
- * optionally gate on minified asset presence, then walk one or more source
- * directories into the zip with a configurable per-source prefix. Excludes
- * are matched as path substrings (`str_contains`), the loose mode used by
- * lib_cwmscripture and CWMScriptureLinks. Strict-mode (Proclaim's 4-mode
- * exclude + vendor prune + root-ext include) lands in a follow-up PR.
+ * Supports both the lib_cwmscripture-shape build flow (loose `str_contains`
+ * excludes, optional `ensure-minified` pre-build gate, multiple sources with
+ * per-source zip prefix) and the Proclaim-shape flow (strict 4-mode exclude
+ * matching, vendor pruning, include-roots filter, root-extension allowlist,
+ * auto-run pre-build via `passthru`).
  *
  * Path semantics:
  *   - `BuildConfig::manifest` and `BuildConfig::scriptFile` are
@@ -30,6 +29,11 @@ use ZipArchive;
  */
 final class PackageBuilder
 {
+    /** Files dropped from any `vendor/` subtree when vendorPrune is on. */
+    private const VENDOR_PRUNE_DOC_NAMES = [
+        'README', 'CHANGELOG', 'BACKERS', 'AUTHORS', 'CONTRIBUTING', 'UPGRADE', 'SECURITY', 'LICENSE', 'COPYING',
+    ];
+
     public function __construct(
         private readonly BuildConfig $config,
         private readonly string $projectRoot,
@@ -71,9 +75,9 @@ final class PackageBuilder
         $outputPath = $outputDir . '/' . $outputName;
 
         // Replace any prior build artifact at this exact path. Unlike the
-        // legacy lib_cwmscripture script, we don't wipe the entire dist dir
-        // (that's destructive to unrelated zips); leftover artifacts are
-        // gitignored anyway.
+        // legacy lib_cwmscripture/proclaim_build scripts, we don't wipe the
+        // entire dist dir (that's destructive to unrelated zips); leftover
+        // artifacts are gitignored anyway.
         if (file_exists($outputPath)) {
             unlink($outputPath);
         }
@@ -101,7 +105,7 @@ final class PackageBuilder
         }
 
         foreach ($this->config->sources as $src) {
-            $this->addDirectory($zip, $this->resolve($src['from']), $src['to'], $this->config->excludes);
+            $this->addDirectory($zip, $this->resolve($src['from']), $src['to']);
         }
 
         $fileCount = $zip->numFiles;
@@ -133,24 +137,57 @@ final class PackageBuilder
     }
 
     /**
-     * Run the configured pre-build gate.
+     * Run the configured pre-build hook.
      *
-     * `ensure-minified` is the only mode currently supported. For each listed
-     * directory, every `<name>.<ext>` that isn't already a `.min.<ext>` must
-     * have a corresponding `<name>.min.<ext>` sibling, otherwise the build
-     * fails with a hint to run the project's build step.
+     * Modes:
+     *   - `ensure-minified` — gate on presence of `*.min.{ext}` siblings.
+     *   - `run` — passthru a shell command (Proclaim's auto `npm run build`).
      *
-     * @param array{mode: string, dirs?: list<string>} $preBuild
+     * @param array{mode: string, dirs?: list<string>, command?: string} $preBuild
      */
     private function runPreBuild(array $preBuild): void
     {
-        if ($preBuild['mode'] !== 'ensure-minified') {
+        if ($preBuild['mode'] === 'ensure-minified') {
+            $this->ensureMinifiedAssets($preBuild['dirs'] ?? []);
+
             return;
         }
 
+        if ($preBuild['mode'] === 'run') {
+            $command = (string) ($preBuild['command'] ?? '');
+
+            // BuildConfig validates this, but defense in depth.
+            if (trim($command) === '') {
+                throw new \RuntimeException('preBuild.mode "run" requires a non-empty command');
+            }
+
+            // The command may use shell features (&&, env vars, redirects) — passthru
+            // gives the user live progress output. Per CLAUDE.md the build config is
+            // trusted (committed by the project author), so the shell semantics are OK.
+            echo "Running pre-build: $command\n";
+
+            $exitCode = 0;
+            passthru($command, $exitCode);
+
+            if ($exitCode !== 0) {
+                throw new \RuntimeException("Pre-build command failed with exit $exitCode");
+            }
+
+            echo "\n";
+        }
+    }
+
+    /**
+     * For each listed dir, every `<name>.<ext>` that isn't already a `.min.<ext>`
+     * must have a corresponding `<name>.min.<ext>` sibling.
+     *
+     * @param list<string> $dirs
+     */
+    private function ensureMinifiedAssets(array $dirs): void
+    {
         $missing = [];
 
-        foreach ($preBuild['dirs'] ?? [] as $relDir) {
+        foreach ($dirs as $relDir) {
             $absDir = $this->resolve($relDir);
 
             if (!is_dir($absDir)) {
@@ -170,7 +207,6 @@ final class PackageBuilder
 
                 $ext = $m[1];
 
-                // Already a minified version — skip.
                 if (str_ends_with($entry, '.min.' . $ext)) {
                     continue;
                 }
@@ -197,10 +233,8 @@ final class PackageBuilder
 
     /**
      * Walk a source directory and add its files to the zip under $zipPrefix.
-     *
-     * @param list<string> $excludes
      */
-    private function addDirectory(ZipArchive $zip, string $sourcePath, string $zipPrefix, array $excludes): void
+    private function addDirectory(ZipArchive $zip, string $sourcePath, string $zipPrefix): void
     {
         if (!is_dir($sourcePath)) {
             echo "  SKIP: $sourcePath (not found)\n";
@@ -224,10 +258,12 @@ final class PackageBuilder
                 continue;
             }
 
-            $filePath     = $file->getRealPath();
-            $relativePath = substr($filePath, strlen($sourceReal) + 1);
+            $filePath = $file->getRealPath();
+            // Normalize separators to forward-slash so cross-platform
+            // patterns and globs match on Windows too.
+            $relativePath = str_replace('\\', '/', substr($filePath, strlen($sourceReal) + 1));
 
-            if (self::matchesExclude($relativePath, $excludes)) {
+            if (!$this->shouldInclude($relativePath)) {
                 continue;
             }
 
@@ -239,17 +275,130 @@ final class PackageBuilder
     }
 
     /**
-     * @param list<string> $excludes
+     * Decide whether a file (by its source-relative path) lands in the zip.
+     *
+     * Excludes are checked first, then includes (when configured). When
+     * `includeRoots` and `includeRootExtensions` are both empty (the default
+     * lib_cwmscripture shape), everything not explicitly excluded is included.
      */
-    private static function matchesExclude(string $path, array $excludes): bool
+    private function shouldInclude(string $relativePath): bool
     {
-        foreach ($excludes as $pattern) {
-            if ($pattern !== '' && str_contains($path, $pattern)) {
+        if ($this->matchesExcludes($relativePath)) {
+            return false;
+        }
+
+        if ($this->config->includeRoots === [] && $this->config->includeRootExtensions === []) {
+            return true;
+        }
+
+        return $this->matchesIncludes($relativePath);
+    }
+
+    /**
+     * Apply every configured exclusion rule against the relative path.
+     *
+     * Order: excludeMatchMode list → excludeExtensions → excludePaths globs →
+     * vendorPrune. Any match short-circuits to `true`.
+     */
+    private function matchesExcludes(string $relativePath): bool
+    {
+        foreach ($this->config->excludes as $pattern) {
+            if ($pattern === '') {
+                continue;
+            }
+
+            if ($this->config->excludeMatchMode === BuildConfig::MATCH_STRICT) {
+                if (self::matchesStrict($relativePath, $pattern)) {
+                    return true;
+                }
+            } elseif (str_contains($relativePath, $pattern)) {
+                return true;
+            }
+        }
+
+        if ($this->config->excludeExtensions !== []) {
+            $ext = pathinfo($relativePath, PATHINFO_EXTENSION);
+
+            if ($ext !== '' && in_array($ext, $this->config->excludeExtensions, true)) {
+                return true;
+            }
+        }
+
+        foreach ($this->config->excludePaths as $glob) {
+            if ($glob !== '' && fnmatch($glob, $relativePath)) {
+                return true;
+            }
+        }
+
+        if ($this->config->vendorPrune && str_contains($relativePath, '/vendor/')) {
+            $basename = basename($relativePath);
+
+            if ($basename === 'installed.json' || $basename === 'installed.php') {
+                return true;
+            }
+
+            $upper = strtoupper(pathinfo($basename, PATHINFO_FILENAME));
+
+            if (in_array($upper, self::VENDOR_PRUNE_DOC_NAMES, true)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * Strict 4-mode pattern match: exact, prefix-with-slash, contained-with-slashes,
+     * suffix-after-slash. Matches Proclaim's `proclaim_build.php` semantics.
+     */
+    private static function matchesStrict(string $path, string $pattern): bool
+    {
+        $clean = rtrim($pattern, '/');
+
+        if ($clean === '') {
+            return false;
+        }
+
+        if ($path === $clean) {
+            return true;
+        }
+
+        if (str_starts_with($path, $clean . '/')) {
+            return true;
+        }
+
+        if (str_contains($path, '/' . $clean . '/')) {
+            return true;
+        }
+
+        return str_ends_with($path, '/' . $clean);
+    }
+
+    /**
+     * Apply the include filter: at least one of (a) the path starts with a
+     * configured root prefix, or (b) the file is at the source root and has
+     * an extension on the root-extensions allowlist.
+     */
+    private function matchesIncludes(string $relativePath): bool
+    {
+        foreach ($this->config->includeRoots as $root) {
+            if ($root !== '' && str_starts_with($relativePath, $root)) {
+                return true;
+            }
+        }
+
+        if ($this->config->includeRootExtensions === []) {
+            return false;
+        }
+
+        // Root-level files only — those with no '/' in the source-relative path.
+        if (str_contains($relativePath, '/')) {
+            return false;
+        }
+
+        $ext = pathinfo($relativePath, PATHINFO_EXTENSION);
+
+        return $ext !== '' && in_array($ext, $this->config->includeRootExtensions, true);
     }
 
     private function log(string $line): void

--- a/tests/Build/PackageBuilderTest.php
+++ b/tests/Build/PackageBuilderTest.php
@@ -219,6 +219,258 @@ PHP;
         ]);
     }
 
+    // --- PR C: strict-mode excludes, vendor prune, include filter, run pre-build ---
+
+    #[Test]
+    public function strictModeMatchesAllFourPositionsForOnePattern(): void
+    {
+        // Files Proclaim's exact 4-mode logic must catch with a single ".git" entry.
+        $this->writeManifest('proclaim.xml', '10.3.2');
+        $this->writeFile('admin/index.html', '');                    // included
+        $this->writeFile('.git/HEAD', '');                            // exact (root prefix '.git/')
+        $this->writeFile('admin/.git/HEAD', '');                      // contained '/.git/'
+        $this->writeFile('admin/sub/.git', '');                       // suffix '/.git'
+        $this->writeFile('libraries/.git/x.txt', '');                 // contained
+        // A path that contains "git" but not as a directory boundary should NOT be excluded.
+        $this->writeFile('admin/widget.html', '');                    // included (contains 'git' but not in 4-mode)
+
+        $builder = new PackageBuilder($this->makeProclaimConfig(['.git']), $this->tmpDir);
+        $this->expectOutputRegex('/Building com_proclaim-10\.3\.2\.zip/');
+        $zip = $builder->build();
+
+        $entries = $this->zipEntries($zip);
+        $this->assertContains('admin/index.html', $entries);
+        $this->assertContains('admin/widget.html', $entries);
+        $this->assertNotContains('.git/HEAD', $entries);
+        $this->assertNotContains('admin/.git/HEAD', $entries);
+        $this->assertNotContains('admin/sub/.git', $entries);
+        $this->assertNotContains('libraries/.git/x.txt', $entries);
+    }
+
+    #[Test]
+    public function strictModeDoesNotOvermatchSubstrings(): void
+    {
+        // Pattern 'git' under contains-mode would match 'admin/widget.html' (contains "git").
+        // Strict mode should NOT — strict requires '/git/' or '/git' or 'git/' or exact 'git'.
+        $this->writeManifest('proclaim.xml', '1.0.0');
+        $this->writeFile('admin/widget.html', '');
+        $this->writeFile('admin/git/HEAD', '');
+
+        $builder = new PackageBuilder($this->makeProclaimConfig(['git']), $this->tmpDir);
+        $this->expectOutputRegex('/Package built/');
+        $zip = $builder->build();
+
+        $entries = $this->zipEntries($zip);
+        $this->assertContains('admin/widget.html', $entries);
+        $this->assertNotContains('admin/git/HEAD', $entries);
+    }
+
+    #[Test]
+    public function excludeExtensionsDropsMapFiles(): void
+    {
+        $this->writeManifest('proclaim.xml', '1.0.0');
+        $this->writeFile('admin/script.js', '');
+        $this->writeFile('admin/script.js.map', '');
+        $this->writeFile('media/foo.css', '');
+        $this->writeFile('media/foo.css.map', '');
+
+        $builder = new PackageBuilder(
+            $this->makeProclaimConfig([], ['excludeExtensions' => ['map']]),
+            $this->tmpDir
+        );
+        $this->expectOutputRegex('/Package built/');
+        $zip = $builder->build();
+
+        $entries = $this->zipEntries($zip);
+        $this->assertContains('admin/script.js', $entries);
+        $this->assertContains('media/foo.css', $entries);
+        $this->assertNotContains('admin/script.js.map', $entries);
+        $this->assertNotContains('media/foo.css.map', $entries);
+    }
+
+    #[Test]
+    public function excludePathsGlobMatchesBackupSqlFiles(): void
+    {
+        // The exact rule Proclaim's existing script bakes in (lines 277-279).
+        $this->writeManifest('proclaim.xml', '1.0.0');
+        $this->writeFile('media/backup/db.sql', '-- DDL');
+        $this->writeFile('media/backup/sub/old.sql', '-- DDL');
+        $this->writeFile('media/keep.sql', '-- KEEP');
+
+        $builder = new PackageBuilder(
+            $this->makeProclaimConfig([], ['excludePaths' => ['media/backup/*.sql']]),
+            $this->tmpDir
+        );
+        $this->expectOutputRegex('/Package built/');
+        $zip = $builder->build();
+
+        $entries = $this->zipEntries($zip);
+        $this->assertContains('media/keep.sql', $entries);
+        $this->assertNotContains('media/backup/db.sql', $entries);
+        $this->assertNotContains('media/backup/sub/old.sql', $entries);
+    }
+
+    #[Test]
+    public function vendorPruneDropsComposerMetadataAndDocs(): void
+    {
+        $this->writeManifest('proclaim.xml', '1.0.0');
+        $this->writeFile('libraries/vendor/composer/installed.json', '{}');
+        $this->writeFile('libraries/vendor/composer/installed.php', '<?php');
+        $this->writeFile('libraries/vendor/symfony/dependency/README.md', '# readme');
+        $this->writeFile('libraries/vendor/symfony/dependency/CHANGELOG.md', '# changelog');
+        $this->writeFile('libraries/vendor/symfony/dependency/LICENSE', 'mit');
+        $this->writeFile('libraries/vendor/symfony/dependency/src/X.php', '<?php // keep');
+        // README outside vendor — must be kept (vendorPrune only acts on vendor subtrees).
+        $this->writeFile('libraries/README.md', 'lib readme');
+
+        $builder = new PackageBuilder(
+            $this->makeProclaimConfig([], ['vendorPrune' => true]),
+            $this->tmpDir
+        );
+        $this->expectOutputRegex('/Package built/');
+        $zip = $builder->build();
+
+        $entries = $this->zipEntries($zip);
+        $this->assertContains('libraries/vendor/symfony/dependency/src/X.php', $entries);
+        $this->assertContains('libraries/README.md', $entries);
+        $this->assertNotContains('libraries/vendor/composer/installed.json', $entries);
+        $this->assertNotContains('libraries/vendor/composer/installed.php', $entries);
+        $this->assertNotContains('libraries/vendor/symfony/dependency/README.md', $entries);
+        $this->assertNotContains('libraries/vendor/symfony/dependency/CHANGELOG.md', $entries);
+        $this->assertNotContains('libraries/vendor/symfony/dependency/LICENSE', $entries);
+    }
+
+    #[Test]
+    public function includeRootsFilterDropsPathsOutsideAllowlist(): void
+    {
+        $this->writeManifest('proclaim.xml', '1.0.0');
+        $this->writeFile('admin/x.php', '<?php');
+        $this->writeFile('media/y.css', '');
+        $this->writeFile('libraries/z.php', '<?php');
+        // Not in any allowlisted root and not a root-level allowlist-ext file:
+        $this->writeFile('docs/architecture.md', '# arch');
+        $this->writeFile('scratch/temp.txt', 'tmp');
+
+        $builder = new PackageBuilder(
+            $this->makeProclaimConfig([], [
+                'includeRoots' => ['admin/', 'media/', 'libraries/'],
+            ]),
+            $this->tmpDir
+        );
+        $this->expectOutputRegex('/Package built/');
+        $zip = $builder->build();
+
+        $entries = $this->zipEntries($zip);
+        $this->assertContains('admin/x.php', $entries);
+        $this->assertContains('media/y.css', $entries);
+        $this->assertContains('libraries/z.php', $entries);
+        $this->assertNotContains('docs/architecture.md', $entries);
+        $this->assertNotContains('scratch/temp.txt', $entries);
+    }
+
+    #[Test]
+    public function includeRootExtensionsAdmitsAllowlistedRootFiles(): void
+    {
+        $this->writeManifest('proclaim.xml', '1.0.0');
+        $this->writeFile('admin/x.php', '<?php');
+        // Root-level files: only the allowlisted extensions should land in zip.
+        // (proclaim.xml is the manifest — it lands at zip root through the
+        // dedicated manifest path, not the source walk; tested elsewhere.)
+        $this->writeFile('LICENSE.txt', 'GPL2');
+        $this->writeFile('README.md', '# readme');
+        $this->writeFile('package.json', '{}');                        // .json not allowed
+        $this->writeFile('docs.html', '<html/>');                       // .html not allowed
+
+        $builder = new PackageBuilder(
+            $this->makeProclaimConfig([], [
+                'includeRoots'          => ['admin/'],
+                'includeRootExtensions' => ['xml', 'txt', 'md'],
+            ]),
+            $this->tmpDir
+        );
+        $this->expectOutputRegex('/Package built/');
+        $zip = $builder->build();
+
+        $entries = $this->zipEntries($zip);
+        $this->assertContains('admin/x.php', $entries);
+        $this->assertContains('LICENSE.txt', $entries);
+        $this->assertContains('README.md', $entries);
+        $this->assertNotContains('package.json', $entries);
+        $this->assertNotContains('docs.html', $entries);
+    }
+
+    #[Test]
+    public function runModePreBuildExecutesCommand(): void
+    {
+        $this->writeManifest('proclaim.xml', '1.0.0');
+        $this->writeFile('admin/x.php', '<?php');
+
+        // Echo a sentinel into a marker file we can assert was created.
+        $marker = $this->tmpDir . '/_marker.txt';
+        $cmd    = 'printf hello > ' . escapeshellarg($marker);
+
+        $builder = new PackageBuilder(
+            $this->makeProclaimConfig([], [
+                'preBuild' => ['mode' => 'run', 'command' => $cmd],
+            ]),
+            $this->tmpDir
+        );
+        $this->expectOutputRegex('/Running pre-build:/');
+        $builder->build();
+
+        $this->assertFileExists($marker);
+        $this->assertSame('hello', file_get_contents($marker));
+    }
+
+    #[Test]
+    public function runModePreBuildAbortsOnNonZeroExit(): void
+    {
+        $this->writeManifest('proclaim.xml', '1.0.0');
+        $this->writeFile('admin/x.php', '<?php');
+
+        $builder = new PackageBuilder(
+            $this->makeProclaimConfig([], [
+                'preBuild' => ['mode' => 'run', 'command' => 'false'],
+            ]),
+            $this->tmpDir
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Pre-build command failed');
+        $this->expectOutputRegex('/Running pre-build/');
+        $builder->build();
+    }
+
+    #[Test]
+    public function buildConfigRejectsRunPreBuildWithoutCommand(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('build.preBuild.command is required when mode is "run"');
+
+        BuildConfig::fromArray([
+            'outputDir'  => 'build/dist',
+            'outputName' => 'foo-{version}.zip',
+            'manifest'   => 'foo.xml',
+            'sources'    => [['from' => 'src', 'to' => 'src']],
+            'preBuild'   => ['mode' => 'run'],
+        ]);
+    }
+
+    #[Test]
+    public function buildConfigRejectsInvalidExcludeMatchMode(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('build.excludeMatchMode');
+
+        BuildConfig::fromArray([
+            'outputDir'        => 'build/dist',
+            'outputName'       => 'foo-{version}.zip',
+            'manifest'         => 'foo.xml',
+            'sources'          => [['from' => 'src', 'to' => 'src']],
+            'excludeMatchMode' => 'fuzzy',
+        ]);
+    }
+
     // --- Helpers ---
 
     /**
@@ -248,6 +500,28 @@ PHP;
     private function makeLibConfig(): BuildConfig
     {
         return BuildConfig::fromArray($this->libConfigArray());
+    }
+
+    /**
+     * Build a Proclaim-shape BuildConfig: walks the project root (`from: '.'`)
+     * with strict-mode 4-mode excludes. Tests pass `$excludes` as positional
+     * (the most-tweaked field) and `$overrides` for the rest.
+     *
+     * @param  list<string>          $excludes
+     * @param  array<string, mixed>  $overrides
+     */
+    private function makeProclaimConfig(array $excludes = [], array $overrides = []): BuildConfig
+    {
+        $base = [
+            'outputDir'        => 'build/dist',
+            'outputName'       => 'com_proclaim-{version}.zip',
+            'manifest'         => 'proclaim.xml',
+            'sources'          => [['from' => '.', 'to' => '']],
+            'excludes'         => $excludes,
+            'excludeMatchMode' => 'strict',
+        ];
+
+        return BuildConfig::fromArray(array_merge($base, $overrides));
     }
 
     private function writeManifest(string $relPath, string $version): void

--- a/tests/Build/PackageBuilderTest.php
+++ b/tests/Build/PackageBuilderTest.php
@@ -1,0 +1,322 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Build;
+
+use CWM\BuildTools\Build\BuildConfig;
+use CWM\BuildTools\Build\PackageBuilder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ZipArchive;
+
+/**
+ * End-to-end tests that build a real zip from a temp fixture project and
+ * assert its contents — the only meaningful coverage for a script whose
+ * job is producing a correct on-disk artifact.
+ */
+final class PackageBuilderTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/cwm-build-test-' . uniqid('', true);
+        mkdir($this->tmpDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->rrmdir($this->tmpDir);
+    }
+
+    #[Test]
+    public function buildsLibCwmscriptureShape(): void
+    {
+        $this->writeManifest('cwmscripture.xml', '1.2.0');
+        $this->writeFile('script.php', '<?php // install hook');
+        $this->writeFile('src/Service/Foo.php', '<?php // foo');
+        $this->writeFile('src/Service/Bar.php', '<?php // bar');
+        $this->writeFile('sql/install.mysql.utf8.sql', '-- DDL');
+        $this->writeFile('language/en-GB/en-GB.lib_cwmscripture.ini', '');
+        $this->writeFile('media/lib_cwmscripture/js/foo.js', 'console.log("foo");');
+        $this->writeFile('media/lib_cwmscripture/js/foo.min.js', 'console.log("foo")');
+        $this->writeFile('media/lib_cwmscripture/css/foo.css', '.foo{}');
+        $this->writeFile('media/lib_cwmscripture/css/foo.min.css', '.foo{}');
+        // Excluded entries — should NOT end up in zip.
+        $this->writeFile('src/.DS_Store', '');
+        $this->writeFile('src/node_modules/x/index.js', '');
+
+        $builder = new PackageBuilder($this->makeLibConfig(), $this->tmpDir);
+
+        $this->expectOutputRegex('/Building lib_cwmscripture-1\.2\.0\.zip \(v1\.2\.0\)/');
+
+        $zipPath = $builder->build();
+
+        $this->assertSame($this->tmpDir . '/build/dist/lib_cwmscripture-1.2.0.zip', $zipPath);
+        $this->assertFileExists($zipPath);
+
+        $entries = $this->zipEntries($zipPath);
+
+        $this->assertContains('cwmscripture.xml', $entries);
+        $this->assertContains('script.php', $entries);
+        $this->assertContains('lib_cwmscripture/src/Service/Foo.php', $entries);
+        $this->assertContains('lib_cwmscripture/src/Service/Bar.php', $entries);
+        $this->assertContains('lib_cwmscripture/sql/install.mysql.utf8.sql', $entries);
+        $this->assertContains('lib_cwmscripture/language/en-GB/en-GB.lib_cwmscripture.ini', $entries);
+        $this->assertContains('media/lib_cwmscripture/js/foo.js', $entries);
+        $this->assertContains('media/lib_cwmscripture/js/foo.min.js', $entries);
+
+        $this->assertNotContains('src/.DS_Store', $entries);
+        $this->assertNotContains('lib_cwmscripture/src/.DS_Store', $entries);
+        // node_modules anywhere in the path is excluded by the substring match.
+        foreach ($entries as $entry) {
+            $this->assertStringNotContainsString('node_modules', $entry);
+            $this->assertStringNotContainsString('.DS_Store', $entry);
+        }
+    }
+
+    #[Test]
+    public function omitsScriptFileWhenAbsent(): void
+    {
+        $this->writeManifest('cwmscripture.xml', '1.0.0');
+        $this->writeFile('src/Foo.php', '<?php');
+
+        $builder = new PackageBuilder($this->makeLibConfig(), $this->tmpDir);
+
+        $this->expectOutputRegex('/Building lib_cwmscripture-1\.0\.0\.zip/');
+
+        $zipPath = $builder->build();
+        $entries = $this->zipEntries($zipPath);
+
+        $this->assertNotContains('script.php', $entries);
+        $this->assertContains('cwmscripture.xml', $entries);
+    }
+
+    #[Test]
+    public function versionOverrideTakesPrecedenceOverManifest(): void
+    {
+        $this->writeManifest('cwmscripture.xml', '1.0.0');
+        $this->writeFile('src/Foo.php', '<?php');
+
+        $builder = new PackageBuilder($this->makeLibConfig(), $this->tmpDir);
+
+        $this->expectOutputRegex('/Building lib_cwmscripture-9\.9\.9\.zip \(v9\.9\.9\)/');
+
+        $zipPath = $builder->build('9.9.9');
+
+        $this->assertSame($this->tmpDir . '/build/dist/lib_cwmscripture-9.9.9.zip', $zipPath);
+    }
+
+    #[Test]
+    public function ensureMinifiedGateFailsWhenSiblingMissing(): void
+    {
+        $this->writeManifest('cwmscripture.xml', '1.0.0');
+        $this->writeFile('src/Foo.php', '<?php');
+        $this->writeFile('media/lib_cwmscripture/js/foo.js', 'console.log');
+        // foo.min.js intentionally missing.
+
+        $builder = new PackageBuilder($this->makeLibConfig(), $this->tmpDir);
+
+        $exitCode = -1;
+        $stderr   = '';
+
+        // Capture exit() via a child process — preg flag the missing-min message.
+        $script = <<<'PHP'
+<?php
+require '%s/src/Build/BuildConfig.php';
+require '%s/src/Build/ManifestReader.php';
+require '%s/src/Build/PackageBuilder.php';
+$cfg = CWM\BuildTools\Build\BuildConfig::fromArray(%s);
+$b   = new CWM\BuildTools\Build\PackageBuilder($cfg, '%s');
+$b->build();
+PHP;
+
+        $cwm   = realpath(__DIR__ . '/../..');
+        $cfg   = var_export($this->libConfigArray(), true);
+        $proj  = $this->tmpDir;
+        $code  = sprintf($script, $cwm, $cwm, $cwm, $cfg, $proj);
+        $tmpPhp = $this->tmpDir . '/_run.php';
+        file_put_contents($tmpPhp, $code);
+
+        $proc = proc_open(
+            ['php', $tmpPhp],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes
+        );
+
+        if (!is_resource($proc)) {
+            $this->fail('Could not spawn child PHP for gate test');
+        }
+
+        fclose($pipes[0] ?? STDIN);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($proc);
+
+        $this->assertSame(1, $exitCode, 'Gate failure should exit with 1');
+        $this->assertStringContainsString('missing minified assets', (string) $stderr);
+        $this->assertStringContainsString('foo.min.js', (string) $stderr);
+    }
+
+    #[Test]
+    public function ensureMinifiedGatePassesWhenAllPairsPresent(): void
+    {
+        $this->writeManifest('cwmscripture.xml', '1.0.0');
+        $this->writeFile('src/Foo.php', '<?php');
+        $this->writeFile('media/lib_cwmscripture/js/foo.js', 'console.log');
+        $this->writeFile('media/lib_cwmscripture/js/foo.min.js', 'console.log');
+        $this->writeFile('media/lib_cwmscripture/css/foo.css', '.foo{}');
+        $this->writeFile('media/lib_cwmscripture/css/foo.min.css', '.foo{}');
+
+        $builder = new PackageBuilder($this->makeLibConfig(), $this->tmpDir);
+
+        $this->expectOutputRegex('/Package built/');
+        $zipPath = $builder->build();
+        $this->assertFileExists($zipPath);
+    }
+
+    #[Test]
+    public function buildConfigRejectsMissingRequired(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('build.outputDir is required');
+
+        BuildConfig::fromArray([
+            'outputName' => 'foo-{version}.zip',
+            'manifest'   => 'foo.xml',
+            'sources'    => [['from' => 'src', 'to' => 'src']],
+        ]);
+    }
+
+    #[Test]
+    public function buildConfigRejectsEmptySources(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('build.sources is required');
+
+        BuildConfig::fromArray([
+            'outputDir'  => 'build/dist',
+            'outputName' => 'foo-{version}.zip',
+            'manifest'   => 'foo.xml',
+            'sources'    => [],
+        ]);
+    }
+
+    #[Test]
+    public function buildConfigRejectsUnknownPreBuildMode(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('build.preBuild.mode');
+
+        BuildConfig::fromArray([
+            'outputDir'  => 'build/dist',
+            'outputName' => 'foo-{version}.zip',
+            'manifest'   => 'foo.xml',
+            'sources'    => [['from' => 'src', 'to' => 'src']],
+            'preBuild'   => ['mode' => 'autorun'],
+        ]);
+    }
+
+    // --- Helpers ---
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function libConfigArray(): array
+    {
+        return [
+            'outputDir'  => 'build/dist',
+            'outputName' => 'lib_cwmscripture-{version}.zip',
+            'manifest'   => 'cwmscripture.xml',
+            'scriptFile' => 'script.php',
+            'sources'    => [
+                ['from' => 'src', 'to' => 'lib_cwmscripture/src'],
+                ['from' => 'sql', 'to' => 'lib_cwmscripture/sql'],
+                ['from' => 'language', 'to' => 'lib_cwmscripture/language'],
+                ['from' => 'media/lib_cwmscripture', 'to' => 'media/lib_cwmscripture'],
+            ],
+            'excludes'   => ['.git', '.DS_Store', '.idea', 'node_modules', '.php-cs-fixer.cache'],
+            'preBuild'   => [
+                'mode' => 'ensure-minified',
+                'dirs' => ['media/lib_cwmscripture/js', 'media/lib_cwmscripture/css'],
+            ],
+        ];
+    }
+
+    private function makeLibConfig(): BuildConfig
+    {
+        return BuildConfig::fromArray($this->libConfigArray());
+    }
+
+    private function writeManifest(string $relPath, string $version): void
+    {
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<extension type="library" method="upgrade">
+    <name>CWM Scripture</name>
+    <version>$version</version>
+    <creationDate>2026-05-09</creationDate>
+</extension>
+XML;
+        $this->writeFile($relPath, $xml);
+    }
+
+    private function writeFile(string $relPath, string $content): void
+    {
+        $abs = $this->tmpDir . '/' . $relPath;
+        $dir = dirname($abs);
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0o777, true);
+        }
+
+        file_put_contents($abs, $content);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function zipEntries(string $zipPath): array
+    {
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($zipPath) === true, "Could not open $zipPath");
+
+        $entries = [];
+
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $entries[] = (string) $zip->getNameIndex($i);
+        }
+
+        $zip->close();
+
+        return $entries;
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $entries = scandir($dir) ?: [];
+
+        foreach ($entries as $e) {
+            if ($e === '.' || $e === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $e;
+
+            if (is_link($path) || is_file($path)) {
+                @unlink($path);
+                continue;
+            }
+
+            $this->rrmdir($path);
+        }
+
+        @rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary

**PR C of 5** for issue #5. Extends `cwm-build` (PR B, #13) to cover the bespoke filtering and auto-pre-build behavior in Proclaim's `proclaim_build.php`. **Defaults preserve PR B (lib_cwmscripture) shape; every new field is opt-in.**

> ⚠️ **Stacked on PR B (#13).** Diff base is `feat/cwm-build-binary` so the commit shows only PR C's additions. Merge order: PR B first, then this PR rebases automatically onto main.

## What's new in the `build:` schema

| Field | Effect |
|---|---|
| `excludeMatchMode: "strict"` | 4-mode match (exact / prefix-with-slash / contained-with-slashes / suffix-after-slash). Catches `.git` at any depth without over-matching "git" inside unrelated filenames the way `str_contains` does. Default `"contains"`. |
| `excludeExtensions: ["map"]` | Bare extension list; matching files dropped at any path. |
| `excludePaths: ["media/backup/*.sql"]` | `fnmatch` glob patterns vs the relative path. Covers Proclaim's existing `media/backup/*.sql` rule. |
| `vendorPrune: true` | Drops `installed.json`/`installed.php` and `README*`/`CHANGELOG*`/`BACKERS*`/`AUTHORS*`/`CONTRIBUTING*`/`UPGRADE*`/`SECURITY*`/`LICENSE*`/`COPYING*` (case-insensitive stem match) inside any `vendor/` subtree. Files outside vendor stay. |
| `includeRoots: ["admin/", "media/", "modules/", "plugins/", "site/", "libraries/"]` | Subdirectory allowlist; only files starting with one of these prefixes are admitted. |
| `includeRootExtensions: ["php", "xml", "txt", "md"]` | Root-level (no `/` in path) files with one of these extensions get admitted through the include filter (Proclaim's `LICENSE.txt`, `README.md` at project root). |
| `preBuild.mode: "run"` + `preBuild.command` | Auto-execute a shell command via `passthru` before the zip walk; non-zero exit aborts the build. Matches Proclaim's auto `npm install && npm run build`. |

## Implementation notes

- **Faithful port of Proclaim's logic** (proclaim_build.php lines 240-300), including the precedence: exclude-list → `excludeExtensions` → `excludePaths` → `vendorPrune` → `includeRoots` → `includeRootExtensions`.
- **Strict-mode pattern match** = 4 substring checks against `relativePath`:
  - exact: `path === pattern`
  - prefix: `path startsWith "pattern/"`
  - contained: `path contains "/pattern/"`
  - suffix: `path endsWith "/pattern"`
- **`passthru` for run-mode pre-build**: build config is trusted (committed by the project author) per CLAUDE.md threat model, so spawning a shell with the `&&`/redirect/env-var feature surface is OK. Non-zero exit throws a `RuntimeException` so the caller sees the failure.
- **Path normalization to forward slash** in `addDirectory` for cross-platform glob matching (Windows path separators normalized before pattern check).

## Tests

11 new unit tests, 56 new assertions (48 → 59 / 151 → 207):

| Test | What it asserts |
|---|---|
| `strictModeMatchesAllFourPositionsForOnePattern` | Single `.git` exclude catches it as exact root, contained subpath, suffix end. |
| `strictModeDoesNotOvermatchSubstrings` | Pattern `git` doesn't drop `admin/widget.html` (contains-mode would; strict won't). |
| `excludeExtensionsDropsMapFiles` | `.map` siblings of `.js`/`.css` excluded. |
| `excludePathsGlobMatchesBackupSqlFiles` | `media/backup/*.sql` glob drops backup SQL at any depth without touching `media/keep.sql`. |
| `vendorPruneDropsComposerMetadataAndDocs` | Composer metadata + README/CHANGELOG/LICENSE inside vendor dropped; same files outside vendor kept. |
| `includeRootsFilterDropsPathsOutsideAllowlist` | `docs/` and `scratch/` excluded when only `admin/`/`media/`/`libraries/` allow-listed. |
| `includeRootExtensionsAdmitsAllowlistedRootFiles` | Root-level `LICENSE.txt`/`README.md` admitted; `package.json`/`docs.html` not. |
| `runModePreBuildExecutesCommand` | Pre-build command runs and side-effects land (sentinel file written). |
| `runModePreBuildAbortsOnNonZeroExit` | `false` command throws `RuntimeException("Pre-build command failed")`. |
| `buildConfigRejectsRunPreBuildWithoutCommand` | Validation: `mode: "run"` requires non-empty `command`. |
| `buildConfigRejectsInvalidExcludeMatchMode` | Validation: `excludeMatchMode: "fuzzy"` rejected with helpful message. |

Smoke-tested via the CLI against a Proclaim-shape fixture project: 6 expected zip entries (manifest, root LICENSE.txt + README.md via `includeRootExtensions`, allowlisted-root content, vendor-pruned docs gone, `.map` and `media/backup/*.sql` and `package.json` and `node_modules/` and `build/` all correctly excluded).

## What's deferred

The interactive **3-way version prompt** (Proclaim's XML version / date version / custom choice) needs `Build\Prompt` from PR A (#12). Will land as a small follow-up PR once both PR A and this one merge.

## Roadmap

| PR | Scope | Status |
|---|---|---|
| A — #12 | `Build\Prompt` extraction | open |
| B — #13 | `cwm-build` for lib_cwmscripture's shape | open |
| **C — this PR** | Strict-mode excludes, vendor prune, include roots, run-mode preBuild | **this PR** |
| C′ (follow-up) | 3-way version prompt (depends on A + C) | not started |
| D | `cwm-package` with 4 `includes[]` types + `innerLayout` + opt-in self-verify | not started |
| E | Cut v0.5.0-alpha + migration guide | not started |

## Test plan

- [x] `composer test` — 59/59 passing, 207 assertions
- [x] CLI smoke test against a Proclaim-shape fixture (manifest + 13 source files; zip ends up with 6 expected entries; all 7 exclusion rules verified)
- [x] `git archive` dist verification — only the source files (no test fixtures shipped)
- [ ] Migrate Proclaim to call `cwm-build` (separate PR in Proclaim repo) and `diff -r` the resulting zip against the legacy script's output

Refs #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)