### PR TITLE
chore(release): cut v0.5.0-alpha — PR E of #5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,94 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.0-alpha] - 2026-05-09
+
+First minor bump on the alpha line. Consolidates the per-consumer build /
+package scripts (Proclaim's `proclaim_build.php`, lib_cwmscripture's
+`build-package.php`, CWMScriptureLinks' `build-package.php`) into two
+generic binaries — `cwm-build` and `cwm-package` — driven by new
+`build:` and `package:` blocks in `cwm-build.config.json`. Adds
+`cwm-article`, `cwm-joomla-cms-deps`, and a parameterized
+`build-assets.js` template (issue #7), plus pre-flight `git pull` /
+submodule sync in `cwm-release` (issue #6).
+
+**Schema is additive**, but `cwm-package` itself changes behavior — see
+the migration guide below before bumping. Consumers pinned to `^0.4@alpha`
+do **not** auto-pick this up; they must update their constraint to
+`^0.5@alpha` (or pin to `0.5.0-alpha`) and adopt the new schema fields.
+
+### Migration guide
+
+| Concern | Old (0.4.x) | New (0.5.0) |
+|---|---|---|
+| Build a single zip | `"command": "php build/build-package.php"` (project script) | `"command": "cwm-build"` + new `build:` schema fields below |
+| Assemble multi-ext package | `"command": "php build/proclaim_build.php package"` (project script) | `"command": "cwm-package"` + new `package:` block |
+| `cwm-package` binary | thin `bash -c $build.command` shim | generic assembler reading `package:` block |
+| `cwm-build` binary | did not exist | new — see below |
+
+**Required `composer.json` change** (consumers using cwm-build-tools):
+
+```json
+{
+    "require-dev": {
+        "cwm/build-tools": "^0.5@alpha"
+    }
+}
+```
+
+**Required `cwm-build.config.json` additions** to use the new binaries:
+
+- For a single-extension build (lib_cwmscripture-shape):
+  ```json
+  "build": {
+      "command":    "cwm-build",
+      "outputGlob": "build/dist/lib_cwmscripture-*.zip",
+      "outputDir":  "build/dist",
+      "outputName": "lib_cwmscripture-{version}.zip",
+      "manifest":   "cwmscripture.xml",
+      "scriptFile": "script.php",
+      "sources": [
+          { "from": "src",                    "to": "lib_cwmscripture/src" },
+          { "from": "media/lib_cwmscripture", "to": "media/lib_cwmscripture" }
+      ],
+      "excludes": [".git", ".DS_Store", "node_modules"],
+      "preBuild": {
+          "mode": "ensure-minified",
+          "dirs": ["media/lib_cwmscripture/js", "media/lib_cwmscripture/css"]
+      }
+  }
+  ```
+
+- For a Proclaim-shape strict build, additionally set `excludeMatchMode:
+  "strict"`, `vendorPrune: true`, `includeRoots`, `includeRootExtensions`,
+  `excludeExtensions`, `excludePaths`, and `preBuild.mode: "run"` with
+  `preBuild.command: "npm install && npm run build"`.
+
+- For a multi-extension package wrapper:
+  ```json
+  "package": {
+      "manifest":     "build/pkg_proclaim.xml",
+      "outputDir":    "build/dist",
+      "outputName":   "pkg_proclaim-{version}.zip",
+      "innerLayout":  "packages-prefix",
+      "installer":    "build/script.install.php",
+      "languageFiles": [
+          { "from": "build/language/en-GB/en-GB.pkg_proclaim.sys.ini",
+            "to":   "language/en-GB/en-GB.pkg_proclaim.sys.ini" }
+      ],
+      "includes": [
+          { "type": "self",     "outputName": "com_proclaim.zip" },
+          { "type": "subBuild", "path": "libraries/lib_cwmscripture",
+            "buildScript": "build/build-package.php",
+            "distGlob":    "build/dist/lib_cwmscripture-*.zip",
+            "outputName":  "lib_cwmscripture.zip" }
+      ]
+  }
+  ```
+
+After migration the project's own `build/build-package.php` /
+`build/proclaim_build.php` scripts can be deleted.
+
 ### Added
 
 - `cwm-build` 3-way interactive version prompt — new optional


### PR DESCRIPTION
## Summary

**PR E of 5** — final piece of issue #5. Cuts the v0.5.0-alpha release with a CHANGELOG migration guide for consumers.

## What this PR does

1. Moves the (sizable) `[Unreleased]` block under a new `## [0.5.0-alpha] - 2026-05-09` heading.
2. Adds a release-overview intro explaining the consolidation work and signaling the schema-additive-but-binary-behavior-changing nature of the bump.
3. Adds a **Migration guide** table + concrete example configs for the three consumer shapes (single-extension build, Proclaim-shape strict build, multi-extension package).
4. Empty `[Unreleased]` placeholder remains at the top for future work.

> ℹ️ **Rebased after PR #19** (3-way version prompt) merged. The version prompt entry now sits under `[0.5.0-alpha]` along with the rest of the release content.

## Why a minor bump

Per the alpha-line versioning policy in CLAUDE.md:

> **Minor bump (`0.4.x-alpha` → `0.5.0-alpha`)** — breaking schema or CLI changes. Consumers must update their constraint.

The schema additions are technically additive, BUT `bin/cwm-package`'s behavior changed: it was a thin `bash -c $build.command` wrapper in 0.4.x, now it's a config-driven assembler reading a `package:` block. Any consumer that had `cwm-package` wired to invoke their old build script will need to either:
- Switch the wired script back to `build.command` directly, OR
- Add a `package:` block to their `cwm-build.config.json`.

So consumers pinned to `^0.4@alpha` correctly do NOT auto-pick this up; they must bump their constraint to `^0.5@alpha`.

## Headline changes since 0.4.1-alpha

- **`cwm-build`** (new) — config-driven extension zip builder; loose/strict exclude modes, vendor pruning, include-roots filter, ensure-minified gate, run-mode pre-build (#5 PR B + C)
- **`cwm-build` 3-way version prompt** — opt-in `versionPrompt` config field; offers manifest / date-stamped / custom version choice on ad-hoc local builds (#19)
- **`cwm-package`** (rewritten) — multi-extension package assembler with four `includes[]` entry types (`self`/`subBuild`/`prebuilt`/`inline`), two `innerLayout`s, opt-in self-verify (#5 PR D)
- **`Build\Prompt`** — extracted `ask()` helper with the countdown + ANSI redraw fix from Proclaim (#5 PR A)
- **`cwm-article`** — generic CWM release announcement poster (#7)
- **`cwm-joomla-cms-deps`** — generic joomla-cms test source cloner (#7)
- **`build-assets.js` template** — config-driven asset copier (#7)
- **`cwm-release` pre-flight** — `git pull --ff-only` + submodule sync + warn on untagged submodule pointers (#6)

## Test suite size

| Metric | v0.4.1-alpha | v0.5.0-alpha |
|---|---|---|
| Tests | 40 | 91 |
| Assertions | 100 | 310 |

## Roadmap status

| PR | Scope | Status |
|---|---|---|
| A — #12 | `Build\Prompt` extraction | merged |
| B — #13 | `cwm-build` for lib_cwmscripture | merged |
| C — #16 | Strict-mode features | merged |
| D — #17 | `cwm-package` with 4 `includes[]` types | merged |
| C′ — #19 | 3-way version prompt | merged |
| **E — this PR** | v0.5.0-alpha cut + migration guide | **this PR** |

After this PR merges, the post-merge release flow per CLAUDE.md is:

```
git tag -a v0.5.0-alpha -m "v0.5.0-alpha"
git push origin v0.5.0-alpha
gh release create v0.5.0-alpha --prerelease --title 'v0.5.0-alpha' --notes "..."
```

That's a manual step (per repo policy — no auto-tagging from PRs).

## What's still deferred

- **Per-consumer migrations** (Proclaim, lib_cwmscripture, CSL) — separate PRs in those repos that switch `build.command` and `package.command` to the new binaries and delete the legacy build scripts. They unlock fully on `composer update` once `0.5.0-alpha` is tagged and pushed.

## Test plan

- [x] `composer test` — 91/91 passing, 310 assertions
- [x] CHANGELOG structure verified — `[Unreleased]` empty placeholder, `[0.5.0-alpha]` with intro + migration guide + Added section, `[0.4.1-alpha]` follows
- [ ] After merge: tag + push + GH release per CLAUDE.md release flow
- [ ] After tag: validate one consumer's migration end-to-end (suggest lib_cwmscripture as the simplest first migration)

Closes #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)