### PR TITLE
feat(release): substitute __DEPLOY_VERSION__ placeholder at release time (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-05-14
+
+### Added
+
+- `cwm-release` now substitutes a placeholder token (default
+  `__DEPLOY_VERSION__`) with the release version across configured source
+  paths, between the manifest bump and the package build. Closes #24.
+  - Opt-in via a new `substituteTokens` subkey under `versionTracking` in
+    `cwm-build.config.json`:
+    ```json
+    {
+      "versionTracking": {
+        "substituteTokens": {
+          "token":      "__DEPLOY_VERSION__",
+          "paths":      ["admin/", "site/", "libraries/", "modules/", "plugins/"],
+          "extensions": ["php"]
+        }
+      }
+    }
+    ```
+  - Solves the "I don't know which version my code will ship in" problem
+    for `@since` PHPDoc tags. Devs write `@since __DEPLOY_VERSION__` on
+    in-flight code; the release pipeline substitutes the real version
+    at cut time. Matches the convention used throughout `joomla-cms`.
+  - Substitution runs only during `cwm-release` — `cwm-bump` standalone
+    leaves placeholders intact so dev branches between releases stay
+    free to accumulate `__DEPLOY_VERSION__` markers.
+  - Always skips `vendor/`, `node_modules/`, and `.git/` directories
+    regardless of configured paths (defensive — those should never be
+    rewritten).
+  - Files without the token are not rewritten (no spurious mtime bumps).
+- New `CWM\BuildTools\Release\TokenSubstituter` class plus
+  `scripts/substitute-tokens.php` CLI entry.
+
+### Changed
+
+- `cwm-release` pipeline is now 9 steps (was 8). The new step 2
+  ("Substitute `__DEPLOY_VERSION__` placeholder") sits between bump and
+  build. Steps 3-9 are the prior 2-8 renumbered. No behavior change for
+  projects that don't configure `substituteTokens`.
+
 ## [1.0.0] - 2026-05-14
 
 First stable release. The 0.x-alpha line is closed; the release pipeline,

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ When the block is present:
 - **`cwm-bump X.Y.Z`** writes `active_development.version = X.Y.Z` and
   `package.json:version = X.Y.Z`. Skipped when `--component` narrows the
   bump to a single extension type.
-- **`cwm-release X.Y.Z`** (step 7) writes `current.version = X.Y.Z`,
+- **`cwm-release X.Y.Z`** (step 8) writes `current.version = X.Y.Z`,
   recomputes `next.{patch,minor,major}`, and refreshes `_updated`.
   `active_development` is intentionally left alone — it stays pointing at
   whatever the last `cwm-bump` set, so devs explicitly advance it when
@@ -257,6 +257,34 @@ When the block is present:
 
 Either field is optional. Omit the whole block to keep the prior
 behaviour (only XML manifests get bumped).
+
+#### `@since __DEPLOY_VERSION__` placeholder substitution
+
+Add a `substituteTokens` subkey to opt into release-time `@since` tag
+substitution. Devs write `@since __DEPLOY_VERSION__` in source on
+in-flight code; `cwm-release` replaces the token with the real version
+between bump and build, so the released zip carries correct tags.
+
+```json
+{
+  "versionTracking": {
+    "substituteTokens": {
+      "token":      "__DEPLOY_VERSION__",
+      "paths":      ["admin/", "site/", "libraries/", "modules/", "plugins/"],
+      "extensions": ["php"]
+    }
+  }
+}
+```
+
+- Substitution runs only during `cwm-release` (step 2). `cwm-bump`
+  standalone leaves placeholders alone so dev branches between releases
+  stay free to accumulate `__DEPLOY_VERSION__` markers.
+- `vendor/`, `node_modules/`, and `.git/` directories are always skipped
+  regardless of configured paths.
+- Files without the token aren't touched — no spurious mtime bumps.
+- Matches the convention used throughout `joomla-cms` for `@since` tags
+  on in-flight code.
 
 ## Roadmap
 

--- a/examples/library/cwm-build.config.json
+++ b/examples/library/cwm-build.config.json
@@ -49,6 +49,12 @@
     "_versionTracking_comment": "Opt-in. When present, cwm-bump syncs active_development.version + package.json:version; cwm-release syncs current.version, next.{patch,minor,major}, and _updated. Omit the block to skip.",
     "versionTracking": {
         "versionsJson": "build/versions.json",
-        "packageJson":  "package.json"
+        "packageJson":  "package.json",
+        "_substituteTokens_comment": "Opt-in @since __DEPLOY_VERSION__ substitution at release time. Drop the block to skip.",
+        "substituteTokens": {
+            "token":      "__DEPLOY_VERSION__",
+            "paths":      ["src/", "language/"],
+            "extensions": ["php"]
+        }
     }
 }

