### PR TITLE
feat(package): cwm-package binary with 4 includes[] types — PR D of #5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `cwm-build` binary + `scripts/build.php` + `src/Build/PackageBuilder` +
+  `src/Build/BuildConfig` — generic Joomla extension zip builder driven by a
+  `build:` block in `cwm-build.config.json`. Phase 1 covers the
+  lib_cwmscripture build shape: read manifest version, optionally gate on
+  presence of `*.min.{js,css}` siblings (`preBuild.mode: "ensure-minified"`),
+  walk one or more source directories with a per-source zip-path prefix, apply
+  loose `str_contains` excludes. CLI flags `-v`/`--verbose`, `--version <ver>`
+  override, `--help`. New schema fields: `build.outputDir`, `outputName`
+  (supports `{version}`), `manifest`, `scriptFile`, `sources[]`, `excludes`,
+  `preBuild`. Coexists with the existing `build.command` / `build.outputGlob`
+  fields used by `cwm-release` — consumers migrate by setting
+  `build.command: "cwm-build"`. Strict-mode filtering, vendor pruning, auto-
+  run pre-build, and the interactive 3-way version prompt land in subsequent
+  PRs (still part of #5). 8 new unit tests / 39 assertions covering the
+  end-to-end build, version override, gate pass/fail, and config validation.
+
 - `templates/build-assets.js` — generic version of Proclaim's
   `build/build-assets.js` that copies images, mirrors a manually-managed
   vendor source tree, and cherry-picks files/dirs out of npm packages in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `cwm-package` rewritten — replaces the prior thin shell-pass-through wrapper
+  (`bash -c $build.command`) with a generic Joomla multi-extension package
+  assembler driven by a new `package:` block in `cwm-build.config.json`. New
+  classes: `src/Build/PackageConfig` and `src/Build/Packager`; CLI script
+  `scripts/package.php`. Supports four `includes[]` entry types:
+  - `self` — invoke `cwm-build` on the project's own `build:` block, then
+    bundle the result. Handles Proclaim's "step 3: build com_proclaim".
+  - `subBuild` — array-form `proc_open` of `php <buildScript> [args]` inside
+    `path`, then glob `distGlob` (relative to `path`) for the produced zip.
+    Handles Proclaim's two `passthru('php …/build-package.php …')` calls
+    (including the `--plugin-only` arg) during transition while sub-extensions
+    still ship their own scripts.
+  - `prebuilt` — assume already on disk; glob `distGlob` (project-relative).
+    Multiple matches → most-recently modified wins.
+  - `inline` — nested `BuildConfig`-shaped block; cwm-build runs in-process
+    on it. Handles CSL's `plg_task_cwmscripture` (a sibling directory built
+    in-process).
+
+  Other features: `innerLayout` (`"root"` for outer-zip entries at root vs
+  `"packages-prefix"` for `packages/<outputName>` paths — Proclaim's layout),
+  optional `installer` scriptfile, `languageFiles[]` with explicit `from`/`to`
+  paths, opt-in `verify.expectedEntries[]` self-check (CSL's verifyPackage
+  feature). Staging dir is a unique scratch dir under `sys_get_temp_dir()`
+  cleaned up on success or failure (no shell-driven `rm -rf` calls; native
+  PHP recursion with `is_link()` guards per CLAUDE.md).
+
+  20 new unit tests / 79 assertions covering all 4 include types, both inner
+  layouts, version override, installer + language file placement, verify
+  pass/fail, and config validation (required fields, invalid type, invalid
+  layout, subBuild missing path, inline missing nested config). PR D of #5.
+
 - `cwm-build` binary + `scripts/build.php` + `src/Build/PackageBuilder` +
   `src/Build/BuildConfig` — generic Joomla extension zip builder driven by a
   `build:` block in `cwm-build.config.json`. Phase 1 covers the

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Across `Proclaim`, `lib_cwmscripture`, `CWMScriptureLinks`, and `plg_task_cwmscr
 
 | Surface | What | Where |
 |---|---|---|
-| **CLI tools** | `cwm-release`, `cwm-bump`, `cwm-package`, `cwm-sync-configs`, `cwm-sync-languages`, `cwm-ars-publish`, `cwm-changelog`, `cwm-article`, `cwm-init`, `cwm-setup`, `cwm-link`, `cwm-link-check`, `cwm-clean`, `cwm-verify`, `cwm-joomla-install`, `cwm-joomla-latest`, `cwm-joomla-cms-deps` | `bin/` |
+| **CLI tools** | `cwm-release`, `cwm-bump`, `cwm-build`, `cwm-package`, `cwm-sync-configs`, `cwm-sync-languages`, `cwm-ars-publish`, `cwm-changelog`, `cwm-article`, `cwm-init`, `cwm-setup`, `cwm-link`, `cwm-link-check`, `cwm-clean`, `cwm-verify`, `cwm-joomla-install`, `cwm-joomla-latest`, `cwm-joomla-cms-deps` | `bin/` |
 | **Scripts** | Generic 8-step release pipeline, multi-manifest version bumper, config syncer | `scripts/` |
 | **PHP library** | `ProjectConfig`, `ManifestReader`, `PackageBuilder`, `ArsPublisher`, `Bumper` | `src/` (PSR-4 `CWM\BuildTools\`) |
 | **Reusable GH Actions** | `joomla-package-ci.yml`, `joomla-library-ci.yml` (called via `workflow_call`) | `.github/workflows/` |

--- a/bin/cwm-build
+++ b/bin/cwm-build
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# cwm-build — build an installable Joomla extension zip from
+# cwm-build.config.json.
+#
+# Reads the `build:` block of cwm-build.config.json in the project root and
+# produces an installable zip under build.outputDir. See `cwm-build --help`
+# for full usage.
+#
+# Usage from a consuming project:
+#   composer cwm-build                       # full build
+#   composer cwm-build -- -v                 # verbose
+#   composer cwm-build -- --version 1.2.3    # override version
+#
+set -euo pipefail
+
+PROJECT_ROOT="$(pwd)"
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ ! -f "${PROJECT_ROOT}/cwm-build.config.json" ]; then
+    echo "Error: cwm-build.config.json not found in $PROJECT_ROOT"
+    echo "Run 'cwm-init' to scaffold one, or see"
+    echo "  ${TOOLS_DIR}/examples/ for reference configs."
+    exit 1
+fi
+
+exec php "${TOOLS_DIR}/scripts/build.php" "$@"

--- a/bin/cwm-package
+++ b/bin/cwm-package
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 #
-# cwm-package — invoke the project's build command from cwm-build.config.json.
+# cwm-package — assemble a multi-extension Joomla package zip from
+# cwm-build.config.json.
 #
-# This is a thin wrapper around build.command in the config file. The actual
-# zip-building logic stays project-specific for now (Phase 4 will introduce
-# a generic builder that can replace project-specific build-package.php
-# files where they're similar enough).
+# Reads the `package:` block of cwm-build.config.json in the project root
+# and assembles an installable wrapper zip with one or more child extension
+# zips. Supports four `includes[]` entry types (`self`, `subBuild`,
+# `prebuilt`, `inline`). See `cwm-package --help` for full usage.
+#
+# Usage from a consuming project:
+#   composer cwm-package                       # full assembly
+#   composer cwm-package -- -v                 # verbose
+#   composer cwm-package -- --version 1.2.3    # override version
 #
 set -euo pipefail
 
@@ -14,15 +20,9 @@ TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 if [ ! -f "${PROJECT_ROOT}/cwm-build.config.json" ]; then
     echo "Error: cwm-build.config.json not found in $PROJECT_ROOT"
+    echo "Run 'cwm-init' to scaffold one, or see"
+    echo "  ${TOOLS_DIR}/examples/ for reference configs."
     exit 1
 fi
 
-BUILD_CMD=$(php -r '$c = json_decode(file_get_contents("cwm-build.config.json"), true); echo $c["build"]["command"] ?? "";')
-
-if [ -z "$BUILD_CMD" ]; then
-    echo "Error: build.command not set in cwm-build.config.json"
-    exit 1
-fi
-
-echo "Running: $BUILD_CMD"
-exec bash -c "$BUILD_CMD"
+exec php "${TOOLS_DIR}/scripts/package.php" "$@"

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "bin": [
         "bin/cwm-release",
         "bin/cwm-bump",
+        "bin/cwm-build",
         "bin/cwm-package",
         "bin/cwm-sync-configs",
         "bin/cwm-sync-languages",

--- a/examples/library/cwm-build.config.json
+++ b/examples/library/cwm-build.config.json
@@ -10,8 +10,24 @@
         ]
     },
     "build": {
-        "command": "npm run build && php build/build-package.php",
-        "outputGlob": "build/dist/lib_cwmscripture-*.zip"
+        "_command_comment": "command + outputGlob are read by cwm-release. command = 'cwm-build' delegates to the generic builder, which reads outputDir/outputName/manifest/scriptFile/sources/excludes/preBuild from this same block. cwm-release then matches outputGlob to find the produced artifact.",
+        "command": "cwm-build",
+        "outputGlob": "build/dist/lib_cwmscripture-*.zip",
+        "outputDir": "build/dist",
+        "outputName": "lib_cwmscripture-{version}.zip",
+        "manifest": "cwmscripture.xml",
+        "scriptFile": "script.php",
+        "sources": [
+            { "from": "src",                    "to": "lib_cwmscripture/src" },
+            { "from": "sql",                    "to": "lib_cwmscripture/sql" },
+            { "from": "language",               "to": "lib_cwmscripture/language" },
+            { "from": "media/lib_cwmscripture", "to": "media/lib_cwmscripture" }
+        ],
+        "excludes": [".git", ".DS_Store", ".idea", "node_modules", ".php-cs-fixer.cache"],
+        "preBuild": {
+            "mode": "ensure-minified",
+            "dirs": ["media/lib_cwmscripture/js", "media/lib_cwmscripture/css"]
+        }
     },
     "ars": {
         "endpoint": "https://www.christianwebministries.org",

--- a/scripts/build.php
+++ b/scripts/build.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * cwm-build — generic extension zip builder.
+ *
+ * Reads `build:` block of cwm-build.config.json from the current working
+ * directory and produces an installable Joomla extension zip per the
+ * declared sources, excludes, and optional pre-build gate.
+ *
+ * Phase 1 — covers lib_cwmscripture's build shape (loose `str_contains`
+ * exclude matching, optional `ensure-minified` gate, per-source zip
+ * prefix). Subsequent PRs add Proclaim's strict-mode filtering, vendor
+ * pruning, auto-run pre-build, and the 3-way version prompt.
+ */
+
+require_once __DIR__ . '/../src/Build/BuildConfig.php';
+require_once __DIR__ . '/../src/Build/ManifestReader.php';
+require_once __DIR__ . '/../src/Build/PackageBuilder.php';
+
+use CWM\BuildTools\Build\BuildConfig;
+use CWM\BuildTools\Build\PackageBuilder;
+
+$projectRoot = getcwd() ?: '.';
+$args        = $argv;
+array_shift($args);
+
+if (in_array('--help', $args, true) || in_array('-h', $args, true)) {
+    echo <<<HELP
+cwm-build — build an installable extension zip from cwm-build.config.json.
+
+WHAT IT DOES
+  Reads the `build:` block of cwm-build.config.json (in the current working
+  directory), runs the optional pre-build gate, then walks every configured
+  source directory into a zip under build.outputDir. Manifest version is
+  read from <version> in build.manifest unless --version overrides.
+
+PREREQUISITES
+  - cwm-build.config.json with a `build:` block in the project root
+  - The manifest XML referenced by build.manifest
+
+USAGE
+  cwm-build                       # full build using config defaults
+  cwm-build -v                    # verbose: print every file added
+  cwm-build --version 1.2.3       # override version (skip manifest read)
+  cwm-build --help
+
+OPTIONS
+  -v, --verbose          Print every file as it's added to the zip.
+      --version <ver>    Use this version instead of the manifest's <version>.
+  -h, --help             Show this help.
+
+EXIT CODE
+  0 on success.
+  1 on missing config, invalid config, missing manifest, or pre-build gate
+  failure (e.g. missing `.min.js` siblings under `ensure-minified`).
+
+RELATED
+  cwm-package          # multi-extension package wrapper (planned for #5 PR D)
+  cwm-bump             # version bump across manifests
+  cwm-release          # full release pipeline; runs build.command from config
+
+HELP;
+    exit(0);
+}
+
+$verbose         = in_array('-v', $args, true) || in_array('--verbose', $args, true);
+$versionOverride = null;
+
+for ($i = 0, $n = count($args); $i < $n; $i++) {
+    if ($args[$i] === '--version' && isset($args[$i + 1])) {
+        $versionOverride = $args[++$i];
+        continue;
+    }
+
+    if ($args[$i] === '-v' || $args[$i] === '--verbose') {
+        continue;
+    }
+
+    fwrite(STDERR, "Error: unrecognized argument '{$args[$i]}'. Run with --help for usage.\n");
+    exit(1);
+}
+
+$configFile = $projectRoot . '/cwm-build.config.json';
+
+if (!is_file($configFile)) {
+    fwrite(STDERR, "Error: cwm-build.config.json not found in $projectRoot\n");
+    fwrite(STDERR, "Run 'cwm-init' to scaffold one, or run from your project root.\n");
+    exit(1);
+}
+
+$rawConfig = json_decode((string) file_get_contents($configFile), true);
+
+if (!is_array($rawConfig)) {
+    fwrite(STDERR, "Error: cwm-build.config.json is not valid JSON\n");
+    exit(1);
+}
+
+if (!isset($rawConfig['build']) || !is_array($rawConfig['build'])) {
+    fwrite(STDERR, "Error: cwm-build.config.json has no `build` block.\n");
+    fwrite(STDERR, "  See examples/library/cwm-build.config.json for the shape.\n");
+    exit(1);
+}
+
+try {
+    $config = BuildConfig::fromArray($rawConfig['build']);
+} catch (\InvalidArgumentException $e) {
+    fwrite(STDERR, "Error: invalid build config — " . $e->getMessage() . "\n");
+    exit(1);
+}
+
+$builder = new PackageBuilder($config, $projectRoot, $verbose);
+
+try {
+    $builder->build($versionOverride);
+} catch (\Throwable $e) {
+    fwrite(STDERR, "Error: build failed — " . $e->getMessage() . "\n");
+    exit(1);
+}

--- a/scripts/package.php
+++ b/scripts/package.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * cwm-package — generic Joomla multi-extension package zip assembler.
+ *
+ * Reads `package:` block of cwm-build.config.json from the current working
+ * directory and assembles an installable Joomla package zip wrapping one
+ * or more child extension zips. Supports four `includes[]` entry types
+ * (`self`, `subBuild`, `prebuilt`, `inline`), two inner layouts (`root`
+ * and `packages-prefix`), an optional installer scriptfile, optional
+ * language files, and an opt-in self-verify step.
+ */
+
+require_once __DIR__ . '/../src/Build/BuildConfig.php';
+require_once __DIR__ . '/../src/Build/ManifestReader.php';
+require_once __DIR__ . '/../src/Build/PackageBuilder.php';
+require_once __DIR__ . '/../src/Build/PackageConfig.php';
+require_once __DIR__ . '/../src/Build/Packager.php';
+
+use CWM\BuildTools\Build\BuildConfig;
+use CWM\BuildTools\Build\PackageConfig;
+use CWM\BuildTools\Build\Packager;
+
+$projectRoot = getcwd() ?: '.';
+$args        = $argv;
+array_shift($args);
+
+if (in_array('--help', $args, true) || in_array('-h', $args, true)) {
+    echo <<<HELP
+cwm-package — assemble a multi-extension Joomla package zip from cwm-build.config.json.
+
+WHAT IT DOES
+  Reads the `package:` block of cwm-build.config.json (in the current working
+  directory). For each `includes[]` entry, resolves a child extension zip
+  via one of four mechanisms (`self`, `subBuild`, `prebuilt`, `inline`),
+  then assembles the outer zip with the package manifest, optional installer
+  scriptfile, optional language files, and the staged child zips at either
+  outer root or under `packages/` (per `innerLayout`).
+
+PREREQUISITES
+  - cwm-build.config.json with a `package:` block in the project root
+  - The package manifest XML referenced by package.manifest
+  - For `self` includes: a parsable `build:` block in the same config
+
+USAGE
+  cwm-package                       # assemble using config defaults
+  cwm-package -v                    # verbose: print every entry added to the outer zip
+  cwm-package --version 1.2.3       # override version (skip manifest read)
+  cwm-package --help
+
+OPTIONS
+  -v, --verbose          Print every file as it's added to the outer zip.
+      --version <ver>    Use this version instead of the package manifest's <version>.
+  -h, --help             Show this help.
+
+EXIT CODE
+  0 on success.
+  1 on missing config, invalid config, missing manifest, missing
+  sub-extension build artifact, sub-build script failure, or `verify`
+  step failure.
+
+`includes[]` ENTRY TYPES
+  self      — invoke cwm-build on the project's own `build:` block, then
+              bundle the result. Outer-zip entry name = `outputName`.
+  subBuild  — `php <buildScript> [args...]` inside `path`, then glob
+              `distGlob` (relative to `path`) for the produced zip.
+  prebuilt  — assume already on disk; glob `distGlob` (project-relative).
+  inline    — nested BuildConfig; cwm-build runs in-process on it.
+
+RELATED
+  cwm-build           # build a single extension zip; used by `self` and `inline`
+  cwm-bump            # version bump across manifests
+  cwm-release         # full release pipeline; runs build.command from config
+
+HELP;
+    exit(0);
+}
+
+$verbose         = in_array('-v', $args, true) || in_array('--verbose', $args, true);
+$versionOverride = null;
+
+for ($i = 0, $n = count($args); $i < $n; $i++) {
+    if ($args[$i] === '--version' && isset($args[$i + 1])) {
+        $versionOverride = $args[++$i];
+        continue;
+    }
+
+    if ($args[$i] === '-v' || $args[$i] === '--verbose') {
+        continue;
+    }
+
+    fwrite(STDERR, "Error: unrecognized argument '{$args[$i]}'. Run with --help for usage.\n");
+    exit(1);
+}
+
+$configFile = $projectRoot . '/cwm-build.config.json';
+
+if (!is_file($configFile)) {
+    fwrite(STDERR, "Error: cwm-build.config.json not found in $projectRoot\n");
+    fwrite(STDERR, "Run 'cwm-init' to scaffold one, or run from your project root.\n");
+    exit(1);
+}
+
+$rawConfig = json_decode((string) file_get_contents($configFile), true);
+
+if (!is_array($rawConfig)) {
+    fwrite(STDERR, "Error: cwm-build.config.json is not valid JSON\n");
+    exit(1);
+}
+
+if (!isset($rawConfig['package']) || !is_array($rawConfig['package'])) {
+    fwrite(STDERR, "Error: cwm-build.config.json has no `package` block.\n");
+    fwrite(STDERR, "  See examples/ for the shape, or use cwm-build for single-extension builds.\n");
+    exit(1);
+}
+
+try {
+    $packageConfig = PackageConfig::fromArray($rawConfig['package']);
+} catch (\InvalidArgumentException $e) {
+    fwrite(STDERR, "Error: invalid package config — " . $e->getMessage() . "\n");
+    exit(1);
+}
+
+$parentBuild = null;
+
+if (isset($rawConfig['build']) && is_array($rawConfig['build'])) {
+    try {
+        $parentBuild = BuildConfig::fromArray($rawConfig['build']);
+    } catch (\InvalidArgumentException $e) {
+        // The build: block is invalid — only an issue if `self` is used in
+        // includes[]. Defer the error to packaging time so projects that
+        // don't use `self` aren't blocked.
+        $parentBuild = null;
+    }
+}
+
+$packager = new Packager($packageConfig, $parentBuild, $projectRoot, $verbose);
+
+try {
+    $packager->package($versionOverride);
+} catch (\Throwable $e) {
+    fwrite(STDERR, "Error: package failed — " . $e->getMessage() . "\n");
+    exit(1);
+}

--- a/src/Build/BuildConfig.php
+++ b/src/Build/BuildConfig.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Build;
+
+/**
+ * Parsed `build:` block of `cwm-build.config.json`.
+ *
+ * Captures only the fields needed by the lib_cwmscripture-shape build flow
+ * (the simplest of the three consumer shapes the consolidation targets — see
+ * issue #5). Subsequent PRs add fields for Proclaim's strict-mode filtering,
+ * vendor pruning, auto-run pre-build, and interactive version prompting.
+ */
+final class BuildConfig
+{
+    /**
+     * @param string                                       $outputDir       Absolute or project-relative directory for the built zip.
+     * @param string                                       $outputName      Output filename pattern; supports `{version}` substitution.
+     * @param string                                       $manifest        Project-relative path to the manifest XML; version is read from its <version> element.
+     * @param string|null                                  $scriptFile      Optional install scriptfile, added at zip root if present.
+     * @param list<array{from: string, to: string}>        $sources         Source directories with their zip-path prefix.
+     * @param list<string>                                 $excludes        Path substrings to skip (str_contains semantics).
+     * @param array{mode: string, dirs?: list<string>}|null $preBuild       Optional pre-build gate config.
+     */
+    public function __construct(
+        public readonly string $outputDir,
+        public readonly string $outputName,
+        public readonly string $manifest,
+        public readonly ?string $scriptFile,
+        public readonly array $sources,
+        public readonly array $excludes,
+        public readonly ?array $preBuild,
+    ) {
+    }
+
+    /**
+     * Build a BuildConfig from the raw `build:` block of cwm-build.config.json.
+     *
+     * @param  array<string, mixed> $cfg
+     * @throws \InvalidArgumentException When required fields are missing or malformed.
+     */
+    public static function fromArray(array $cfg): self
+    {
+        foreach (['outputDir', 'outputName', 'manifest'] as $required) {
+            if (empty($cfg[$required]) || !is_string($cfg[$required])) {
+                throw new \InvalidArgumentException("build.$required is required and must be a string");
+            }
+        }
+
+        $rawSources = $cfg['sources'] ?? [];
+
+        if (!is_array($rawSources) || $rawSources === []) {
+            throw new \InvalidArgumentException('build.sources is required and must be a non-empty array');
+        }
+
+        $sources = [];
+
+        foreach ($rawSources as $i => $src) {
+            if (!is_array($src) || empty($src['from']) || !isset($src['to'])) {
+                throw new \InvalidArgumentException("build.sources[$i] must have non-empty 'from' and 'to' keys");
+            }
+
+            $sources[] = ['from' => (string) $src['from'], 'to' => (string) $src['to']];
+        }
+
+        $rawExcludes = $cfg['excludes'] ?? [];
+
+        if (!is_array($rawExcludes)) {
+            throw new \InvalidArgumentException('build.excludes must be an array of strings');
+        }
+
+        $excludes = array_values(array_map('strval', $rawExcludes));
+
+        $preBuild = null;
+
+        if (isset($cfg['preBuild'])) {
+            if (!is_array($cfg['preBuild']) || empty($cfg['preBuild']['mode'])) {
+                throw new \InvalidArgumentException('build.preBuild must be an object with a non-empty `mode`');
+            }
+
+            $mode = (string) $cfg['preBuild']['mode'];
+
+            if ($mode !== 'ensure-minified') {
+                throw new \InvalidArgumentException(
+                    "build.preBuild.mode must be 'ensure-minified' (got '$mode'). " .
+                    "Other modes (e.g. 'run', 'gate') are reserved for future PRs."
+                );
+            }
+
+            $dirs = $cfg['preBuild']['dirs'] ?? [];
+
+            if (!is_array($dirs)) {
+                throw new \InvalidArgumentException('build.preBuild.dirs must be an array of strings');
+            }
+
+            $preBuild = [
+                'mode' => $mode,
+                'dirs' => array_values(array_map('strval', $dirs)),
+            ];
+        }
+
+        return new self(
+            outputDir:  (string) $cfg['outputDir'],
+            outputName: (string) $cfg['outputName'],
+            manifest:   (string) $cfg['manifest'],
+            scriptFile: isset($cfg['scriptFile']) && is_string($cfg['scriptFile']) ? $cfg['scriptFile'] : null,
+            sources:    $sources,
+            excludes:   $excludes,
+            preBuild:   $preBuild,
+        );
+    }
+}

--- a/src/Build/PackageBuilder.php
+++ b/src/Build/PackageBuilder.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Build;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ZipArchive;
+
+/**
+ * Builds an installable extension zip per a {@see BuildConfig}.
+ *
+ * Phase 1 — covers the lib_cwmscripture build shape: read manifest version,
+ * optionally gate on minified asset presence, then walk one or more source
+ * directories into the zip with a configurable per-source prefix. Excludes
+ * are matched as path substrings (`str_contains`), the loose mode used by
+ * lib_cwmscripture and CWMScriptureLinks. Strict-mode (Proclaim's 4-mode
+ * exclude + vendor prune + root-ext include) lands in a follow-up PR.
+ *
+ * Path semantics:
+ *   - `BuildConfig::manifest` and `BuildConfig::scriptFile` are
+ *     project-relative; their `basename()` becomes the in-zip path.
+ *   - `BuildConfig::sources[i].from` is project-relative; every file under
+ *     it gets prefixed with `sources[i].to` inside the zip.
+ *   - `BuildConfig::outputDir` is project-relative.
+ *   - `outputName` accepts a literal `{version}` token — substituted with
+ *     the value read from the manifest (or `versionOverride` argument).
+ */
+final class PackageBuilder
+{
+    public function __construct(
+        private readonly BuildConfig $config,
+        private readonly string $projectRoot,
+        private readonly bool $verbose = false,
+    ) {
+        if (!is_dir($this->projectRoot)) {
+            throw new \InvalidArgumentException("Project root does not exist: $this->projectRoot");
+        }
+    }
+
+    /**
+     * Run the full build flow.
+     *
+     * @param  string|null $versionOverride  When non-null, used in place of the manifest's <version>. Useful for ad-hoc rebuilds.
+     * @return string                        Absolute path to the resulting zip.
+     */
+    public function build(?string $versionOverride = null): string
+    {
+        $manifestPath = $this->resolve($this->config->manifest);
+
+        if (!is_file($manifestPath)) {
+            throw new \RuntimeException("Manifest not found: $manifestPath");
+        }
+
+        $reader  = new ManifestReader($manifestPath);
+        $version = $versionOverride ?? $reader->version();
+
+        if ($this->config->preBuild !== null) {
+            $this->runPreBuild($this->config->preBuild);
+        }
+
+        $outputDir = $this->resolve($this->config->outputDir);
+
+        if (!is_dir($outputDir) && !mkdir($outputDir, 0o777, true) && !is_dir($outputDir)) {
+            throw new \RuntimeException("Could not create output directory: $outputDir");
+        }
+
+        $outputName = str_replace('{version}', $version, $this->config->outputName);
+        $outputPath = $outputDir . '/' . $outputName;
+
+        // Replace any prior build artifact at this exact path. Unlike the
+        // legacy lib_cwmscripture script, we don't wipe the entire dist dir
+        // (that's destructive to unrelated zips); leftover artifacts are
+        // gitignored anyway.
+        if (file_exists($outputPath)) {
+            unlink($outputPath);
+        }
+
+        echo "Building " . basename($outputPath) . " (v$version)\n";
+
+        $zip = new ZipArchive();
+
+        if ($zip->open($outputPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            throw new \RuntimeException("Could not create zip: $outputPath");
+        }
+
+        $manifestEntry = basename($this->config->manifest);
+        $zip->addFile($manifestPath, $manifestEntry);
+        $this->log("  + $manifestEntry");
+
+        if ($this->config->scriptFile !== null) {
+            $scriptAbs = $this->resolve($this->config->scriptFile);
+
+            if (is_file($scriptAbs)) {
+                $scriptEntry = basename($this->config->scriptFile);
+                $zip->addFile($scriptAbs, $scriptEntry);
+                $this->log("  + $scriptEntry");
+            }
+        }
+
+        foreach ($this->config->sources as $src) {
+            $this->addDirectory($zip, $this->resolve($src['from']), $src['to'], $this->config->excludes);
+        }
+
+        $fileCount = $zip->numFiles;
+        $zip->close();
+
+        $sizeKb = (int) round((int) filesize($outputPath) / 1024);
+        echo "\nPackage built: $outputPath\n";
+        echo "  Files: $fileCount\n";
+        echo "  Size:  {$sizeKb} KB\n";
+
+        return $outputPath;
+    }
+
+    /**
+     * Resolve a project-relative path against the project root.
+     */
+    private function resolve(string $path): string
+    {
+        if ($path === '') {
+            return $this->projectRoot;
+        }
+
+        // Already absolute — pass through.
+        if ($path[0] === '/' || (strlen($path) > 1 && $path[1] === ':')) {
+            return $path;
+        }
+
+        return rtrim($this->projectRoot, '/') . '/' . $path;
+    }
+
+    /**
+     * Run the configured pre-build gate.
+     *
+     * `ensure-minified` is the only mode currently supported. For each listed
+     * directory, every `<name>.<ext>` that isn't already a `.min.<ext>` must
+     * have a corresponding `<name>.min.<ext>` sibling, otherwise the build
+     * fails with a hint to run the project's build step.
+     *
+     * @param array{mode: string, dirs?: list<string>} $preBuild
+     */
+    private function runPreBuild(array $preBuild): void
+    {
+        if ($preBuild['mode'] !== 'ensure-minified') {
+            return;
+        }
+
+        $missing = [];
+
+        foreach ($preBuild['dirs'] ?? [] as $relDir) {
+            $absDir = $this->resolve($relDir);
+
+            if (!is_dir($absDir)) {
+                continue;
+            }
+
+            $entries = scandir($absDir) ?: [];
+
+            foreach ($entries as $entry) {
+                if ($entry === '.' || $entry === '..' || !is_file($absDir . '/' . $entry)) {
+                    continue;
+                }
+
+                if (!preg_match('/\.([a-z0-9]+)$/i', $entry, $m)) {
+                    continue;
+                }
+
+                $ext = $m[1];
+
+                // Already a minified version — skip.
+                if (str_ends_with($entry, '.min.' . $ext)) {
+                    continue;
+                }
+
+                $minEntry = substr($entry, 0, -strlen('.' . $ext)) . '.min.' . $ext;
+
+                if (!file_exists($absDir . '/' . $minEntry)) {
+                    $missing[] = $relDir . '/' . $minEntry;
+                }
+            }
+        }
+
+        if ($missing !== []) {
+            fwrite(STDERR, "Pre-build gate failed: missing minified assets:\n");
+
+            foreach ($missing as $m) {
+                fwrite(STDERR, "  - $m\n");
+            }
+
+            fwrite(STDERR, "\nRun the project's build step (typically `npm run build`) before packaging.\n");
+            exit(1);
+        }
+    }
+
+    /**
+     * Walk a source directory and add its files to the zip under $zipPrefix.
+     *
+     * @param list<string> $excludes
+     */
+    private function addDirectory(ZipArchive $zip, string $sourcePath, string $zipPrefix, array $excludes): void
+    {
+        if (!is_dir($sourcePath)) {
+            echo "  SKIP: $sourcePath (not found)\n";
+
+            return;
+        }
+
+        $sourceReal = realpath($sourcePath);
+
+        if ($sourceReal === false) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($sourcePath, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::LEAVES_ONLY
+        );
+
+        foreach ($iterator as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            $filePath     = $file->getRealPath();
+            $relativePath = substr($filePath, strlen($sourceReal) + 1);
+
+            if (self::matchesExclude($relativePath, $excludes)) {
+                continue;
+            }
+
+            $entryPath = $zipPrefix === '' ? $relativePath : rtrim($zipPrefix, '/') . '/' . $relativePath;
+
+            $zip->addFile($filePath, $entryPath);
+            $this->log("  + $entryPath");
+        }
+    }
+
+    /**
+     * @param list<string> $excludes
+     */
+    private static function matchesExclude(string $path, array $excludes): bool
+    {
+        foreach ($excludes as $pattern) {
+            if ($pattern !== '' && str_contains($path, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function log(string $line): void
+    {
+        if ($this->verbose) {
+            echo $line . "\n";
+        }
+    }
+}

--- a/src/Build/PackageConfig.php
+++ b/src/Build/PackageConfig.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Build;
+
+/**
+ * Parsed `package:` block of `cwm-build.config.json`.
+ *
+ * Drives `cwm-package`'s assembly of a multi-extension Joomla package zip.
+ * Each entry in `includes[]` is a discriminated union over four `type`s:
+ *
+ *   - `self`     — invoke {@see PackageBuilder} against the project's own
+ *                  `build:` block, then bundle the result. Proclaim's
+ *                  "step 3: build com_proclaim" in process.
+ *   - `subBuild` — shell out to a sub-extension's existing build script
+ *                  (`php <buildScript> [args]`) within `path`, then glob
+ *                  `distGlob` (relative to `path`) for the produced zip.
+ *                  Used during transition while sub-extensions still ship
+ *                  their own `build/build-package.php` scripts.
+ *   - `prebuilt` — assume the zip is already built; glob `distGlob` and
+ *                  copy. Helpful when the sub-extension is a submodule
+ *                  whose release zip is already on disk.
+ *   - `inline`   — a nested `BuildConfig`-shaped block; the Packager runs
+ *                  {@see PackageBuilder} on that config and bundles the
+ *                  result. CSL's `plg_task_cwmscripture` (a sibling
+ *                  directory built in-process) maps to this.
+ */
+final class PackageConfig
+{
+    public const LAYOUT_ROOT             = 'root';
+    public const LAYOUT_PACKAGES_PREFIX  = 'packages-prefix';
+
+    public const TYPE_SELF      = 'self';
+    public const TYPE_SUB_BUILD = 'subBuild';
+    public const TYPE_PREBUILT  = 'prebuilt';
+    public const TYPE_INLINE    = 'inline';
+
+    /**
+     * @param string                                $manifest       Path to the package manifest XML; version is read from <version>.
+     * @param string                                $outputDir      Project-relative directory for the assembled outer zip.
+     * @param string                                $outputName     Output filename pattern; `{version}` substituted from manifest.
+     * @param string                                $innerLayout    Where child zips are placed inside the outer zip — `"root"` (default) or `"packages-prefix"` (under `packages/`).
+     * @param string|null                           $installer      Optional install scriptfile path; added at outer-zip root if present.
+     * @param list<array{from: string, to: string}> $languageFiles  Language INI files; `from` is project-relative source, `to` is its outer-zip path.
+     * @param non-empty-list<array<string, mixed>>  $includes       Discriminated-union entries (see class doc).
+     * @param array{expectedEntries?: list<string>}|null $verify    Optional self-verify block.
+     */
+    public function __construct(
+        public readonly string $manifest,
+        public readonly string $outputDir,
+        public readonly string $outputName,
+        public readonly string $innerLayout,
+        public readonly ?string $installer,
+        public readonly array $languageFiles,
+        public readonly array $includes,
+        public readonly ?array $verify,
+    ) {
+    }
+
+    /**
+     * @param  array<string, mixed> $cfg
+     * @throws \InvalidArgumentException When required fields are missing or malformed.
+     */
+    public static function fromArray(array $cfg): self
+    {
+        foreach (['manifest', 'outputDir', 'outputName'] as $required) {
+            if (empty($cfg[$required]) || !is_string($cfg[$required])) {
+                throw new \InvalidArgumentException("package.$required is required and must be a string");
+            }
+        }
+
+        $innerLayout = $cfg['innerLayout'] ?? self::LAYOUT_ROOT;
+
+        if (!is_string($innerLayout) || !in_array($innerLayout, [self::LAYOUT_ROOT, self::LAYOUT_PACKAGES_PREFIX], true)) {
+            throw new \InvalidArgumentException(
+                'package.innerLayout must be "root" or "packages-prefix" (got ' . var_export($innerLayout, true) . ')'
+            );
+        }
+
+        $installer = isset($cfg['installer']) && is_string($cfg['installer']) ? $cfg['installer'] : null;
+
+        $rawLanguage = $cfg['languageFiles'] ?? [];
+
+        if (!is_array($rawLanguage)) {
+            throw new \InvalidArgumentException('package.languageFiles must be an array');
+        }
+
+        $languageFiles = [];
+
+        foreach ($rawLanguage as $i => $entry) {
+            if (!is_array($entry) || empty($entry['from']) || empty($entry['to'])) {
+                throw new \InvalidArgumentException("package.languageFiles[$i] must have non-empty 'from' and 'to' keys");
+            }
+
+            $languageFiles[] = ['from' => (string) $entry['from'], 'to' => (string) $entry['to']];
+        }
+
+        $rawIncludes = $cfg['includes'] ?? [];
+
+        if (!is_array($rawIncludes) || $rawIncludes === []) {
+            throw new \InvalidArgumentException('package.includes is required and must be a non-empty array');
+        }
+
+        $includes = [];
+
+        foreach ($rawIncludes as $i => $entry) {
+            $includes[] = self::validateInclude($i, $entry);
+        }
+
+        $verify = null;
+
+        if (isset($cfg['verify'])) {
+            if (!is_array($cfg['verify'])) {
+                throw new \InvalidArgumentException('package.verify must be an object');
+            }
+
+            $expected = $cfg['verify']['expectedEntries'] ?? [];
+
+            if (!is_array($expected)) {
+                throw new \InvalidArgumentException('package.verify.expectedEntries must be an array of strings');
+            }
+
+            $verify = [
+                'expectedEntries' => array_values(array_map('strval', $expected)),
+            ];
+        }
+
+        return new self(
+            manifest:      (string) $cfg['manifest'],
+            outputDir:     (string) $cfg['outputDir'],
+            outputName:    (string) $cfg['outputName'],
+            innerLayout:   $innerLayout,
+            installer:     $installer,
+            languageFiles: $languageFiles,
+            includes:      $includes,
+            verify:        $verify,
+        );
+    }
+
+    /**
+     * Validate one `includes[]` entry by `type` and return the normalized shape.
+     *
+     * @param  array<string, mixed>|mixed $entry
+     * @return array<string, mixed>
+     */
+    private static function validateInclude(int $i, mixed $entry): array
+    {
+        if (!is_array($entry) || empty($entry['type'])) {
+            throw new \InvalidArgumentException("package.includes[$i] must have a `type`");
+        }
+
+        $type = (string) $entry['type'];
+
+        if (empty($entry['outputName']) || !is_string($entry['outputName'])) {
+            throw new \InvalidArgumentException("package.includes[$i] requires non-empty 'outputName'");
+        }
+
+        $normalized = ['type' => $type, 'outputName' => (string) $entry['outputName']];
+
+        switch ($type) {
+            case self::TYPE_SELF:
+                // No extra fields. Bundles the result of running `cwm-build`
+                // on the project's own `build:` block.
+                break;
+
+            case self::TYPE_SUB_BUILD:
+                foreach (['path', 'buildScript', 'distGlob'] as $req) {
+                    if (empty($entry[$req]) || !is_string($entry[$req])) {
+                        throw new \InvalidArgumentException("package.includes[$i] (type subBuild) requires non-empty '$req'");
+                    }
+                }
+
+                $args = $entry['args'] ?? [];
+
+                if (!is_array($args)) {
+                    throw new \InvalidArgumentException("package.includes[$i].args must be an array of strings");
+                }
+
+                $normalized['path']        = (string) $entry['path'];
+                $normalized['buildScript'] = (string) $entry['buildScript'];
+                $normalized['distGlob']    = (string) $entry['distGlob'];
+                $normalized['args']        = array_values(array_map('strval', $args));
+                break;
+
+            case self::TYPE_PREBUILT:
+                if (empty($entry['distGlob']) || !is_string($entry['distGlob'])) {
+                    throw new \InvalidArgumentException("package.includes[$i] (type prebuilt) requires non-empty 'distGlob'");
+                }
+
+                $normalized['distGlob'] = (string) $entry['distGlob'];
+                break;
+
+            case self::TYPE_INLINE:
+                if (empty($entry['config']) || !is_array($entry['config'])) {
+                    throw new \InvalidArgumentException("package.includes[$i] (type inline) requires a 'config' object");
+                }
+
+                // Validate by running BuildConfig::fromArray — surfaces nested errors here.
+                BuildConfig::fromArray($entry['config']);
+                $normalized['config'] = $entry['config'];
+                break;
+
+            default:
+                throw new \InvalidArgumentException(
+                    "package.includes[$i].type must be one of: self, subBuild, prebuilt, inline (got '$type')"
+                );
+        }
+
+        return $normalized;
+    }
+}

--- a/src/Build/Packager.php
+++ b/src/Build/Packager.php
@@ -1,0 +1,448 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Build;
+
+use ZipArchive;
+
+/**
+ * Assembles a multi-extension Joomla package zip from a {@see PackageConfig}.
+ *
+ * For every entry in `PackageConfig::includes[]`, resolves a single child zip
+ * (by running an inline build, shelling out to a sub-script, globbing for a
+ * pre-built artifact, or building the project's own `build:` block) and
+ * stages it under a unique scratch dir. Then assembles the outer zip with
+ * the package manifest, optional installer scriptfile, optional language
+ * files, and the staged child zips at either outer-zip root or under
+ * `packages/` (per `innerLayout`).
+ *
+ * Differences from the legacy proclaim_build.php / CWMScriptureLinks
+ * build-package.php scripts:
+ *   - No shell-driven `rm -rf` calls — cleanup is native PHP, with
+ *     `is_link()` guards to prevent symlink-escape from the project tree
+ *     (per CLAUDE.md).
+ *   - No string-form shell calls. Sub-build invocations use `proc_open`
+ *     array form; STDOUT/STDERR are inherited so the user sees live progress.
+ */
+final class Packager
+{
+    /**
+     * @param PackageConfig    $config       The package: block.
+     * @param BuildConfig|null $parentBuild  Required only when `includes[]` contains a `self` entry — used to invoke {@see PackageBuilder} on the project's own `build:` block.
+     * @param string           $projectRoot  Project root (CWD when invoked from `cwm-package`).
+     * @param bool             $verbose      Print per-file additions to the outer zip.
+     */
+    public function __construct(
+        private readonly PackageConfig $config,
+        private readonly ?BuildConfig $parentBuild,
+        private readonly string $projectRoot,
+        private readonly bool $verbose = false,
+    ) {
+        if (!is_dir($this->projectRoot)) {
+            throw new \InvalidArgumentException("Project root does not exist: $this->projectRoot");
+        }
+    }
+
+    /**
+     * Run the full assembly flow.
+     *
+     * @param  string|null $versionOverride  When non-null, used in place of the manifest's <version>.
+     * @return string                        Absolute path to the assembled outer zip.
+     */
+    public function package(?string $versionOverride = null): string
+    {
+        $manifestPath = $this->resolve($this->config->manifest);
+
+        if (!is_file($manifestPath)) {
+            throw new \RuntimeException("Package manifest not found: $manifestPath");
+        }
+
+        $reader  = new ManifestReader($manifestPath);
+        $version = $versionOverride ?? $reader->version();
+
+        $outputDir = $this->resolve($this->config->outputDir);
+
+        if (!is_dir($outputDir) && !mkdir($outputDir, 0o777, true) && !is_dir($outputDir)) {
+            throw new \RuntimeException("Could not create output directory: $outputDir");
+        }
+
+        $outputName = str_replace('{version}', $version, $this->config->outputName);
+        $outputPath = $outputDir . '/' . $outputName;
+
+        if (file_exists($outputPath)) {
+            unlink($outputPath);
+        }
+
+        echo "Assembling " . basename($outputPath) . " (v$version)\n";
+
+        $stagingDir = $this->createStagingDir();
+
+        try {
+            $stagedChildren = $this->resolveIncludes($stagingDir);
+            $this->writeOuterZip($outputPath, $manifestPath, $stagedChildren);
+
+            if ($this->config->verify !== null) {
+                $this->verifyOutputZip($outputPath, $this->config->verify);
+            }
+        } finally {
+            $this->removeDirectory($stagingDir);
+        }
+
+        $sizeKb = (int) round((int) filesize($outputPath) / 1024);
+        echo "\nPackage assembled: $outputPath\n";
+        echo "  Children: " . count($this->config->includes) . "\n";
+        echo "  Size:     {$sizeKb} KB\n";
+
+        return $outputPath;
+    }
+
+    /**
+     * Resolve every `includes[]` entry into an absolute path to a staged zip.
+     *
+     * @return list<array{outputName: string, path: string}>
+     */
+    private function resolveIncludes(string $stagingDir): array
+    {
+        $resolved = [];
+
+        foreach ($this->config->includes as $i => $include) {
+            $stagedPath = $stagingDir . '/' . $include['outputName'];
+
+            switch ($include['type']) {
+                case PackageConfig::TYPE_SELF:
+                    $stagedPath = $this->resolveSelf($include, $stagedPath);
+                    break;
+
+                case PackageConfig::TYPE_SUB_BUILD:
+                    $stagedPath = $this->resolveSubBuild($include, $stagedPath, $i);
+                    break;
+
+                case PackageConfig::TYPE_PREBUILT:
+                    $stagedPath = $this->resolvePrebuilt($include, $stagedPath, $i);
+                    break;
+
+                case PackageConfig::TYPE_INLINE:
+                    $stagedPath = $this->resolveInline($include, $stagedPath);
+                    break;
+
+                default:
+                    throw new \LogicException("Unhandled include type '{$include['type']}'");
+            }
+
+            $resolved[] = ['outputName' => $include['outputName'], 'path' => $stagedPath];
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Build the project's own `build:` block via PackageBuilder.
+     *
+     * @param array<string, mixed> $include
+     */
+    private function resolveSelf(array $include, string $stagedPath): string
+    {
+        if ($this->parentBuild === null) {
+            throw new \RuntimeException(
+                "package.includes contains a 'self' entry, but the project's `build:` block isn't loaded. " .
+                "Define the `build:` block in cwm-build.config.json so cwm-package can invoke PackageBuilder."
+            );
+        }
+
+        echo "  -> building self ({$include['outputName']})\n";
+
+        $builder    = new PackageBuilder($this->parentBuild, $this->projectRoot, $this->verbose);
+        $producedAt = $builder->build();
+
+        $this->copy($producedAt, $stagedPath);
+
+        return $stagedPath;
+    }
+
+    /**
+     * Shell out to a sub-extension's existing build script and pick up the produced zip.
+     *
+     * @param array<string, mixed> $include
+     */
+    private function resolveSubBuild(array $include, string $stagedPath, int $i): string
+    {
+        $subDir = $this->resolve($include['path']);
+
+        if (!is_dir($subDir)) {
+            throw new \RuntimeException("package.includes[$i] (subBuild): path not found: $subDir");
+        }
+
+        $buildScriptAbs = $subDir . '/' . ltrim($include['buildScript'], '/');
+
+        if (!is_file($buildScriptAbs)) {
+            throw new \RuntimeException("package.includes[$i] (subBuild): buildScript not found: $buildScriptAbs");
+        }
+
+        echo "  -> sub-build {$include['outputName']} (in {$include['path']})\n";
+
+        // Array-form proc_open: no shell, no metachar interpretation. Inherit
+        // STDOUT/STDERR so the user sees the sub-build's progress live.
+        $cmd = array_merge(['php', $buildScriptAbs], $include['args']);
+
+        // Open fresh stdio handles instead of using the predefined STDIN/STDOUT
+        // /STDERR constants — those constants are file resources, and another
+        // test closing the parent's STDIN under PHPUnit's random-order runs
+        // makes them invalid for subsequent uses.
+        $proc = proc_open(
+            $cmd,
+            [
+                0 => ['file', '/dev/null', 'r'],
+                1 => ['file', 'php://stdout', 'w'],
+                2 => ['file', 'php://stderr', 'w'],
+            ],
+            $pipes,
+            $subDir
+        );
+
+        if (!is_resource($proc)) {
+            throw new \RuntimeException("package.includes[$i] (subBuild): could not spawn php for $buildScriptAbs");
+        }
+
+        $exit = proc_close($proc);
+
+        if ($exit !== 0) {
+            throw new \RuntimeException("package.includes[$i] (subBuild): $buildScriptAbs exited with $exit");
+        }
+
+        $globPath = $subDir . '/' . ltrim($include['distGlob'], '/');
+        $matches  = glob($globPath) ?: [];
+
+        if ($matches === []) {
+            throw new \RuntimeException(
+                "package.includes[$i] (subBuild): no files matched distGlob '{$include['distGlob']}' (under {$include['path']})"
+            );
+        }
+
+        // If multiple, pick the most-recently modified (favors the just-produced one).
+        if (count($matches) > 1) {
+            usort($matches, static fn (string $a, string $b): int => filemtime($b) <=> filemtime($a));
+        }
+
+        $this->copy($matches[0], $stagedPath);
+
+        return $stagedPath;
+    }
+
+    /**
+     * Glob for an already-built zip on disk and stage it.
+     *
+     * @param array<string, mixed> $include
+     */
+    private function resolvePrebuilt(array $include, string $stagedPath, int $i): string
+    {
+        $globPath = $this->resolve($include['distGlob']);
+        $matches  = glob($globPath) ?: [];
+
+        if ($matches === []) {
+            throw new \RuntimeException(
+                "package.includes[$i] (prebuilt): no files matched distGlob '{$include['distGlob']}'. " .
+                "Build the sub-extension first (e.g. via its own build script or cwm-build), " .
+                "then re-run cwm-package."
+            );
+        }
+
+        if (count($matches) > 1) {
+            usort($matches, static fn (string $a, string $b): int => filemtime($b) <=> filemtime($a));
+        }
+
+        echo "  -> prebuilt {$include['outputName']} (from " . basename($matches[0]) . ")\n";
+
+        $this->copy($matches[0], $stagedPath);
+
+        return $stagedPath;
+    }
+
+    /**
+     * Build a sub-extension in-process from a nested BuildConfig.
+     *
+     * @param array<string, mixed> $include
+     */
+    private function resolveInline(array $include, string $stagedPath): string
+    {
+        echo "  -> inline build {$include['outputName']}\n";
+
+        $childConfig = BuildConfig::fromArray($include['config']);
+        $builder     = new PackageBuilder($childConfig, $this->projectRoot, $this->verbose);
+        $producedAt  = $builder->build();
+
+        $this->copy($producedAt, $stagedPath);
+
+        return $stagedPath;
+    }
+
+    /**
+     * Write the outer zip — manifest, optional installer, language files,
+     * and the staged child zips at the configured layout.
+     *
+     * @param list<array{outputName: string, path: string}> $stagedChildren
+     */
+    private function writeOuterZip(string $outputPath, string $manifestPath, array $stagedChildren): void
+    {
+        $zip = new ZipArchive();
+
+        if ($zip->open($outputPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            throw new \RuntimeException("Could not create outer zip: $outputPath");
+        }
+
+        $manifestEntry = basename($this->config->manifest);
+        $zip->addFile($manifestPath, $manifestEntry);
+        $this->log("  + $manifestEntry");
+
+        if ($this->config->installer !== null) {
+            $installerAbs = $this->resolve($this->config->installer);
+
+            if (is_file($installerAbs)) {
+                $entry = basename($this->config->installer);
+                $zip->addFile($installerAbs, $entry);
+                $this->log("  + $entry");
+            }
+        }
+
+        foreach ($this->config->languageFiles as $lang) {
+            $fromAbs = $this->resolve($lang['from']);
+
+            if (!is_file($fromAbs)) {
+                throw new \RuntimeException("package.languageFiles: source not found: {$lang['from']}");
+            }
+
+            $zip->addFile($fromAbs, $lang['to']);
+            $this->log("  + {$lang['to']}");
+        }
+
+        $prefix = $this->config->innerLayout === PackageConfig::LAYOUT_PACKAGES_PREFIX ? 'packages/' : '';
+
+        foreach ($stagedChildren as $child) {
+            $entry = $prefix . $child['outputName'];
+            $zip->addFile($child['path'], $entry);
+            $this->log("  + $entry");
+        }
+
+        $zip->close();
+    }
+
+    /**
+     * Re-open the assembled zip and assert each `expectedEntries[]` is present.
+     *
+     * @param array{expectedEntries?: list<string>} $verify
+     */
+    private function verifyOutputZip(string $outputPath, array $verify): void
+    {
+        $expected = $verify['expectedEntries'] ?? [];
+
+        if ($expected === []) {
+            return;
+        }
+
+        $zip = new ZipArchive();
+
+        if ($zip->open($outputPath) !== true) {
+            throw new \RuntimeException("Could not re-open outer zip for verify: $outputPath");
+        }
+
+        $missing = [];
+
+        foreach ($expected as $entry) {
+            if ($zip->locateName($entry) === false) {
+                $missing[] = $entry;
+            }
+        }
+
+        $zip->close();
+
+        if ($missing !== []) {
+            throw new \RuntimeException(
+                "package.verify failed - missing entries:\n  - " . implode("\n  - ", $missing)
+            );
+        }
+
+        echo "  Verify: " . count($expected) . " expected entries present.\n";
+    }
+
+    /**
+     * Resolve a project-relative path against the project root.
+     */
+    private function resolve(string $path): string
+    {
+        if ($path === '') {
+            return $this->projectRoot;
+        }
+
+        if ($path[0] === '/' || (strlen($path) > 1 && $path[1] === ':')) {
+            return $path;
+        }
+
+        return rtrim($this->projectRoot, '/') . '/' . $path;
+    }
+
+    /**
+     * Copy a file, creating the destination's parent directory if needed.
+     */
+    private function copy(string $from, string $to): void
+    {
+        $dir = dirname($to);
+
+        if (!is_dir($dir) && !mkdir($dir, 0o777, true) && !is_dir($dir)) {
+            throw new \RuntimeException("Could not create staging dir: $dir");
+        }
+
+        if (!@copy($from, $to)) {
+            throw new \RuntimeException("Could not copy '$from' to '$to'");
+        }
+    }
+
+    private function createStagingDir(): string
+    {
+        $base = sys_get_temp_dir() . '/cwm-package-' . uniqid('', true);
+
+        if (!mkdir($base, 0o700, true) && !is_dir($base)) {
+            throw new \RuntimeException("Could not create staging dir: $base");
+        }
+
+        return $base;
+    }
+
+    /**
+     * Recursively remove a directory, with `is_link()` guards so a symlink
+     * inside the staging dir gets unlinked rather than recursed-through.
+     */
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir) || is_link($dir)) {
+            @unlink($dir);
+
+            return;
+        }
+
+        $entries = scandir($dir) ?: [];
+
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $entry;
+
+            if (is_link($path) || is_file($path)) {
+                @unlink($path);
+                continue;
+            }
+
+            $this->removeDirectory($path);
+        }
+
+        @rmdir($dir);
+    }
+
+    private function log(string $line): void
+    {
+        if ($this->verbose) {
+            echo $line . "\n";
+        }
+    }
+}

--- a/tests/Build/PackageBuilderTest.php
+++ b/tests/Build/PackageBuilderTest.php
@@ -1,0 +1,322 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Build;
+
+use CWM\BuildTools\Build\BuildConfig;
+use CWM\BuildTools\Build\PackageBuilder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ZipArchive;
+
+/**
+ * End-to-end tests that build a real zip from a temp fixture project and
+ * assert its contents — the only meaningful coverage for a script whose
+ * job is producing a correct on-disk artifact.
+ */
+final class PackageBuilderTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/cwm-build-test-' . uniqid('', true);
+        mkdir($this->tmpDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->rrmdir($this->tmpDir);
+    }
+
+    #[Test]
+    public function buildsLibCwmscriptureShape(): void
+    {
+        $this->writeManifest('cwmscripture.xml', '1.2.0');
+        $this->writeFile('script.php', '<?php // install hook');
+        $this->writeFile('src/Service/Foo.php', '<?php // foo');
+        $this->writeFile('src/Service/Bar.php', '<?php // bar');
+        $this->writeFile('sql/install.mysql.utf8.sql', '-- DDL');
+        $this->writeFile('language/en-GB/en-GB.lib_cwmscripture.ini', '');
+        $this->writeFile('media/lib_cwmscripture/js/foo.js', 'console.log("foo");');
+        $this->writeFile('media/lib_cwmscripture/js/foo.min.js', 'console.log("foo")');
+        $this->writeFile('media/lib_cwmscripture/css/foo.css', '.foo{}');
+        $this->writeFile('media/lib_cwmscripture/css/foo.min.css', '.foo{}');
+        // Excluded entries — should NOT end up in zip.
+        $this->writeFile('src/.DS_Store', '');
+        $this->writeFile('src/node_modules/x/index.js', '');
+
+        $builder = new PackageBuilder($this->makeLibConfig(), $this->tmpDir);
+
+        $this->expectOutputRegex('/Building lib_cwmscripture-1\.2\.0\.zip \(v1\.2\.0\)/');
+
+        $zipPath = $builder->build();
+
+        $this->assertSame($this->tmpDir . '/build/dist/lib_cwmscripture-1.2.0.zip', $zipPath);
+        $this->assertFileExists($zipPath);
+
+        $entries = $this->zipEntries($zipPath);
+
+        $this->assertContains('cwmscripture.xml', $entries);
+        $this->assertContains('script.php', $entries);
+        $this->assertContains('lib_cwmscripture/src/Service/Foo.php', $entries);
+        $this->assertContains('lib_cwmscripture/src/Service/Bar.php', $entries);
+        $this->assertContains('lib_cwmscripture/sql/install.mysql.utf8.sql', $entries);
+        $this->assertContains('lib_cwmscripture/language/en-GB/en-GB.lib_cwmscripture.ini', $entries);
+        $this->assertContains('media/lib_cwmscripture/js/foo.js', $entries);
+        $this->assertContains('media/lib_cwmscripture/js/foo.min.js', $entries);
+
+        $this->assertNotContains('src/.DS_Store', $entries);
+        $this->assertNotContains('lib_cwmscripture/src/.DS_Store', $entries);
+        // node_modules anywhere in the path is excluded by the substring match.
+        foreach ($entries as $entry) {
+            $this->assertStringNotContainsString('node_modules', $entry);
+            $this->assertStringNotContainsString('.DS_Store', $entry);
+        }
+    }
+
+    #[Test]
+    public function omitsScriptFileWhenAbsent(): void
+    {
+        $this->writeManifest('cwmscripture.xml', '1.0.0');
+        $this->writeFile('src/Foo.php', '<?php');
+
+        $builder = new PackageBuilder($this->makeLibConfig(), $this->tmpDir);
+
+        $this->expectOutputRegex('/Building lib_cwmscripture-1\.0\.0\.zip/');
+
+        $zipPath = $builder->build();
+        $entries = $this->zipEntries($zipPath);
+
+        $this->assertNotContains('script.php', $entries);
+        $this->assertContains('cwmscripture.xml', $entries);
+    }
+
+    #[Test]
+    public function versionOverrideTakesPrecedenceOverManifest(): void
+    {
+        $this->writeManifest('cwmscripture.xml', '1.0.0');
+        $this->writeFile('src/Foo.php', '<?php');
+
+        $builder = new PackageBuilder($this->makeLibConfig(), $this->tmpDir);
+
+        $this->expectOutputRegex('/Building lib_cwmscripture-9\.9\.9\.zip \(v9\.9\.9\)/');
+
+        $zipPath = $builder->build('9.9.9');
+
+        $this->assertSame($this->tmpDir . '/build/dist/lib_cwmscripture-9.9.9.zip', $zipPath);
+    }
+
+    #[Test]
+    public function ensureMinifiedGateFailsWhenSiblingMissing(): void
+    {
+        $this->writeManifest('cwmscripture.xml', '1.0.0');
+        $this->writeFile('src/Foo.php', '<?php');
+        $this->writeFile('media/lib_cwmscripture/js/foo.js', 'console.log');
+        // foo.min.js intentionally missing.
+
+        $builder = new PackageBuilder($this->makeLibConfig(), $this->tmpDir);
+
+        $exitCode = -1;
+        $stderr   = '';
+
+        // Capture exit() via a child process — preg flag the missing-min message.
+        $script = <<<'PHP'
+<?php
+require '%s/src/Build/BuildConfig.php';
+require '%s/src/Build/ManifestReader.php';
+require '%s/src/Build/PackageBuilder.php';
+$cfg = CWM\BuildTools\Build\BuildConfig::fromArray(%s);
+$b   = new CWM\BuildTools\Build\PackageBuilder($cfg, '%s');
+$b->build();
+PHP;
+
+        $cwm   = realpath(__DIR__ . '/../..');
+        $cfg   = var_export($this->libConfigArray(), true);
+        $proj  = $this->tmpDir;
+        $code  = sprintf($script, $cwm, $cwm, $cwm, $cfg, $proj);
+        $tmpPhp = $this->tmpDir . '/_run.php';
+        file_put_contents($tmpPhp, $code);
+
+        $proc = proc_open(
+            ['php', $tmpPhp],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes
+        );
+
+        if (!is_resource($proc)) {
+            $this->fail('Could not spawn child PHP for gate test');
+        }
+
+        fclose($pipes[0] ?? STDIN);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($proc);
+
+        $this->assertSame(1, $exitCode, 'Gate failure should exit with 1');
+        $this->assertStringContainsString('missing minified assets', (string) $stderr);
+        $this->assertStringContainsString('foo.min.js', (string) $stderr);
+    }
+
+    #[Test]
+    public function ensureMinifiedGatePassesWhenAllPairsPresent(): void
+    {
+        $this->writeManifest('cwmscripture.xml', '1.0.0');
+        $this->writeFile('src/Foo.php', '<?php');
+        $this->writeFile('media/lib_cwmscripture/js/foo.js', 'console.log');
+        $this->writeFile('media/lib_cwmscripture/js/foo.min.js', 'console.log');
+        $this->writeFile('media/lib_cwmscripture/css/foo.css', '.foo{}');
+        $this->writeFile('media/lib_cwmscripture/css/foo.min.css', '.foo{}');
+
+        $builder = new PackageBuilder($this->makeLibConfig(), $this->tmpDir);
+
+        $this->expectOutputRegex('/Package built/');
+        $zipPath = $builder->build();
+        $this->assertFileExists($zipPath);
+    }
+
+    #[Test]
+    public function buildConfigRejectsMissingRequired(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('build.outputDir is required');
+
+        BuildConfig::fromArray([
+            'outputName' => 'foo-{version}.zip',
+            'manifest'   => 'foo.xml',
+            'sources'    => [['from' => 'src', 'to' => 'src']],
+        ]);
+    }
+
+    #[Test]
+    public function buildConfigRejectsEmptySources(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('build.sources is required');
+
+        BuildConfig::fromArray([
+            'outputDir'  => 'build/dist',
+            'outputName' => 'foo-{version}.zip',
+            'manifest'   => 'foo.xml',
+            'sources'    => [],
+        ]);
+    }
+
+    #[Test]
+    public function buildConfigRejectsUnknownPreBuildMode(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('build.preBuild.mode');
+
+        BuildConfig::fromArray([
+            'outputDir'  => 'build/dist',
+            'outputName' => 'foo-{version}.zip',
+            'manifest'   => 'foo.xml',
+            'sources'    => [['from' => 'src', 'to' => 'src']],
+            'preBuild'   => ['mode' => 'autorun'],
+        ]);
+    }
+
+    // --- Helpers ---
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function libConfigArray(): array
+    {
+        return [
+            'outputDir'  => 'build/dist',
+            'outputName' => 'lib_cwmscripture-{version}.zip',
+            'manifest'   => 'cwmscripture.xml',
+            'scriptFile' => 'script.php',
+            'sources'    => [
+                ['from' => 'src', 'to' => 'lib_cwmscripture/src'],
+                ['from' => 'sql', 'to' => 'lib_cwmscripture/sql'],
+                ['from' => 'language', 'to' => 'lib_cwmscripture/language'],
+                ['from' => 'media/lib_cwmscripture', 'to' => 'media/lib_cwmscripture'],
+            ],
+            'excludes'   => ['.git', '.DS_Store', '.idea', 'node_modules', '.php-cs-fixer.cache'],
+            'preBuild'   => [
+                'mode' => 'ensure-minified',
+                'dirs' => ['media/lib_cwmscripture/js', 'media/lib_cwmscripture/css'],
+            ],
+        ];
+    }
+
+    private function makeLibConfig(): BuildConfig
+    {
+        return BuildConfig::fromArray($this->libConfigArray());
+    }
+
+    private function writeManifest(string $relPath, string $version): void
+    {
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<extension type="library" method="upgrade">
+    <name>CWM Scripture</name>
+    <version>$version</version>
+    <creationDate>2026-05-09</creationDate>
+</extension>
+XML;
+        $this->writeFile($relPath, $xml);
+    }
+
+    private function writeFile(string $relPath, string $content): void
+    {
+        $abs = $this->tmpDir . '/' . $relPath;
+        $dir = dirname($abs);
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0o777, true);
+        }
+
+        file_put_contents($abs, $content);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function zipEntries(string $zipPath): array
+    {
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($zipPath) === true, "Could not open $zipPath");
+
+        $entries = [];
+
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $entries[] = (string) $zip->getNameIndex($i);
+        }
+
+        $zip->close();
+
+        return $entries;
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $entries = scandir($dir) ?: [];
+
+        foreach ($entries as $e) {
+            if ($e === '.' || $e === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $e;
+
+            if (is_link($path) || is_file($path)) {
+                @unlink($path);
+                continue;
+            }
+
+            $this->rrmdir($path);
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/Build/PackagerTest.php
+++ b/tests/Build/PackagerTest.php
@@ -1,0 +1,681 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Build;
+
+use CWM\BuildTools\Build\BuildConfig;
+use CWM\BuildTools\Build\PackageConfig;
+use CWM\BuildTools\Build\Packager;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ZipArchive;
+
+/**
+ * End-to-end tests for the multi-extension package assembler.
+ *
+ * Each test stands up a minimal fixture project, runs the Packager, and
+ * asserts the contents of the produced outer zip. Sub-build tests use a
+ * tiny Stub PHP build script that produces a known zip so we don't need
+ * a real Joomla extension on disk.
+ */
+final class PackagerTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/cwm-pkg-test-' . uniqid('', true);
+        mkdir($this->tmpDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->rrmdir($this->tmpDir);
+    }
+
+    // --- Layout: root vs packages-prefix ---
+
+    #[Test]
+    public function rootLayoutPlacesChildZipsAtOuterRoot(): void
+    {
+        $this->writeManifest('build/pkg.xml', '1.0.0');
+        $this->prebuildChild('build/dist/sub-1.0.0.zip', 'sub.xml');
+
+        $config = $this->makePackageConfig([
+            'innerLayout' => 'root',
+            'includes'    => [[
+                'type'       => 'prebuilt',
+                'distGlob'   => 'build/dist/sub-*.zip',
+                'outputName' => 'sub.zip',
+            ]],
+        ]);
+
+        $packager = new Packager($config, null, $this->tmpDir);
+        $this->expectOutputRegex('/Assembling pkg-1\.0\.0\.zip/');
+        $outer = $packager->package();
+
+        $entries = $this->zipEntries($outer);
+        $this->assertContains('pkg.xml', $entries);
+        $this->assertContains('sub.zip', $entries);
+        $this->assertNotContains('packages/sub.zip', $entries);
+    }
+
+    #[Test]
+    public function packagesPrefixLayoutPlacesChildZipsUnderPackagesDir(): void
+    {
+        $this->writeManifest('build/pkg.xml', '1.0.0');
+        $this->prebuildChild('build/dist/sub-1.0.0.zip', 'sub.xml');
+
+        $config = $this->makePackageConfig([
+            'innerLayout' => 'packages-prefix',
+            'includes'    => [[
+                'type'       => 'prebuilt',
+                'distGlob'   => 'build/dist/sub-*.zip',
+                'outputName' => 'sub.zip',
+            ]],
+        ]);
+
+        $packager = new Packager($config, null, $this->tmpDir);
+        $this->expectOutputRegex('/Assembling/');
+        $outer = $packager->package();
+
+        $entries = $this->zipEntries($outer);
+        $this->assertContains('pkg.xml', $entries);
+        $this->assertContains('packages/sub.zip', $entries);
+        $this->assertNotContains('sub.zip', $entries);
+    }
+
+    // --- prebuilt include ---
+
+    #[Test]
+    public function prebuiltMissingZipFailsWithHelpfulMessage(): void
+    {
+        $this->writeManifest('build/pkg.xml', '1.0.0');
+
+        $config = $this->makePackageConfig([
+            'includes' => [[
+                'type'       => 'prebuilt',
+                'distGlob'   => 'build/dist/sub-*.zip',
+                'outputName' => 'sub.zip',
+            ]],
+        ]);
+
+        $packager = new Packager($config, null, $this->tmpDir);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("no files matched distGlob 'build/dist/sub-*.zip'");
+        $this->expectOutputRegex('/Assembling/');
+        $packager->package();
+    }
+
+    #[Test]
+    public function prebuiltPicksMostRecentlyModifiedWhenMultipleMatch(): void
+    {
+        $this->writeManifest('build/pkg.xml', '1.0.0');
+        $this->prebuildChild('build/dist/sub-1.0.0.zip', 'sub.xml');
+        sleep(1);  // ensure mtime ordering is observable
+        $this->prebuildChild('build/dist/sub-1.1.0.zip', 'sub-newer.xml');
+
+        $config = $this->makePackageConfig([
+            'includes' => [[
+                'type'       => 'prebuilt',
+                'distGlob'   => 'build/dist/sub-*.zip',
+                'outputName' => 'sub.zip',
+            ]],
+        ]);
+
+        $packager = new Packager($config, null, $this->tmpDir);
+        $this->expectOutputRegex('/sub-1\.1\.0\.zip/');
+        $outer = $packager->package();
+
+        // The staged child zip's content should be from the newer build (sub-newer.xml inside).
+        $childEntries = $this->zipEntriesOfNested($outer, 'sub.zip');
+        $this->assertContains('sub-newer.xml', $childEntries);
+    }
+
+    // --- subBuild include ---
+
+    #[Test]
+    public function subBuildShellsOutAndPicksUpProducedZip(): void
+    {
+        $this->writeManifest('build/pkg.xml', '1.0.0');
+
+        // Create a sub-extension dir with a tiny PHP build script that writes a zip.
+        mkdir($this->tmpDir . '/lib', 0o777, true);
+        mkdir($this->tmpDir . '/lib/dist', 0o777, true);
+        file_put_contents($this->tmpDir . '/lib/build.php', <<<'PHP'
+<?php
+$zip = new ZipArchive();
+$out = __DIR__ . '/dist/lib-1.0.0.zip';
+$zip->open($out, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+$zip->addFromString('lib.xml', '<?xml version="1.0"?><extension/>');
+$zip->close();
+echo "  produced $out\n";
+PHP);
+
+        $config = $this->makePackageConfig([
+            'includes' => [[
+                'type'        => 'subBuild',
+                'path'        => 'lib',
+                'buildScript' => 'build.php',
+                'distGlob'    => 'dist/lib-*.zip',
+                'outputName'  => 'lib.zip',
+            ]],
+        ]);
+
+        $packager = new Packager($config, null, $this->tmpDir);
+        $this->expectOutputRegex('/sub-build lib\.zip/');
+        $outer = $packager->package();
+
+        $entries = $this->zipEntries($outer);
+        $this->assertContains('lib.zip', $entries);
+
+        // The staged child should contain lib.xml.
+        $childEntries = $this->zipEntriesOfNested($outer, 'lib.zip');
+        $this->assertContains('lib.xml', $childEntries);
+    }
+
+    #[Test]
+    public function subBuildFailsWhenScriptExitsNonZero(): void
+    {
+        $this->writeManifest('build/pkg.xml', '1.0.0');
+
+        mkdir($this->tmpDir . '/lib', 0o777, true);
+        file_put_contents($this->tmpDir . '/lib/build.php', "<?php exit(2);\n");
+
+        $config = $this->makePackageConfig([
+            'includes' => [[
+                'type'        => 'subBuild',
+                'path'        => 'lib',
+                'buildScript' => 'build.php',
+                'distGlob'    => 'dist/*.zip',
+                'outputName'  => 'lib.zip',
+            ]],
+        ]);
+
+        $packager = new Packager($config, null, $this->tmpDir);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('exited with 2');
+        $this->expectOutputRegex('/sub-build/');
+        $packager->package();
+    }
+
+    #[Test]
+    public function subBuildPassesArgsToScript(): void
+    {
+        $this->writeManifest('build/pkg.xml', '1.0.0');
+
+        mkdir($this->tmpDir . '/lib', 0o777, true);
+        mkdir($this->tmpDir . '/lib/dist', 0o777, true);
+        // Script writes the args it received into a marker file that we then
+        // also include in the zip so we can read it back at the test level.
+        file_put_contents($this->tmpDir . '/lib/build.php', <<<'PHP'
+<?php
+$args = array_slice($argv, 1);
+$marker = __DIR__ . '/_marker.txt';
+file_put_contents($marker, implode(' ', $args));
+$zip = new ZipArchive();
+$out = __DIR__ . '/dist/lib-1.0.0.zip';
+$zip->open($out, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+$zip->addFile($marker, '_marker.txt');
+$zip->close();
+PHP);
+
+        $config = $this->makePackageConfig([
+            'includes' => [[
+                'type'        => 'subBuild',
+                'path'        => 'lib',
+                'buildScript' => 'build.php',
+                'args'        => ['--plugin-only', 'extra'],
+                'distGlob'    => 'dist/lib-*.zip',
+                'outputName'  => 'lib.zip',
+            ]],
+        ]);
+
+        $packager = new Packager($config, null, $this->tmpDir);
+        $this->expectOutputRegex('/sub-build/');
+        $packager->package();
+
+        $marker = file_get_contents($this->tmpDir . '/lib/_marker.txt');
+        $this->assertSame('--plugin-only extra', $marker);
+    }
+
+    // --- inline include ---
+
+    #[Test]
+    public function inlineIncludeBuildsNestedConfigAndBundles(): void
+    {
+        $this->writeManifest('build/pkg.xml', '1.0.0');
+        $this->writeManifest('plg_task/cwmscripture.xml', '1.5.0');
+        $this->writeFile('plg_task/script.php', '<?php // task install');
+        $this->writeFile('plg_task/src/Task.php', '<?php // task');
+
+        $config = $this->makePackageConfig([
+            'includes' => [[
+                'type'       => 'inline',
+                'outputName' => 'plg_task.zip',
+                'config'     => [
+                    'outputDir'  => 'build/dist',
+                    'outputName' => 'plg_task-{version}.zip',
+                    'manifest'   => 'plg_task/cwmscripture.xml',
+                    'scriptFile' => 'plg_task/script.php',
+                    'sources'    => [
+                        ['from' => 'plg_task/src', 'to' => 'src'],
+                    ],
+                ],
+            ]],
+        ]);
+
+        $packager = new Packager($config, null, $this->tmpDir);
+        $this->expectOutputRegex('/inline build plg_task\.zip/');
+        $outer = $packager->package();
+
+        $entries = $this->zipEntries($outer);
+        $this->assertContains('plg_task.zip', $entries);
+
+        $childEntries = $this->zipEntriesOfNested($outer, 'plg_task.zip');
+        $this->assertContains('cwmscripture.xml', $childEntries);
+        $this->assertContains('script.php', $childEntries);
+        $this->assertContains('src/Task.php', $childEntries);
+    }
+
+    // --- self include ---
+
+    #[Test]
+    public function selfIncludeBuildsParentBuildConfig(): void
+    {
+        $this->writeManifest('build/pkg.xml', '1.0.0');
+        $this->writeManifest('main.xml', '2.0.0');
+        $this->writeFile('src/Foo.php', '<?php');
+
+        $parentBuild = BuildConfig::fromArray([
+            'outputDir'  => 'build/dist',
+            'outputName' => 'main-{version}.zip',
+            'manifest'   => 'main.xml',
+            'sources'    => [['from' => 'src', 'to' => 'src']],
+        ]);
+
+        $config = $this->makePackageConfig([
+            'includes' => [[
+                'type'       => 'self',
+                'outputName' => 'main.zip',
+            ]],
+        ]);
+
+        $packager = new Packager($config, $parentBuild, $this->tmpDir);
+        $this->expectOutputRegex('/building self \(main\.zip\)/');
+        $outer = $packager->package();
+
+        $entries = $this->zipEntries($outer);
+        $this->assertContains('main.zip', $entries);
+
+        $childEntries = $this->zipEntriesOfNested($outer, 'main.zip');
+        $this->assertContains('main.xml', $childEntries);
+        $this->assertContains('src/Foo.php', $childEntries);
+    }
+
+    #[Test]
+    public function selfIncludeRequiresParentBuildConfig(): void
+    {
+        $this->writeManifest('build/pkg.xml', '1.0.0');
+
+        $config = $this->makePackageConfig([
+            'includes' => [[
+                'type'       => 'self',
+                'outputName' => 'main.zip',
+            ]],
+        ]);
+
+        $packager = new Packager($config, null, $this->tmpDir);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("'self' entry, but the project's `build:` block isn't loaded");
+        $this->expectOutputRegex('/Assembling/');
+        $packager->package();
+    }
+
+    // --- installer + language files ---
+
+    #[Test]
+    public function installerAndLanguageFilesLandAtConfiguredPaths(): void
+    {
+        $this->writeManifest('build/pkg.xml', '1.0.0');
+        $this->prebuildChild('build/dist/sub-1.0.0.zip', 'sub.xml');
+        $this->writeFile('build/script.install.php', '<?php // installer');
+        $this->writeFile('build/language/en-GB/en-GB.pkg.sys.ini', 'PKG_TITLE="Hi"');
+
+        $config = $this->makePackageConfig([
+            'installer'     => 'build/script.install.php',
+            'languageFiles' => [[
+                'from' => 'build/language/en-GB/en-GB.pkg.sys.ini',
+                'to'   => 'language/en-GB/en-GB.pkg.sys.ini',
+            ]],
+            'includes' => [[
+                'type'       => 'prebuilt',
+                'distGlob'   => 'build/dist/sub-*.zip',
+                'outputName' => 'sub.zip',
+            ]],
+        ]);
+
+        $packager = new Packager($config, null, $this->tmpDir);
+        $this->expectOutputRegex('/Assembling/');
+        $outer = $packager->package();
+
+        $entries = $this->zipEntries($outer);
+        $this->assertContains('pkg.xml', $entries);
+        $this->assertContains('script.install.php', $entries);
+        $this->assertContains('language/en-GB/en-GB.pkg.sys.ini', $entries);
+        $this->assertContains('sub.zip', $entries);
+    }
+
+    // --- verify step ---
+
+    #[Test]
+    public function verifyPassesWhenAllExpectedEntriesArePresent(): void
+    {
+        $this->writeManifest('build/pkg.xml', '1.0.0');
+        $this->prebuildChild('build/dist/sub-1.0.0.zip', 'sub.xml');
+
+        $config = $this->makePackageConfig([
+            'includes' => [[
+                'type'       => 'prebuilt',
+                'distGlob'   => 'build/dist/sub-*.zip',
+                'outputName' => 'sub.zip',
+            ]],
+            'verify' => [
+                'expectedEntries' => ['pkg.xml', 'sub.zip'],
+            ],
+        ]);
+
+        $packager = new Packager($config, null, $this->tmpDir);
+        $this->expectOutputRegex('/2 expected entries present/');
+        $outer = $packager->package();
+
+        $this->assertFileExists($outer);
+    }
+
+    #[Test]
+    public function verifyFailsWhenExpectedEntryIsMissing(): void
+    {
+        $this->writeManifest('build/pkg.xml', '1.0.0');
+        $this->prebuildChild('build/dist/sub-1.0.0.zip', 'sub.xml');
+
+        $config = $this->makePackageConfig([
+            'includes' => [[
+                'type'       => 'prebuilt',
+                'distGlob'   => 'build/dist/sub-*.zip',
+                'outputName' => 'sub.zip',
+            ]],
+            'verify' => [
+                'expectedEntries' => ['pkg.xml', 'missing.zip'],
+            ],
+        ]);
+
+        $packager = new Packager($config, null, $this->tmpDir);
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('missing entries');
+        $this->expectOutputRegex('/Assembling/');
+        $packager->package();
+    }
+
+    // --- version override ---
+
+    #[Test]
+    public function versionOverrideTakesPrecedenceOverManifest(): void
+    {
+        $this->writeManifest('build/pkg.xml', '1.0.0');
+        $this->prebuildChild('build/dist/sub-1.0.0.zip', 'sub.xml');
+
+        $config = $this->makePackageConfig([
+            'outputName' => 'pkg-{version}.zip',
+            'includes'   => [[
+                'type'       => 'prebuilt',
+                'distGlob'   => 'build/dist/sub-*.zip',
+                'outputName' => 'sub.zip',
+            ]],
+        ]);
+
+        $packager = new Packager($config, null, $this->tmpDir);
+        $this->expectOutputRegex('/pkg-9\.9\.9\.zip/');
+        $outer = $packager->package('9.9.9');
+
+        $this->assertSame($this->tmpDir . '/build/dist/pkg-9.9.9.zip', $outer);
+    }
+
+    // --- config validation ---
+
+    #[Test]
+    public function packageConfigRejectsMissingRequired(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('package.manifest is required');
+
+        PackageConfig::fromArray([
+            'outputDir'  => 'build/dist',
+            'outputName' => 'pkg-{version}.zip',
+            'includes'   => [['type' => 'self', 'outputName' => 'main.zip']],
+        ]);
+    }
+
+    #[Test]
+    public function packageConfigRejectsEmptyIncludes(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('package.includes is required');
+
+        PackageConfig::fromArray([
+            'manifest'   => 'pkg.xml',
+            'outputDir'  => 'build/dist',
+            'outputName' => 'pkg-{version}.zip',
+            'includes'   => [],
+        ]);
+    }
+
+    #[Test]
+    public function packageConfigRejectsInvalidIncludeType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('package.includes[0].type');
+
+        PackageConfig::fromArray([
+            'manifest'   => 'pkg.xml',
+            'outputDir'  => 'build/dist',
+            'outputName' => 'pkg-{version}.zip',
+            'includes'   => [['type' => 'bogus', 'outputName' => 'x.zip']],
+        ]);
+    }
+
+    #[Test]
+    public function packageConfigRejectsInvalidLayout(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('package.innerLayout');
+
+        PackageConfig::fromArray([
+            'manifest'    => 'pkg.xml',
+            'outputDir'   => 'build/dist',
+            'outputName'  => 'pkg-{version}.zip',
+            'innerLayout' => 'flat',
+            'includes'    => [['type' => 'self', 'outputName' => 'm.zip']],
+        ]);
+    }
+
+    #[Test]
+    public function packageConfigRejectsSubBuildMissingPath(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("package.includes[0] (type subBuild) requires non-empty 'path'");
+
+        PackageConfig::fromArray([
+            'manifest'   => 'pkg.xml',
+            'outputDir'  => 'build/dist',
+            'outputName' => 'pkg-{version}.zip',
+            'includes'   => [[
+                'type'        => 'subBuild',
+                'outputName'  => 'lib.zip',
+                'buildScript' => 'build.php',
+                'distGlob'    => 'dist/*.zip',
+            ]],
+        ]);
+    }
+
+    #[Test]
+    public function packageConfigRejectsInlineMissingNestedConfig(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("package.includes[0] (type inline) requires a 'config' object");
+
+        PackageConfig::fromArray([
+            'manifest'   => 'pkg.xml',
+            'outputDir'  => 'build/dist',
+            'outputName' => 'pkg-{version}.zip',
+            'includes'   => [['type' => 'inline', 'outputName' => 'x.zip']],
+        ]);
+    }
+
+    // --- Helpers ---
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function makePackageConfig(array $overrides = []): PackageConfig
+    {
+        $base = [
+            'manifest'    => 'build/pkg.xml',
+            'outputDir'   => 'build/dist',
+            'outputName'  => 'pkg-{version}.zip',
+            'innerLayout' => 'root',
+        ];
+
+        return PackageConfig::fromArray(array_merge($base, $overrides));
+    }
+
+    private function writeManifest(string $relPath, string $version): void
+    {
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<extension type="library" method="upgrade">
+    <name>Test</name>
+    <version>$version</version>
+    <creationDate>2026-05-09</creationDate>
+</extension>
+XML;
+        $this->writeFile($relPath, $xml);
+    }
+
+    private function writeFile(string $relPath, string $content): void
+    {
+        $abs = $this->tmpDir . '/' . $relPath;
+        $dir = dirname($abs);
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0o777, true);
+        }
+
+        file_put_contents($abs, $content);
+    }
+
+    /**
+     * Pre-create a child zip with a single XML entry to simulate an
+     * already-built sub-extension on disk.
+     */
+    private function prebuildChild(string $relPath, string $manifestEntryName): void
+    {
+        $abs = $this->tmpDir . '/' . $relPath;
+        $dir = dirname($abs);
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0o777, true);
+        }
+
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($abs, ZipArchive::CREATE | ZipArchive::OVERWRITE) === true);
+        $zip->addFromString($manifestEntryName, '<?xml version="1.0"?><extension/>');
+        $zip->close();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function zipEntries(string $zipPath): array
+    {
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($zipPath) === true, "Could not open $zipPath");
+
+        $entries = [];
+
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $entries[] = (string) $zip->getNameIndex($i);
+        }
+
+        $zip->close();
+
+        return $entries;
+    }
+
+    /**
+     * Extract a nested zip from $outerPath, then return the entries of that
+     * inner zip — used to verify what landed inside child zips.
+     *
+     * @return list<string>
+     */
+    private function zipEntriesOfNested(string $outerPath, string $innerEntry): array
+    {
+        $outer = new ZipArchive();
+        $this->assertTrue($outer->open($outerPath) === true);
+
+        $tmp = tempnam(sys_get_temp_dir(), 'cwm-nested-');
+
+        // Use file_put_contents on the stream; ZipArchive::extractTo would
+        // require a destination dir.
+        $bytes = $outer->getFromName($innerEntry);
+        $outer->close();
+
+        if ($bytes === false) {
+            $this->fail("Inner entry '$innerEntry' missing from outer zip $outerPath");
+        }
+
+        file_put_contents($tmp, $bytes);
+
+        $inner   = new ZipArchive();
+        $this->assertTrue($inner->open($tmp) === true);
+        $entries = [];
+
+        for ($i = 0; $i < $inner->numFiles; $i++) {
+            $entries[] = (string) $inner->getNameIndex($i);
+        }
+
+        $inner->close();
+        @unlink($tmp);
+
+        return $entries;
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $entries = scandir($dir) ?: [];
+
+        foreach ($entries as $e) {
+            if ($e === '.' || $e === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $e;
+
+            if (is_link($path) || is_file($path)) {
+                @unlink($path);
+                continue;
+            }
+
+            $this->rrmdir($path);
+        }
+
+        @rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary

**PR D of 5** for issue #5. Replaces the prior `cwm-package` shell-pass-through wrapper with a generic Joomla multi-extension package assembler driven by a new `package:` block in `cwm-build.config.json`.

> ⚠️ **Stacked on PR B (#13).** Diff base is `feat/cwm-build-binary` since PR D shares `BuildConfig` and `PackageBuilder` from PR B. Merge order: B first, then this. Sibling to PR C (#14); both rebase onto main once B merges.

## Four `includes[]` entry types

| Type | What it does | Real-world consumer |
|---|---|---|
| `self` | Invoke `cwm-build` on the project's own `build:` block, then bundle the result | Proclaim's "step 3: build com_proclaim" |
| `subBuild` | array-form `proc_open` of `php <buildScript> [args]` inside `path`, then glob `distGlob` for the produced zip | Proclaim's two `passthru('php …/build-package.php …')` calls (incl. `--plugin-only`) during transition |
| `prebuilt` | Assume already on disk; glob `distGlob` (project-relative). Multiple matches → most-recently modified wins | CSL where the lib zip is already produced upstream |
| `inline` | Nested `BuildConfig`; `cwm-build` runs in-process on it | CSL's `plg_task_cwmscripture` (sibling dir built in-process) |

## Other features

- **`innerLayout`** — `"root"` places child zips at outer-zip root (CSL); `"packages-prefix"` places them under `packages/<outputName>` (Proclaim). Default `"root"`.
- **`installer`** — optional `script.install.php` at outer-zip root.
- **`languageFiles[]`** — explicit `{ from, to }` pairs with arbitrary in-zip paths (Proclaim's `language/en-GB/en-GB.pkg_proclaim.sys.ini`).
- **`verify.expectedEntries[]`** — opt-in self-check; re-opens the assembled zip and asserts each entry is present. Ports CSL's `verifyPackage` feature.

## Implementation notes

- **No shell-driven `rm -rf`** anywhere — staging dir cleanup is native PHP recursion with `is_link()` guards (CLAUDE.md guardrail).
- **All sub-build calls use array-form `proc_open`** — no shell, no metachar interpretation.
- **`proc_open` descriptors use `php://stdout`/`php://stderr` URIs** instead of the predefined `STDOUT`/`STDERR` resources — those constants become invalid if an earlier test under PHPUnit's random-order runs has closed the parent's stdio. The URIs reopen fresh handles per call. (Discovered the hard way during test suite stabilization.)
- **Staging is `sys_get_temp_dir()/cwm-package-<uniqid>/`** — outside the project tree so a crash mid-assembly doesn't leave artifacts.
- **`try/finally`** wraps the include-resolve + outer-zip-write so staging always gets cleaned even when verify fails.

## Tests

20 new tests / 79 new assertions (48 → 68 / 151 → 230):

| Category | Tests |
|---|---|
| Layout | `rootLayoutPlacesChildZipsAtOuterRoot`, `packagesPrefixLayoutPlacesChildZipsUnderPackagesDir` |
| `prebuilt` | `prebuiltMissingZipFailsWithHelpfulMessage`, `prebuiltPicksMostRecentlyModifiedWhenMultipleMatch` |
| `subBuild` | `subBuildShellsOutAndPicksUpProducedZip`, `subBuildFailsWhenScriptExitsNonZero`, `subBuildPassesArgsToScript` |
| `inline` | `inlineIncludeBuildsNestedConfigAndBundles` |
| `self` | `selfIncludeBuildsParentBuildConfig`, `selfIncludeRequiresParentBuildConfig` |
| Manifest extras | `installerAndLanguageFilesLandAtConfiguredPaths` |
| `verify` | `verifyPassesWhenAllExpectedEntriesArePresent`, `verifyFailsWhenExpectedEntryIsMissing` |
| Override | `versionOverrideTakesPrecedenceOverManifest` |
| Validation | 6 tests (missing required, empty includes, invalid type, invalid layout, subBuild missing path, inline missing nested config) |

End-to-end tests both **assemble the outer zip** and **extract child zips** from it to assert nested entries — the only meaningful coverage when the produced artifact is a multi-level zip.

CLI smoke-tested against a fixture combining `self` + `prebuilt` + `inline` plus installer + language files + verify; all 6 expected outer-zip entries appear at the correct paths and verify reports success.

## Files

- `src/Build/PackageConfig.php` — new (~210 lines)
- `src/Build/Packager.php` — new (~440 lines)
- `scripts/package.php` — new CLI entry (~145 lines)
- `bin/cwm-package` — rewritten (was 28 lines of `bash -c $build.command` shim; now a thin delegate)
- `tests/Build/PackagerTest.php` — new (~680 lines)
- `CHANGELOG.md` — entry under `[Unreleased]`

## Roadmap

| PR | Scope | Status |
|---|---|---|
| A — #12 | `Build\Prompt` extraction | open |
| B — #13 | `cwm-build` for lib_cwmscripture's shape | open |
| C — #14 | Proclaim strict-mode features | open |
| **D — this PR** | `cwm-package` with 4 `includes[]` types + verify | **this PR** |
| C′ (follow-up) | 3-way version prompt — depends on A + C | not started |
| E | Cut v0.5.0-alpha + migration guide | not started |

## Test plan

- [x] `composer test` — 68/68 passing, 230 assertions
- [x] CLI smoke against a fixture with `self` + `prebuilt` + `inline` + installer + language file + verify (6 expected outer-zip entries; all correct)
- [x] `git archive` dist verification — only source files (no test fixtures shipped)
- [ ] Migrate Proclaim to call `cwm-package` (separate Proclaim PR) and `diff -r` against the legacy proclaim_build.php output
- [ ] Migrate CSL to call `cwm-package` (separate CSL PR) and confirm the `verifyPackage` step passes

Refs #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)