### PR TITLE
fix(link): only symlink role=dev installs, never role=test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-07-25
+
 ### Fixed
 
 - **`cwm-link` no longer symlinks `role=test` installs (data-loss hazard).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`cwm-link` no longer symlinks `role=test` installs (data-loss hazard).**
+  `scripts/link.php` selected every configured install via
+  `PropertiesReader::installs()` instead of filtering to `role=dev`, so
+  `composer symlink` linked test installs too. That contradicts the documented
+  contract in `InstallConfig` — `role=dev` is *the* symlink target, while a
+  `role=test` install is a real install target for the built zip.
+
+  The consequence was severe. A linked test site points its extension
+  directories back at the consumer's working repo, and reset/teardown harnesses
+  delete those directories to get a clean slate. Because `is_dir()` returns true
+  for a symlink pointing at a directory, such a harness walks *through* the link
+  and empties its target — deleting repo source. This was found in Proclaim with
+  12 links present on `j6-test` (caught before any harness ran; no data lost).
+
+  `scripts/link-check.php` had the same unfiltered selection, reporting every
+  expected link as `MISSING` on a deliberately file-backed test install.
+  `scripts/install-zip.php` was already correct (`ROLE_TEST`), and
+  `scripts/clean.php` is safe either way since `Linker::unlink()` guards on
+  `is_link()` — leaving it unfiltered usefully strips stray links.
+
+  Consumers with a recursive-delete helper should also ensure it checks
+  `is_link()` on the path it is *given*, not only on that path's children.
+
 ## [1.5.1] - 2026-06-16
 
 ### Added (non-breaking, opt-in)

--- a/scripts/link-check.php
+++ b/scripts/link-check.php
@@ -13,6 +13,7 @@ require_once __DIR__ . '/../src/Dev/PropertiesReader.php';
 require_once __DIR__ . '/../src/Dev/LinkResolver.php';
 require_once __DIR__ . '/../src/Dev/Linker.php';
 
+use CWM\BuildTools\Dev\InstallConfig;
 use CWM\BuildTools\Dev\LinkResolver;
 use CWM\BuildTools\Dev\Linker;
 use CWM\BuildTools\Dev\PropertiesReader;
@@ -75,7 +76,10 @@ foreach ($resolver->internalLinks() as $pair) {
     $issues += reportLink($linker->check($pair['source'], $pair['target']), $verbose);
 }
 
-foreach ($reader->installs() as $install) {
+// Mirror cwm-link: only role=dev installs are expected to carry symlinks, so
+// only those are checked. A role=test install is deliberately file-backed and
+// would otherwise report every expected link as MISSING.
+foreach ($reader->installsFor(InstallConfig::ROLE_DEV) as $install) {
     echo "\nInstall: {$install->path}\n";
 
     if (!is_dir($install->path)) {

--- a/scripts/link.php
+++ b/scripts/link.php
@@ -22,6 +22,7 @@ require_once __DIR__ . '/../src/Dev/LinkResolver.php';
 require_once __DIR__ . '/../src/Dev/Linker.php';
 
 use CWM\BuildTools\Config\InstalledPackageReader;
+use CWM\BuildTools\Dev\InstallConfig;
 use CWM\BuildTools\Dev\LinkResolver;
 use CWM\BuildTools\Dev\Linker;
 use CWM\BuildTools\Dev\PropertiesReader;
@@ -90,10 +91,14 @@ if (!$reader->exists()) {
     exit(1);
 }
 
-$installs = $reader->installs();
+// Only role=dev installs are symlink targets. A role=test install is a real
+// install target for the built zip — linking one points the site's extension
+// dirs back at the working repo, which puts that source in the blast radius of
+// any teardown that deletes extension dirs (cwm-clean, reset harnesses).
+$installs = $reader->installsFor(InstallConfig::ROLE_DEV);
 
 if ($installs === []) {
-    fwrite(STDERR, "No Joomla installs configured in build.properties.\n");
+    fwrite(STDERR, "No role=dev Joomla install configured in build.properties.\n");
 
     exit(1);
 }


### PR DESCRIPTION
## The bug

`scripts/link.php` selected every configured install via `PropertiesReader::installs()` instead of filtering to `role=dev`, so `composer symlink` linked `role=test` installs too.

That contradicts this project's own documented contract. `InstallConfig.php:15` states `role=dev` is *the* symlink target, while a `role=test` install is a real install target for the built zip — and `DevTargetVerifier` says the same. `scripts/install-zip.php` already got this right with `ROLE_TEST`; `link.php` never did.

## Why it matters

This is data loss, not cosmetic noise.

A linked test site points its extension directories back at the consumer's working repo. Reset/teardown harnesses delete those directories to get a clean slate. Because `is_dir()` returns **true for a symlink pointing at a directory**, such a harness walks *through* the link and empties its target — deleting repo source.

Found in Proclaim, where `j6-test` had 12 links including `components/com_proclaim -> Proclaim/site` and `media/com_proclaim -> Proclaim/media`. Its reset harness would have wiped `admin/`, `site/`, `media/`, `modules/` and `plugins/` in the working tree. Caught before anything ran; no data was lost.

## Changes

- `link.php` — `installsFor(InstallConfig::ROLE_DEV)`, and the empty-case error now says "No role=dev Joomla install configured".
- `link-check.php` — same filter. It had the identical bug, reporting every expected link as `MISSING` on a deliberately file-backed test install.
- `clean.php` — **left unfiltered on purpose.** `Linker::unlink()` guards on `is_link()` (`Linker.php:148`), so scanning every install usefully strips stray links from a test site without ever touching a real directory.
- `joomla-install.php`, `setup.php`, `verify.php` — correctly unfiltered; `verify.php` already takes an explicit target.

## Testing

All 214 existing tests pass. The role filtering itself is already covered by `PropertiesReaderTest::installs_for_filters_by_role`.

No test was added for `link.php`'s selection: `scripts/*.php` are procedural entry points with no test harness in this repo (only `src/` classes are covered), so adding one is a larger refactor than this fix warrants. Flagging it as a real coverage gap — every script-level bug here, including this one, is currently invisible to CI.

## Note for consumers

Anyone with a recursive-delete helper should also check `is_link()` on the path it is **given**, not only on that path's children — the guard is easy to place one level too deep. Proclaim's counterpart fix is Joomla-Bible-Study/Proclaim#1311.

Worth a patch release: until consumers pick this up, `composer symlink` keeps re-linking their test installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)