--- a/examples/package/cwm-build.config.json
+++ b/examples/package/cwm-build.config.json
@@ -40,7 +40,13 @@
     "_versionTracking_comment": "Opt-in. When present, cwm-bump syncs active_development.version + package.json:version; cwm-release syncs current.version, next.{patch,minor,major}, and _updated. Omit the block to skip.",
     "versionTracking": {
         "versionsJson": "build/versions.json",
-        "packageJson":  "package.json"
+        "packageJson":  "package.json",
+        "_substituteTokens_comment": "Opt-in @since __DEPLOY_VERSION__ substitution at release time. Drop the block to skip.",
+        "substituteTokens": {
+            "token":      "__DEPLOY_VERSION__",
+            "paths":      ["admin/", "site/", "libraries/", "modules/", "plugins/", "components/"],
+            "extensions": ["php"]
+        }
     },
     "_assets_comment": "Paths in the assets block are SOURCE-TREE paths, not install-time paths. They should match what the project's existing build/build-assets.js wrote to before adopting this template — typically media/images and media/vendor/<pkg> at the project root. The manifest's <media folder=...> element controls where these end up at install time.",
     "assets": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Generic 8-step release pipeline for a CWM Joomla extension.
+# Generic 9-step release pipeline for a CWM Joomla extension.
 #
 # Reads cwm-build.config.json from the current working directory. All
 # project-specific values (manifest paths, ARS endpoint, GitHub repo)
@@ -8,13 +8,14 @@
 #
 # Steps:
 #   1. Version bump across all manifests in cwm-build.config.json
-#   2. Run the project's build command
-#   3. Commit version bump and push
-#   4. Create GitHub release with built zip(s) attached
-#   5. Generate changelog entry (if generator is configured)
-#   6. Publish to ARS
-#   7. Update versions.json on development branch (if configured)
-#   8. Post CWM release announcement article (optional, skipped if no bullets file)
+#   2. Substitute __DEPLOY_VERSION__ placeholder in source (if configured)
+#   3. Run the project's build command
+#   4. Commit version bump and push
+#   5. Create GitHub release with built zip(s) attached
+#   6. Generate changelog entry (if generator is configured)
+#   7. Publish to ARS
+#   8. Update versions.json (if configured)
+#   9. Post CWM release announcement article (optional, skipped if no bullets file)
 #
 # Usage:
 #   release.sh 1.2.3                # release specific version
@@ -138,12 +139,22 @@ echo "=== ${PKG_NAME} Release ${VERSION} ==="
 echo ""
 
 # --- Step 1: Version bump ---
-echo "[1/8] Bumping version to ${VERSION}..."
+echo "[1/9] Bumping version to ${VERSION}..."
 php "${TOOLS_DIR}/scripts/bump.php" -v "$VERSION"
 echo ""
 
-# --- Step 2: Build ---
-echo "[2/8] Building package..."
+# --- Step 2: Substitute __DEPLOY_VERSION__ placeholder ---
+# Replaces the configured placeholder token (default __DEPLOY_VERSION__) with
+# the release version across configured source paths. Joomla core uses this
+# convention for @since PHPDoc tags on in-flight code where the author can't
+# predict the release number. Substitution runs BEFORE the build so the
+# packaged zip carries the real version, not the placeholder.
+echo "[2/9] Substituting __DEPLOY_VERSION__ placeholder..."
+php "${TOOLS_DIR}/scripts/substitute-tokens.php" -v "$VERSION"
+echo ""
+
+# --- Step 3: Build ---
+echo "[3/9] Building package..."
 BUILD_CMD=$(read_config "build.command")
 if [ -z "$BUILD_CMD" ]; then
     echo "Error: build.command not set in cwm-build.config.json"
