### PR TITLE
fix(package): self include inherits outer wrapper version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.2-alpha] - 2026-05-10
+
+Patch release for the version-threading gap surfaced during the Proclaim
+migration to v0.5.0-alpha.
+
+### Changed
+
+- `cwm-package` `self` include now inherits the outer wrapper's version
+  for its inner `cwm-build` invocation. Previously the inner build read
+  its own manifest's `<version>`; if that drifted from the package
+  manifest's `<version>` (e.g. between `cwm-bump` runs, or with
+  `cwm-package --version X` overriding only the outer name) the inner
+  zip would land at a different version than the wrapper. This was the
+  reason the v0.5.0/0.5.1 release notes asked Proclaim to **not** enable
+  `versionPrompt: { enabled: true }` — an interactive prompt could
+  produce mismatched inner and outer versions. With this fix, the outer
+  version (whether from manifest, `--version` CLI override, or future
+  prompt result) is threaded into the `self` include's `cwm-build` call
+  via `PackageBuilder::build($outerVersion)`. `inline`, `subBuild`, and
+  `prebuilt` includes are version-independent (their version sources
+  are nested manifests, sub-build script outputs, and pre-built
+  artifacts respectively) and remain unchanged. Released this as a
+  patch on the alpha line because: (a) no consumer has merged the new
+  binaries yet, only PRs are open against them; (b) the prior behavior
+  was unintentionally inconsistent with the `self` semantic ("this same
+  project") rather than a deliberate API choice. 2 new tests covering
+  the threading invariant + the CLI override path; the diagnostic
+  output line now includes the inherited version (`-> building self
+  (X.zip) at vN.N.N`).
+
+  Once consumers are on `^0.5@alpha` (auto-picks 0.5.2), Proclaim can
+  enable `versionPrompt: { enabled: true }` and have the prompt result
+  flow consistently from `cwm-package`'s outer manifest read into the
+  `self` include's inner build.
+
 ## [0.5.1-alpha] - 2026-05-09
 
 Patch release for one bug surfaced during the lib_cwmscripture migration

--- a/src/Build/Packager.php
+++ b/src/Build/Packager.php
@@ -79,7 +79,7 @@ final class Packager
         $stagingDir = $this->createStagingDir();
 
         try {
-            $stagedChildren = $this->resolveIncludes($stagingDir);
+            $stagedChildren = $this->resolveIncludes($stagingDir, $version);
             $this->writeOuterZip($outputPath, $manifestPath, $stagedChildren);
 
             if ($this->config->verify !== null) {
@@ -100,9 +100,16 @@ final class Packager
     /**
      * Resolve every `includes[]` entry into an absolute path to a staged zip.
      *
+     * `$outerVersion` is threaded into `self` includes so the inner build
+     * uses the same version as the outer wrapper — Proclaim's `pkg_proclaim`
+     * shape, where the package and the main extension share one version
+     * cadence. `inline`, `subBuild`, and `prebuilt` includes are version-
+     * independent (they have their own manifest, their own dist glob, or
+     * their own pre-built artifact respectively) and are NOT threaded.
+     *
      * @return list<array{outputName: string, path: string}>
      */
-    private function resolveIncludes(string $stagingDir): array
+    private function resolveIncludes(string $stagingDir, string $outerVersion): array
     {
         $resolved = [];
 
@@ -111,7 +118,7 @@ final class Packager
 
             switch ($include['type']) {
                 case PackageConfig::TYPE_SELF:
-                    $stagedPath = $this->resolveSelf($include, $stagedPath);
+                    $stagedPath = $this->resolveSelf($include, $stagedPath, $outerVersion);
                     break;
 
                 case PackageConfig::TYPE_SUB_BUILD:
@@ -139,9 +146,15 @@ final class Packager
     /**
      * Build the project's own `build:` block via PackageBuilder.
      *
+     * The outer package version is threaded down so the `self` zip matches
+     * the wrapper version — without this, the inner extension reads its
+     * own manifest's `<version>` and could end up at a different version
+     * than the wrapper if the manifests have drifted (e.g. between
+     * `cwm-bump` runs).
+     *
      * @param array<string, mixed> $include
      */
-    private function resolveSelf(array $include, string $stagedPath): string
+    private function resolveSelf(array $include, string $stagedPath, string $outerVersion): string
     {
         if ($this->parentBuild === null) {
             throw new \RuntimeException(
@@ -150,10 +163,10 @@ final class Packager
             );
         }
 
-        echo "  -> building self ({$include['outputName']})\n";
+        echo "  -> building self ({$include['outputName']}) at v$outerVersion\n";
 
         $builder    = new PackageBuilder($this->parentBuild, $this->projectRoot, $this->verbose);
-        $producedAt = $builder->build();
+        $producedAt = $builder->build($outerVersion);
 
         $this->copy($producedAt, $stagedPath);
 

--- a/tests/Build/PackagerTest.php
+++ b/tests/Build/PackagerTest.php
@@ -305,7 +305,10 @@ PHP);
         ]);
 
         $packager = new Packager($config, $parentBuild, $this->tmpDir);
-        $this->expectOutputRegex('/building self \(main\.zip\)/');
+        // Outer version is 1.0.0 (build/pkg.xml); the self include uses the
+        // outer version, NOT main.xml's 2.0.0. Diagnostic line surfaces this
+        // so the developer notices version-threading for the self include.
+        $this->expectOutputRegex('/building self \(main\.zip\) at v1\.0\.0/');
         $outer = $packager->package();
 
         $entries = $this->zipEntries($outer);
@@ -314,6 +317,45 @@ PHP);
         $childEntries = $this->zipEntriesOfNested($outer, 'main.zip');
         $this->assertContains('main.xml', $childEntries);
         $this->assertContains('src/Foo.php', $childEntries);
+
+        // The self include's intermediate zip (left in the parent's
+        // build/dist) uses the OUTER version even though main.xml says 2.0.0
+        // — that's the threading invariant.
+        $this->assertFileExists($this->tmpDir . '/build/dist/main-1.0.0.zip');
+        $this->assertFileDoesNotExist($this->tmpDir . '/build/dist/main-2.0.0.zip');
+    }
+
+    #[Test]
+    public function selfIncludeThreadsCliVersionOverrideToInnerBuild(): void
+    {
+        // When `cwm-package --version 9.9.9` is given, the override applies
+        // to the outer wrapper AND threads through to the self include's
+        // inner build, so both name files at 9.9.9 — no manifest reads at all.
+        $this->writeManifest('build/pkg.xml', '1.0.0');
+        $this->writeManifest('main.xml', '2.0.0');
+        $this->writeFile('src/Foo.php', '<?php');
+
+        $parentBuild = BuildConfig::fromArray([
+            'outputDir'  => 'build/dist',
+            'outputName' => 'main-{version}.zip',
+            'manifest'   => 'main.xml',
+            'sources'    => [['from' => 'src', 'to' => 'src']],
+        ]);
+
+        $config = $this->makePackageConfig([
+            'outputName' => 'pkg-{version}.zip',
+            'includes'   => [[
+                'type'       => 'self',
+                'outputName' => 'main.zip',
+            ]],
+        ]);
+
+        $packager = new Packager($config, $parentBuild, $this->tmpDir);
+        $this->expectOutputRegex('/building self \(main\.zip\) at v9\.9\.9/');
+        $outer = $packager->package('9.9.9');
+
+        $this->assertSame($this->tmpDir . '/build/dist/pkg-9.9.9.zip', $outer);
+        $this->assertFileExists($this->tmpDir . '/build/dist/main-9.9.9.zip');
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Patch fix surfaced during the [Proclaim migration to v0.5.0-alpha](https://github.com/Joomla-Bible-Study/Proclaim/pull/1220). The `cwm-package` `self` include type now threads the outer wrapper version into `PackageBuilder::build($outerVersion)` instead of letting the inner build read its own manifest independently.

## Why this is a fix

The `self` semantic is **"this same project"** — by definition the inner build's version should track the outer wrapper. Without threading, two failure modes were possible:

1. **Manifest drift between `cwm-bump` runs.** Outer reads `pkg_proclaim.xml`'s `<version>` (10.3.0), inner reads `proclaim.xml`'s `<version>` (10.3.1) → mismatched zips.

2. **Blocked the `versionPrompt` feature.** The Proclaim migration PR explicitly disabled `versionPrompt: { enabled: true }` because an interactive prompt at the outer level wouldn't propagate to the inner — producing inconsistent inner and outer versions. v0.5.0 release notes called this out as a limitation.

After this fix:
- `cwm-package --version 9.9.9` → outer at 9.9.9, self include at 9.9.9 (was: at manifest version)
- `cwm-package` (no override) → outer reads pkg manifest, self include uses the same version
- `versionPrompt: { enabled: true }` → outer prompt result flows into self include consistently

## What's NOT changed

`inline`, `subBuild`, and `prebuilt` includes are **version-independent** by design and remain unchanged:

- `inline` — nested `BuildConfig` with its own manifest (CSL's `plg_task_cwmscripture` cadence is independent of pkg_cwmscripture's)
- `subBuild` — produces a zip whose version is determined by the sub-build script
- `prebuilt` — already-built artifact on disk

## Why an alpha-line patch (0.5.2-alpha)

- No consumer has merged the new binaries yet — only PRs open against them — so no downstream impact.
- The prior behavior was unintentionally inconsistent with the `self` semantic, not a deliberate API choice.
- Per [CLAUDE.md alpha-line versioning](https://github.com/Joomla-Bible-Study/cwm-build-tools/blob/main/CLAUDE.md#alpha-line-versioning), patch bumps are appropriate for fixes + stub completion; consumers pinned to `^0.5@alpha` auto-pick this up.

## Tests

2 new / extended tests, +5 assertions (92 → 93 / 312 → 317):

- **`selfIncludeBuildsParentBuildConfig` (extended)** — outer at 1.0.0 + inner manifest at 2.0.0 → asserts the inner staged zip is `main-1.0.0.zip`, NOT `main-2.0.0.zip`. Locks in the threading invariant.
- **`selfIncludeThreadsCliVersionOverrideToInnerBuild` (new)** — `cwm-package --version 9.9.9` → both outer wrapper and `self` include use 9.9.9.

The Packager's diagnostic line now surfaces the inherited version:
```
  -> building self (com_proclaim.zip) at v10.3.2
```

## Plan

1. Merge this PR
2. Tag and release **v0.5.2-alpha**
3. Update Proclaim's migration PR (#1220) to enable `versionPrompt: { enabled: true }`
4. Re-verify Proclaim's release flow with the threading active

Refs Joomla-Bible-Study/cwm-build-tools#5 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)