### PR TITLE
fix(build): ensure-minified gate only checks .js / .css primary assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.1-alpha] - 2026-05-09
+
+Patch release for one bug surfaced during the lib_cwmscripture migration
+to v0.5.0-alpha.
+
+### Fixed
+
+- `cwm-build` `preBuild.mode: "ensure-minified"` gate now only checks
+  primary asset extensions (`.js`, `.css`). Earlier the gate iterated
+  every extension in the configured directories and reported spurious
+  failures like `foo.min.js.map → expected foo.min.js.min.map` for
+  source-map (`.map`) and gzip (`.gz`) companions of already-minified
+  files. The first end-to-end consumer migration (lib_cwmscripture)
+  surfaced this immediately; consumers of v0.5.0-alpha that hit the
+  same gate failure should bump to `^0.5@alpha` (auto-picks 0.5.1) or
+  pin to `0.5.1-alpha` directly. Regression test added.
+
 ## [0.5.0-alpha] - 2026-05-09
 
 First minor bump on the alpha line. Consolidates the per-consumer build /

--- a/src/Build/PackageBuilder.php
+++ b/src/Build/PackageBuilder.php
@@ -197,6 +197,15 @@ final class PackageBuilder
      */
     private function ensureMinifiedAssets(array $dirs): void
     {
+        // Only check primary web-asset extensions. Other files in the same
+        // directory (e.g. `*.min.js.map` source maps, `*.min.js.gz` rollup
+        // gzips, `joomla.asset.json`) are not "primary assets that need a
+        // minified sibling" — they're derived from the minified version, or
+        // configuration metadata. Earlier versions of this gate iterated
+        // every extension and produced spurious failures like
+        // `foo.min.js.map → expected foo.min.js.min.map`.
+        $primaryExtensions = ['js', 'css'];
+
         $missing = [];
 
         foreach ($dirs as $relDir) {
@@ -217,7 +226,11 @@ final class PackageBuilder
                     continue;
                 }
 
-                $ext = $m[1];
+                $ext = strtolower($m[1]);
+
+                if (!in_array($ext, $primaryExtensions, true)) {
+                    continue;
+                }
 
                 if (str_ends_with($entry, '.min.' . $ext)) {
                     continue;

--- a/tests/Build/PackageBuilderTest.php
+++ b/tests/Build/PackageBuilderTest.php
@@ -178,6 +178,37 @@ PHP;
     }
 
     #[Test]
+    public function ensureMinifiedGateIgnoresDerivedFiles(): void
+    {
+        // Regression: an earlier implementation iterated every extension in
+        // the gated directories and treated `.map` / `.gz` companions as
+        // "primary assets that need a minified sibling", producing spurious
+        // failures like `foo.min.js.map → expected foo.min.js.min.map`. The
+        // gate should only check actual primary `.js`/`.css` files.
+        $this->writeManifest('cwmscripture.xml', '1.0.0');
+        $this->writeFile('src/Foo.php', '<?php');
+        // Real primary assets + their minified pairs
+        $this->writeFile('media/lib_cwmscripture/js/scripture-tooltip.js', 'console.log');
+        $this->writeFile('media/lib_cwmscripture/js/scripture-tooltip.min.js', 'console.log');
+        // Source maps + gzip companions that don't need their own minified pair
+        $this->writeFile('media/lib_cwmscripture/js/scripture-tooltip.min.js.map', '{}');
+        $this->writeFile('media/lib_cwmscripture/js/scripture-tooltip.min.js.gz', '');
+        $this->writeFile('media/lib_cwmscripture/js/scripture-tooltip.js.map', '{}');
+        // Asset-bundle metadata
+        $this->writeFile('media/lib_cwmscripture/js/joomla.asset.json', '{}');
+        // CSS path with the same shape
+        $this->writeFile('media/lib_cwmscripture/css/scripture-text.css', '.s{}');
+        $this->writeFile('media/lib_cwmscripture/css/scripture-text.min.css', '.s{}');
+        $this->writeFile('media/lib_cwmscripture/css/scripture-text.min.css.map', '{}');
+
+        $builder = new PackageBuilder($this->makeLibConfig(), $this->tmpDir);
+
+        $this->expectOutputRegex('/Package built/');
+        $zipPath = $builder->build();
+        $this->assertFileExists($zipPath);
+    }
+
+    #[Test]
     public function buildConfigRejectsMissingRequired(): void
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
## Summary

Patch fix surfaced during the **lib_cwmscripture migration to v0.5.0-alpha** — the first end-to-end consumer migration. The `preBuild.mode: "ensure-minified"` gate iterated every extension in the configured directories and reported spurious failures like:

```
Pre-build gate failed: missing minified assets:
  - media/lib_cwmscripture/js/scripture-tooltip.min.js.map
  - media/lib_cwmscripture/js/translations-manager.min.js.min.gz
  - media/lib_cwmscripture/css/scripture-text.min.css.min.map
  ...
```

These are source-map (`.map`) and gzip (`.gz`) companions of already-minified files — they're **derived** from minified output and don't need their own minified sibling.

## Fix

Restrict gate iteration to files whose final extension is in a fixed allowlist of primary web-asset extensions: `['js', 'css']`. Source maps, gzipped variants, and other companion files are skipped.

Matches the legacy `lib_cwmscripture/build/build-package.php`'s behavior, which only globbed `*.js` and `*.css` and ignored everything else in the same directory.

## Tests

1 new regression test covering the exact scenario from lib's tree:

- `scripture-tooltip.js` + `scripture-tooltip.min.js` ✓ (real pair)
- `scripture-tooltip.min.js.map` (source map for the minified) — **was** spuriously failing
- `scripture-tooltip.min.js.gz` (rollup gzip companion) — **was** spuriously failing
- `scripture-tooltip.js.map` (source map for unminified) — **was** spuriously failing
- `joomla.asset.json` (asset-bundle metadata) — **was** spuriously failing
- Plus the same pattern for `.css`

After fix: gate passes cleanly. Total suite: **92 / 312** (was 91 / 310).

## Files

- `src/Build/PackageBuilder.php` — `ensureMinifiedAssets()` adds extension allowlist
- `tests/Build/PackageBuilderTest.php` — `ensureMinifiedGateIgnoresDerivedFiles` regression test
- `CHANGELOG.md` — entry under new `[0.5.1-alpha] - 2026-05-09` heading (proposed patch release)

## Plan

1. Merge this PR
2. Tag `v0.5.1-alpha` and push
3. Resume the lib_cwmscripture migration on the patched version (`composer update` auto-picks it up via `^0.5@alpha`)

Refs #5 (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)