@@ -169,8 +180,8 @@ fi
 echo "  Built: ${ARTIFACTS[*]}"
 echo ""
 
-# --- Step 3: Commit and push ---
-echo "[3/8] Committing version bump..."
+# --- Step 4: Commit and push ---
+echo "[4/9] Committing version bump..."
 # Add only files modified by step 1 + 2, not unrelated untracked files. The
 # bump and build steps may dirty several manifests and rebuild the zip; the
 # release branch was clean before step 1 (pre-check), so anything modified or
@@ -183,8 +194,8 @@ git commit -m "chore: bump version to ${VERSION}"
 git push
 echo ""
 
-# --- Step 4: GitHub release ---
-echo "[4/8] Creating GitHub release ${TAG}..."
+# --- Step 5: GitHub release ---
+echo "[5/9] Creating GitHub release ${TAG}..."
 
 # `HEAD` is the bump commit we just pushed; `git describe` from there finds the
 # previous reachable tag, which is what we want for the changelog "since" base.
@@ -212,8 +223,8 @@ gh release create "$TAG" "${ARTIFACTS[@]}" \
 
 echo ""
 
-# --- Step 5: Changelog ---
-echo "[5/8] Updating changelog..."
+# --- Step 6: Changelog ---
+echo "[6/9] Updating changelog..."
 CHANGELOG_FILE=$(read_config "changelog.file")
 if [ -n "$CHANGELOG_FILE" ] && [ -f "$CHANGELOG_FILE" ]; then
     bash "${TOOLS_DIR}/scripts/generate-changelog-entry.sh" "$VERSION"
@@ -230,8 +241,8 @@ else
 fi
 echo ""
 
-# --- Step 6: ARS publish ---
-echo "[6/8] Publishing to ARS..."
+# --- Step 7: ARS publish ---
+echo "[7/9] Publishing to ARS..."
 ARS_ENDPOINT=$(read_config "ars.endpoint")
 if [ -n "$ARS_ENDPOINT" ]; then
     bash "${TOOLS_DIR}/scripts/ars-publish.sh" -v "$VERSION" -f "${ARTIFACTS[0]}"
@@ -240,8 +251,8 @@ else
 fi
 echo ""
 
-# --- Step 7: versions.json update (current + next.* + _updated) ---
-echo "[7/8] Updating versions.json..."
+# --- Step 8: versions.json update (current + next.* + _updated) ---
+echo "[8/9] Updating versions.json..."
 DEV_BRANCH=$(read_config "github.developmentBranch")
 HAS_VERSION_TRACKING=$(read_config "versionTracking.versionsJson")
 
@@ -275,8 +286,8 @@ else
 fi
 echo ""
 
-# --- Step 8: CWM article (optional, only if bullets file exists) ---
-echo "[8/8] Posting CWM release announcement..."
+# --- Step 9: CWM article (optional, only if bullets file exists) ---
+echo "[9/9] Posting CWM release announcement..."
 BULLETS_DIR=$(read_config "announcement.bulletsDir")
 BULLETS_DIR="${BULLETS_DIR:-build}"
 BULLETS_FILE="${BULLETS_DIR}/release-bullets-${VERSION}.txt"

