### PR TITLE
fix(cli): require Prompt.php in scripts/build.php and scripts/package.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.3-alpha] - 2026-05-10
+
+Patch release for a CLI-only autoload bug surfaced when Proclaim enabled
+`versionPrompt: { enabled: true }` against v0.5.2-alpha.
+
+### Fixed
+
+- `scripts/build.php` and `scripts/package.php` now `require_once`
+  `src/Build/Prompt.php`. The CLI entry points are PSR-0-style, loading
+  every class manually rather than relying on Composer's autoloader, and
+  the `Prompt` class (added in 0.5.0-alpha for the 3-way version prompt)
+  was missing from both. The PHPUnit suite did not catch this because
+  unit tests instantiate `PackageBuilder` directly and Composer's
+  autoloader resolves `Prompt` transparently — only the standalone CLI
+  invocation hit the gap. Symptom: `Error: build failed — Class
+  "CWM\BuildTools\Build\Prompt" not found` immediately after enabling
+  `versionPrompt`. Regression test added that spawns
+  `php scripts/build.php` as a child process with `versionPrompt`
+  enabled and asserts no class-not-found errors in stderr.
+
 ## [0.5.2-alpha] - 2026-05-10
 
 Patch release for the version-threading gap surfaced during the Proclaim

--- a/scripts/build.php
+++ b/scripts/build.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../src/Build/BuildConfig.php';
 require_once __DIR__ . '/../src/Build/ManifestReader.php';
+require_once __DIR__ . '/../src/Build/Prompt.php';
 require_once __DIR__ . '/../src/Build/PackageBuilder.php';
 
 use CWM\BuildTools\Build\BuildConfig;

--- a/scripts/package.php
+++ b/scripts/package.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../src/Build/BuildConfig.php';
 require_once __DIR__ . '/../src/Build/ManifestReader.php';
+require_once __DIR__ . '/../src/Build/Prompt.php';
 require_once __DIR__ . '/../src/Build/PackageBuilder.php';
 require_once __DIR__ . '/../src/Build/PackageConfig.php';
 require_once __DIR__ . '/../src/Build/Packager.php';

--- a/tests/Build/PackageBuilderTest.php
+++ b/tests/Build/PackageBuilderTest.php
@@ -598,6 +598,68 @@ PHP;
         $this->assertSame(10, $config->versionPrompt['timeout']);
     }
 
+    // --- CLI script integration (catches missing require_once in scripts/build.php) ---
+
+    #[Test]
+    public function buildScriptResolvesAllRequiredClasses(): void
+    {
+        // Regression: Proclaim's migration enabled `versionPrompt` and the
+        // `cwm-build` CLI threw `Class "CWM\BuildTools\Build\Prompt" not
+        // found` because scripts/build.php didn't `require_once Prompt.php`.
+        // The unit tests instantiate PackageBuilder directly with PHPUnit's
+        // autoloader resolving every class — this child-process test exercises
+        // the real CLI entry point.
+        $this->writeManifest('cwmscripture.xml', '1.0.0');
+        $this->writeFile('src/Foo.php', '<?php');
+        $this->writeFile('media/lib_cwmscripture/js/foo.js', 'console.log');
+        $this->writeFile('media/lib_cwmscripture/js/foo.min.js', 'console.log');
+        $this->writeFile('media/lib_cwmscripture/css/foo.css', '.foo{}');
+        $this->writeFile('media/lib_cwmscripture/css/foo.min.css', '.foo{}');
+
+        $config = $this->libConfigArray();
+        // Add versionPrompt — the field that triggers Prompt::isNonInteractive()
+        // at build time.
+        $config['versionPrompt'] = ['enabled' => true, 'timeout' => 1];
+        file_put_contents(
+            $this->tmpDir . '/cwm-build.config.json',
+            json_encode(['build' => $config], JSON_PRETTY_PRINT)
+        );
+
+        $cwm    = realpath(__DIR__ . '/../..');
+        $script = $cwm . '/scripts/build.php';
+
+        $proc = proc_open(
+            ['php', $script],
+            [
+                0 => ['file', '/dev/null', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $pipes,
+            $this->tmpDir,
+            ['CWM_NONINTERACTIVE' => '1', 'PATH' => (string) getenv('PATH')]
+        );
+
+        if (!is_resource($proc)) {
+            $this->fail('Could not spawn child PHP for CLI integration test');
+        }
+
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($proc);
+
+        $this->assertSame(
+            0,
+            $exit,
+            "scripts/build.php exited $exit\nSTDOUT: $stdout\nSTDERR: $stderr"
+        );
+        $this->assertStringNotContainsString('Class', (string) $stderr);
+        $this->assertStringNotContainsString('not found', (string) $stderr);
+        $this->assertFileExists($this->tmpDir . '/build/dist/lib_cwmscripture-1.0.0.zip');
+    }
+
     // --- Helpers ---
 
     /**


### PR DESCRIPTION
## Summary

- The CLI entry points (`scripts/build.php` and `scripts/package.php`) load every class manually via `require_once` rather than going through Composer's autoloader. The `Prompt` class added in 0.5.0-alpha was missing from both, producing `Class "CWM\BuildTools\Build\Prompt" not found` the first time a consumer enabled `versionPrompt: { enabled: true }`.
- PHPUnit's autoloader masked the gap because unit tests instantiate `PackageBuilder` directly. Added a child-process regression test that spawns `php scripts/build.php` with `versionPrompt` enabled and asserts the build completes cleanly with no class-not-found errors in stderr.
- Surfaced during Proclaim PR #1220's verification after rebase onto main against v0.5.2-alpha.

## Test plan

- [x] `composer test` — 94 tests, 321 assertions pass (including new regression)
- [ ] After merge + tag v0.5.3-alpha, run Proclaim's `composer build` end-to-end to confirm the prompt actually fires and threads the chosen version into the inner `self` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)