--- a/scripts/substitute-tokens.php
+++ b/scripts/substitute-tokens.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * CLI entry for TokenSubstituter — used by cwm-release.
+ *
+ * Reads cwm-build.config.json's `versionTracking.substituteTokens` block
+ * and replaces the configured token with the release version across the
+ * configured source paths.
+ *
+ * Usage:
+ *   php substitute-tokens.php -v 1.2.3
+ *
+ * Exits 0 with no output when the project hasn't opted in (no
+ * substituteTokens block), so release.sh can call this unconditionally.
+ *
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/Release/TokenSubstituter.php';
+
+$projectRoot = getcwd();
+$configFile  = $projectRoot . '/cwm-build.config.json';
+
+if (!is_file($configFile)) {
+    fwrite(STDERR, "Error: cwm-build.config.json not found in $projectRoot\n");
+    exit(1);
+}
+
+$opts    = getopt('v:');
+$version = $opts['v'] ?? null;
+
+if (!$version) {
+    fwrite(STDERR, "Usage: substitute-tokens.php -v <version>\n");
+    exit(1);
+}
+
+$config = json_decode((string) file_get_contents($configFile), true);
+
+if (!is_array($config)) {
+    fwrite(STDERR, "Error: cwm-build.config.json is not valid JSON\n");
+    exit(1);
+}
+
+$substituteConfig = $config['versionTracking']['substituteTokens'] ?? null;
+
+if (!is_array($substituteConfig)) {
+    // Not opted in — silent no-op.
+    exit(0);
+}
+
+$substituter = new CWM\BuildTools\Release\TokenSubstituter($projectRoot, $substituteConfig);
+
+try {
+    $touched = $substituter->substitute($version);
+} catch (\Throwable $e) {
+    fwrite(STDERR, "Error: " . $e->getMessage() . "\n");
+    exit(1);
+}
+
+if ($touched === []) {
+    echo "  (no files contained the token)\n";
+} else {
+    echo "Substituted token in " . count($touched) . " file(s)\n";
+}

--- a/src/Release/TokenSubstituter.php
+++ b/src/Release/TokenSubstituter.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Release;
+
+/**
+ * Replaces a placeholder token (default `__DEPLOY_VERSION__`) with the actual
+ * release version in configured source paths at release time.
+ *
+ * Joomla core uses `__DEPLOY_VERSION__` in `@since` PHPDoc tags throughout
+ * its source tree. The release pipeline substitutes the token with the
+ * version being cut so devs never have to predict the future at PR-write
+ * time. This class brings the same convention to cwm-built extensions.
+ *
+ * Substitution runs ONLY during `cwm-release` (between bump and build) —
+ * not during `cwm-bump` standalone. The placeholder is meant to stay in
+ * source between releases, so dev branches keep accumulating
+ * `@since __DEPLOY_VERSION__` until the next release locks in a real
+ * version.
+ *
+ * Config shape (under cwm-build.config.json `versionTracking`):
+ *
+ *   "substituteTokens": {
+ *     "token":      "__DEPLOY_VERSION__",
+ *     "paths":      ["admin/", "site/", "libraries/", "modules/", "plugins/"],
+ *     "extensions": ["php"]
+ *   }
+ *
+ * Absent `substituteTokens` block → no-op.
+ */
+final class TokenSubstituter
+{
+    private const DEFAULT_TOKEN      = '__DEPLOY_VERSION__';
+    private const DEFAULT_EXTENSIONS = ['php'];
+
+    /**
+     * Directories always skipped during the walk. Substituting inside vendored
+     * code or VCS metadata would be a footgun.
+     */
+    private const ALWAYS_SKIP = ['vendor', 'node_modules', '.git'];
+
+    /**
+     * @param array{token?: string, paths?: list<string>, extensions?: list<string>} $config
+     */
+    public function __construct(
+        private readonly string $projectRoot,
+        private readonly array  $config,
+    ) {
+    }
+
+    /**
+     * Walk configured paths, replace the token with $version in every file
+     * matching the extension filter. Files without the token are left
+     * untouched (no mtime bump, no needless writes).
+     *
+     * @return list<string> Files actually rewritten.
+     */
+    public function substitute(string $version): array
+    {
+        $token      = $this->config['token']      ?? self::DEFAULT_TOKEN;
+        $paths      = $this->config['paths']      ?? [];
+        $extensions = $this->config['extensions'] ?? self::DEFAULT_EXTENSIONS;
+
+        if ($paths === []) {
+            return [];
+        }
+
+        $touched = [];
+
+        foreach ($paths as $relative) {
+            $absolute = $this->projectRoot . '/' . ltrim((string) $relative, '/');
+
+            if (!file_exists($absolute)) {
+                fwrite(STDERR, "Warning: substituteTokens path not found: $absolute (skipped)\n");
+                continue;
+            }
+
+            foreach ($this->walkFiles($absolute, $extensions) as $file) {
+                if ($this->replaceInFile($file, $token, $version)) {
+                    $touched[] = $file;
+                }
+            }
+        }
+
+        return $touched;
+    }
+
+    /**
+     * @param  list<string> $extensions
+     * @return iterable<string>
+     */
+    private function walkFiles(string $path, array $extensions): iterable
+    {
+        if (is_file($path)) {
+            if ($this->matchesExtension($path, $extensions)) {
+                yield $path;
+            }
+            return;
+        }
+
+        $iter = new \RecursiveIteratorIterator(
+            new \RecursiveCallbackFilterIterator(
+                new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+                static function (\SplFileInfo $current): bool {
+                    if ($current->isDir() && in_array($current->getFilename(), self::ALWAYS_SKIP, true)) {
+                        return false;
+                    }
+                    return true;
+                },
+            ),
+        );
+
+        foreach ($iter as $info) {
+            if ($info->isFile() && $this->matchesExtension($info->getPathname(), $extensions)) {
+                yield $info->getPathname();
+            }
+        }
+    }
+
+    /**
+     * @param list<string> $extensions
+     */
+    private function matchesExtension(string $path, array $extensions): bool
+    {
+        $ext = pathinfo($path, PATHINFO_EXTENSION);
+        return in_array($ext, $extensions, true);
+    }
+
+    /**
+     * Read file, replace token if present, write back only when content
+     * actually changed. Returns true when the file was rewritten.
+     */
+    private function replaceInFile(string $path, string $token, string $version): bool
+    {
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            fwrite(STDERR, "Warning: could not read $path (skipped)\n");
+            return false;
+        }
+
+        if (!str_contains($contents, $token)) {
+            return false;
+        }
+
+        $replaced = str_replace($token, $version, $contents);
+
+        if ($replaced === $contents) {
+            return false;
+        }
+
+        if (file_put_contents($path, $replaced) === false) {
+            throw new \RuntimeException("Could not write $path");
+        }
+
+        $count = substr_count($contents, $token);
+        echo "  $path → $count replacement(s)\n";
+
+        return true;
+    }
+}

--- a/tests/Release/TokenSubstituterTest.php
+++ b/tests/Release/TokenSubstituterTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Release;
+
+use CWM\BuildTools\Release\TokenSubstituter;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TokenSubstituterTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/cwm-token-substituter-' . bin2hex(random_bytes(6));
+        mkdir($this->tmpDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->rrmdir($this->tmpDir);
+    }
+
+    #[Test]
+    public function replaces_default_token_in_php_files_under_configured_paths(): void
+    {
+        $this->seedFile('src/Model.php', "<?php\n/**\n * @since  __DEPLOY_VERSION__\n */\nclass Model {}\n");
+        $this->seedFile('src/View.php',  "<?php\n/**\n * @since  __DEPLOY_VERSION__\n */\nclass View {}\n");
+
+        $touched = $this->runQuiet(fn () => $this->substituter(['paths' => ['src/']])->substitute('1.2.3'));
+
+        self::assertCount(2, $touched);
+        self::assertStringContainsString('@since  1.2.3', $this->read('src/Model.php'));
+        self::assertStringContainsString('@since  1.2.3', $this->read('src/View.php'));
+        self::assertStringNotContainsString('__DEPLOY_VERSION__', $this->read('src/Model.php'));
+    }
+
+    #[Test]
+    public function leaves_files_without_token_untouched(): void
+    {
+        $this->seedFile('src/NoToken.php', "<?php\n/**\n * @since  1.0.0\n */\nclass NoToken {}\n");
+        $before = filemtime($this->tmpDir . '/src/NoToken.php');
+
+        clearstatcache();
+        sleep(1);
+
+        $touched = $this->runQuiet(fn () => $this->substituter(['paths' => ['src/']])->substitute('1.2.3'));
+
+        self::assertSame([], $touched);
+
+        $after = filemtime($this->tmpDir . '/src/NoToken.php');
+        self::assertSame($before, $after);
+    }
+
+    #[Test]
+    public function honours_custom_token(): void
+    {
+        $this->seedFile('src/Model.php', "<?php\n// @since  {{VERSION}}\nclass Model {}\n");
+
+        $this->runQuiet(fn () => $this->substituter([
+            'paths' => ['src/'],
+            'token' => '{{VERSION}}',
+        ])->substitute('1.2.3'));
+
+        self::assertStringContainsString('@since  1.2.3', $this->read('src/Model.php'));
+    }
+
+    #[Test]
+    public function honours_extensions_filter(): void
+    {
+        $this->seedFile('src/Model.php',     "<?php\n// __DEPLOY_VERSION__\n");
+        $this->seedFile('src/template.tpl',  "// __DEPLOY_VERSION__\n");
+        $this->seedFile('src/script.js',     "// __DEPLOY_VERSION__\n");
+
+        $this->runQuiet(fn () => $this->substituter([
+            'paths'      => ['src/'],
+            'extensions' => ['php', 'tpl'],
+        ])->substitute('1.2.3'));
+
+        self::assertStringContainsString('1.2.3', $this->read('src/Model.php'));
+        self::assertStringContainsString('1.2.3', $this->read('src/template.tpl'));
+        // .js is not in the filter
+        self::assertStringContainsString('__DEPLOY_VERSION__', $this->read('src/script.js'));
+    }
+
+    #[Test]
+    public function recurses_into_subdirectories(): void
+    {
+        $this->seedFile('admin/src/Controller.php',                "<?php\n// __DEPLOY_VERSION__\n");
+        $this->seedFile('admin/src/View/Items/HtmlView.php',       "<?php\n// __DEPLOY_VERSION__\n");
+        $this->seedFile('admin/src/View/Items/Tmpl/default.php',   "<?php\n// __DEPLOY_VERSION__\n");
+
+        $touched = $this->runQuiet(fn () => $this->substituter(['paths' => ['admin/']])->substitute('1.2.3'));
+
+        self::assertCount(3, $touched);
+    }
+
+    #[Test]
+    public function always_skips_vendor_node_modules_and_git_directories(): void
+    {
+        $this->seedFile('src/Model.php',                 "<?php\n// __DEPLOY_VERSION__\n");
+        $this->seedFile('src/vendor/dep/Lib.php',        "<?php\n// __DEPLOY_VERSION__\n");
+        $this->seedFile('src/node_modules/pkg/index.js', "// __DEPLOY_VERSION__\n");
+        $this->seedFile('src/.git/HEAD',                 "ref: __DEPLOY_VERSION__\n");
+
+        $touched = $this->runQuiet(fn () => $this->substituter([
+            'paths'      => ['src/'],
+            'extensions' => ['php', 'js'],
+        ])->substitute('1.2.3'));
+
+        self::assertCount(1, $touched);
+        self::assertStringContainsString('__DEPLOY_VERSION__', $this->read('src/vendor/dep/Lib.php'));
+        self::assertStringContainsString('__DEPLOY_VERSION__', $this->read('src/node_modules/pkg/index.js'));
+    }
+
+    #[Test]
+    public function missing_path_warns_but_does_not_throw(): void
+    {
+        $touched = $this->runQuiet(fn () => $this->substituter(['paths' => ['nonexistent/']])->substitute('1.2.3'));
+
+        self::assertSame([], $touched);
+    }
+
+    #[Test]
+    public function empty_paths_list_is_noop(): void
+    {
+        $this->seedFile('src/Model.php', "<?php\n// __DEPLOY_VERSION__\n");
+
+        $touched = $this->runQuiet(fn () => $this->substituter(['paths' => []])->substitute('1.2.3'));
+
+        self::assertSame([], $touched);
+        self::assertStringContainsString('__DEPLOY_VERSION__', $this->read('src/Model.php'));
+    }
+
+    #[Test]
+    public function replaces_multiple_occurrences_per_file(): void
+    {
+        $this->seedFile('src/Model.php',
+            "<?php\n"
+            . "/**\n * @since  __DEPLOY_VERSION__\n */\n"
+            . "class Model {\n"
+            . "    /** @since  __DEPLOY_VERSION__ */\n"
+            . "    public function foo() {}\n"
+            . "    /** @since  __DEPLOY_VERSION__ */\n"
+            . "    public function bar() {}\n"
+            . "}\n");
+
+        $this->runQuiet(fn () => $this->substituter(['paths' => ['src/']])->substitute('1.2.3'));
+
+        $contents = $this->read('src/Model.php');
+        self::assertSame(3, substr_count($contents, '@since  1.2.3'));
+        self::assertStringNotContainsString('__DEPLOY_VERSION__', $contents);
+    }
+
+    #[Test]
+    public function single_file_path_works(): void
+    {
+        $this->seedFile('build/script.php', "<?php\n// __DEPLOY_VERSION__\n");
+
+        $touched = $this->runQuiet(fn () => $this->substituter([
+            'paths' => ['build/script.php'],
+        ])->substitute('1.2.3'));
+
+        self::assertCount(1, $touched);
+        self::assertStringContainsString('1.2.3', $this->read('build/script.php'));
+    }
+
+    // --- helpers ----------------------------------------------------------
+
+    /**
+     * @param array{token?: string, paths?: list<string>, extensions?: list<string>} $config
+     */
+    private function substituter(array $config): TokenSubstituter
+    {
+        return new TokenSubstituter($this->tmpDir, $config);
+    }
+
+    private function runQuiet(callable $fn): mixed
+    {
+        ob_start();
+        try {
+            return $fn();
+        } finally {
+            ob_end_clean();
+        }
+    }
+
+    private function seedFile(string $relative, string $contents): void
+    {
+        $absolute = $this->tmpDir . '/' . $relative;
+        $dir      = dirname($absolute);
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0o777, true);
+        }
+
+        file_put_contents($absolute, $contents);
+    }
+
+    private function read(string $relative): string
+    {
+        return (string) file_get_contents($this->tmpDir . '/' . $relative);
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = "$dir/$entry";
+
+            if (is_link($path) || !is_dir($path)) {
+                @unlink($path);
+            } else {
+                $this->rrmdir($path);
+            }
+        }
+
+        @rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds opt-in `@since __DEPLOY_VERSION__` placeholder substitution to `cwm-release`.
- Devs write `@since __DEPLOY_VERSION__` on in-flight code; release pipeline replaces with real version between bump and build.
- New `CWM\BuildTools\Release\TokenSubstituter` class + `scripts/substitute-tokens.php` CLI.
- Wired into `release.sh` as new step 2; existing steps 2-8 renumbered to 3-9.

Closes #24. Companion to #23 (versions.json + package.json sync, shipped in v1.0.0).

## Why

When a dev writes a new method on a development branch, they can't predict which release ships their code — patch slips into a minor, minor slips into a major, hotfixes jump the queue. Writing `@since 10.3.0` today and shipping in `10.4.0` next month leaves the wrong tag in the codebase forever.

`joomla-cms` handles this with `__DEPLOY_VERSION__`: write the placeholder in source, release build substitutes it. This PR brings the same convention to cwm-built extensions.

## Config

```json
{
  "versionTracking": {
    "substituteTokens": {
      "token":      "__DEPLOY_VERSION__",
      "paths":      ["admin/", "site/", "libraries/", "modules/", "plugins/"],
      "extensions": ["php"]
    }
  }
}
```

All keys optional with sensible defaults; an absent `substituteTokens` block is a no-op.

## Behaviour details

- **Runs only during `cwm-release`** (step 2, between bump and build). `cwm-bump` standalone leaves placeholders alone so dev branches between releases stay free to accumulate `__DEPLOY_VERSION__` markers.
- **Always skips** `vendor/`, `node_modules/`, `.git/` regardless of configured paths (defensive — substituting inside vendored code would be a footgun).
- **Files without the token aren't rewritten** — no spurious mtime bumps; idempotent re-runs.
- **Custom tokens supported** for projects with existing placeholder conventions (e.g. `{{VERSION}}`).
- **Extension filter** controls which files participate (default `["php"]`; configurable).

## Test plan

- [x] `composer test` — 116/116 green (10 new `TokenSubstituterTest` tests cover replacement, multiple occurrences per file, extension filter, recursion into subdirs, vendor/node_modules/.git skip, missing paths, empty paths list, single-file path, custom tokens)
- [ ] Smoke test in Proclaim: add `substituteTokens` block + a test method with `@since __DEPLOY_VERSION__`, run `cwm-release` dry-run-ish, verify substitution before build
- [ ] Verify the substituted source ends up in the built zip (not just the working tree)

## Versioning

Additive change; targets `v1.0.1` patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)