### PR TITLE
fix(sync-configs): guard build.dist.properties against leaked credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`cwm-sync-configs` now guards `build.dist.properties` against leaked credentials
+  and silent data loss.** That file is committed by every consumer while per-machine
+  values belong in the gitignored `build.properties` — the two names differ by four
+  characters, and the wrong one gets edited. Because sync overwrites the consumer's
+  copy from the template, it also quietly disposed of the evidence: credentials
+  vanished from the working tree while remaining in any commit that had already
+  captured them.
+
+  Three checks now run before the write, via the new
+  `Config\DistPropertiesInspector`:
+
+  - **Refuses to sync** if the cwm-build-tools template itself carries populated
+    credential values — that would propagate to every consumer.
+  - **Warns** when the consumer's existing file has real values in credential keys,
+    naming them and pointing at `git log -p -- build.dist.properties` so the
+    developer can check whether they reached history.
+  - **Reports keys about to be removed** because the template lacks them. Usually
+    stale hand-edits, but occasionally the consumer is ahead of the shared schema
+    and silently deleting that is unhelpful. Found in practice: Proclaim's 11
+    `builder.j6-test.*` keys would have been dropped without a word.
+
+  Matching is on key name (`db_user`, `db_pass`, `db_name`, `password`, `secret`,
+  `token`, `api_key`) rather than value, since local credentials rarely look
+  distinctive. The template's documented `admin_pass = admin` placeholder is
+  deliberately outside the pattern.
+
+### Added
+
+- `templates/build.properties.tmpl` — commented-out `j6-test` section, so a second
+  `role = test` install is part of the shared schema rather than a local addition
+  the next sync deletes. Carries the warning that a `role = test` target must be a
+  real, non-symlinked install, since the harness wipes and reinstalls it.
+- `tests/Config/DistPropertiesInspectorTest.php` — 12 tests, including one asserting
+  the shipped template never carries populated credentials.
+
 ## [1.6.1] - 2026-07-25
 
 ### Fixed

--- a/scripts/sync-configs.php
+++ b/scripts/sync-configs.php
@@ -25,6 +25,7 @@
  */
 
 require_once __DIR__ . '/../src/Config/ProfileResolver.php';
+require_once __DIR__ . '/../src/Config/DistPropertiesInspector.php';
 
 $projectRoot = getcwd();
 $toolsRoot   = realpath(__DIR__ . '/..');
@@ -287,6 +288,25 @@ function syncBuildDistProperties(string $projectRoot, string $templates, bool $d
 
     $templateBody = (string) file_get_contents($source);
 
+    // The template is committed by every consumer, so it must never ship a
+    // populated secret. Checked before anything is written: if this ever trips,
+    // the leak is in cwm-build-tools and would propagate to every project.
+    $inspector       = new \CWM\BuildTools\Config\DistPropertiesInspector();
+    $templateSecrets = $inspector->populatedSecretKeys($templateBody);
+
+    if ($templateSecrets !== []) {
+        echo "build.dist.properties: REFUSING to sync — the cwm-build-tools template has populated\n";
+        echo "  credential values, and this file is committed by every consumer:\n";
+
+        foreach ($templateSecrets as $key) {
+            echo "    {$key}\n";
+        }
+
+        echo "  Blank them in {$source} before running this again.\n";
+
+        return;
+    }
+
     // Comment marker is `#` (not `;`) so Java-properties-aware IDEs accept
     // it cleanly; PHP's `parse_ini_string` accepts both. The template body
     // already starts with the canonical header, so we don't re-stamp our
@@ -300,6 +320,34 @@ function syncBuildDistProperties(string $projectRoot, string $templates, bool $d
         return;
     }
 
+    // Two things worth saying out loud before this file is replaced. Both
+    // describe the OLD content, so they have to be reported whether or not the
+    // write actually happens.
+    $existingSecrets = $inspector->populatedSecretKeys($existing);
+    $droppedKeys     = $inspector->keysMissingFromTemplate($existing, $templateBody);
+
+    if ($existingSecrets !== []) {
+        echo "build.dist.properties: WARNING — the current file has real values in credential keys:\n";
+
+        foreach ($existingSecrets as $key) {
+            echo "    {$key}\n";
+        }
+
+        echo "  This file is committed. Per-machine values belong in build.properties (gitignored).\n";
+        echo "  Check whether they reached git: git log -p -- build.dist.properties\n";
+    }
+
+    if ($droppedKeys !== []) {
+        echo "build.dist.properties: NOTE — " . \count($droppedKeys) . " key(s) present locally are not in\n";
+        echo "  the cwm-build-tools template and will be removed:\n";
+
+        foreach ($droppedKeys as $key) {
+            echo "    {$key}\n";
+        }
+
+        echo "  If they are a legitimate part of the schema, add them to the template instead.\n";
+    }
+
     if ($dryRun) {
         echo "build.dist.properties: would " . ($existing === '' ? 'create' : 'update') . " (dry-run)\n";
 
@@ -309,6 +357,8 @@ function syncBuildDistProperties(string $projectRoot, string $templates, bool $d
     file_put_contents($target, $newContent);
     echo "build.dist.properties: " . ($existing === '' ? 'created' : 'updated') . " from template\n";
 }
+
+
 
 /**
  * Read composer.json `config.vendor-dir` so the eslint import path matches

--- a/src/Config/DistPropertiesInspector.php
+++ b/src/Config/DistPropertiesInspector.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Config;
+
+/**
+ * Inspects `build.dist.properties` content before `cwm-sync-configs` replaces it.
+ *
+ * Background: `build.dist.properties` is the committed template each consumer
+ * ships so a fresh clone has a starting point, while per-machine values live in
+ * the gitignored `build.properties`. The two filenames differ by four characters,
+ * and the wrong one gets edited often enough to matter — a developer's database
+ * credentials end up in a file destined for a public repository.
+ *
+ * `cwm-sync-configs` overwrites the consumer's copy from the cwm-build-tools
+ * template, which quietly disposes of the evidence: the credentials vanish from
+ * the working tree while remaining in whatever commit already captured them, and
+ * any legitimate local additions vanish with them. This class supplies the two
+ * things worth saying out loud before that write happens.
+ *
+ * @since 1.6.2
+ */
+final class DistPropertiesInspector
+{
+    /**
+     * Key suffixes whose populated value should be treated as a secret.
+     *
+     * Matching is on the key name rather than the value. The point is to catch a
+     * local database credential sitting in a committed file, and those rarely
+     * look distinctive — the case that prompted this was
+     * `db_user = root` / `db_pass = root` / `db_name = j5_dev`.
+     *
+     * `admin_pass` is deliberately absent: the shipped template documents
+     * `admin_pass = admin` as a placeholder for a throwaway local install.
+     */
+    private const SECRET_KEY_PATTERN = '/(db_user|db_pass|db_name|password|secret|token|api_key)$/i';
+
+    /**
+     * Keys holding a non-empty value that looks like a secret.
+     *
+     * @param string $properties Raw properties-file content.
+     *
+     * @return list<string> Fully-qualified keys, e.g. `builder.j5.db_pass`.
+     */
+    public function populatedSecretKeys(string $properties): array
+    {
+        $found = [];
+
+        foreach (self::pairs($properties) as [$key, $value]) {
+            if ($value !== '' && preg_match(self::SECRET_KEY_PATTERN, $key) === 1) {
+                $found[] = $key;
+            }
+        }
+
+        return $found;
+    }
+
+    /**
+     * Keys the consumer has that the template does not — about to be removed.
+     *
+     * Usually that is correct (stale hand-edits), but occasionally the consumer
+     * is ahead of the template: a project that added a `role = test` install
+     * before the shared schema caught up. Deleting that silently is unhelpful,
+     * so the caller reports it and the schema gets fixed instead.
+     *
+     * @param string $existing Current consumer file content.
+     * @param string $template Authoritative template content.
+     *
+     * @return list<string>
+     */
+    public function keysMissingFromTemplate(string $existing, string $template): array
+    {
+        $keysOf = static fn (string $body): array => array_map(
+            static fn (array $pair): string => $pair[0],
+            self::pairs($body)
+        );
+
+        return array_values(array_diff($keysOf($existing), $keysOf($template)));
+    }
+
+    /**
+     * Key/value pairs from a properties file, skipping blanks, section headers
+     * and comments. Both `#` and `;` open a comment here: the template uses `#`
+     * so Java-properties-aware IDEs accept it, and PHP tolerates both.
+     *
+     * @return list<array{0: string, 1: string}>
+     */
+    private static function pairs(string $body): array
+    {
+        if (trim($body) === '') {
+            return [];
+        }
+
+        $pairs = [];
+
+        foreach (preg_split('/\R/', $body) ?: [] as $line) {
+            $line = trim($line);
+
+            if ($line === '' || $line[0] === '#' || $line[0] === ';' || $line[0] === '[') {
+                continue;
+            }
+
+            if (!str_contains($line, '=')) {
+                continue;
+            }
+
+            [$key, $value] = explode('=', $line, 2);
+
+            $pairs[] = [trim($key), trim($value)];
+        }
+
+        return $pairs;
+    }
+}

--- a/templates/build.properties.tmpl
+++ b/templates/build.properties.tmpl
@@ -75,6 +75,25 @@ builder.j5-test.admin_user  = admin
 builder.j5-test.admin_pass  = admin
 builder.j5-test.admin_email = admin@example.com
 
+# ----- Joomla 6 test install (artifact verification) ----------------------
+# A second role = test install, so the release harness can verify the built
+# package against both supported major versions. Commented out by default —
+# uncomment and add `j6-test` to `builder.installs` above if you run one.
+# Must be a real, non-symlinked install: role = test targets are wiped and
+# reinstalled by the harness, and a symlink would put the working repo in
+# the blast radius.
+#builder.j6-test.role        = test
+#builder.j6-test.path        = /path/to/joomla6-test
+#builder.j6-test.url         = https://j6-test.local
+#builder.j6-test.version     = 6.0.0
+#builder.j6-test.db_host     = localhost
+#builder.j6-test.db_user     =
+#builder.j6-test.db_pass     =
+#builder.j6-test.db_name     =
+#builder.j6-test.admin_user  = admin
+#builder.j6-test.admin_pass  = admin
+#builder.j6-test.admin_email = admin@example.com
+
 # ----- CWM sibling paths --------------------------------------------------
 # Per-developer absolute paths to CWM siblings declared in
 # cwm-build.config.json under dev.cwmSiblings. Written by `composer setup`.

--- a/tests/Config/DistPropertiesInspectorTest.php
+++ b/tests/Config/DistPropertiesInspectorTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Config;
+
+use CWM\BuildTools\Config\DistPropertiesInspector;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DistPropertiesInspectorTest extends TestCase
+{
+    private DistPropertiesInspector $inspector;
+
+    protected function setUp(): void
+    {
+        $this->inspector = new DistPropertiesInspector();
+    }
+
+    /**
+     * The case that prompted this: a developer's local database credentials in
+     * the committed template rather than the gitignored build.properties.
+     */
+    public function testDetectsLocalDatabaseCredentials(): void
+    {
+        $properties = <<<'PROPS'
+        builder.j5.db_host     = localhost
+        builder.j5.db_user     = root
+        builder.j5.db_pass     = root
+        builder.j5.db_name     = j5_dev
+        PROPS;
+
+        self::assertSame(
+            ['builder.j5.db_user', 'builder.j5.db_pass', 'builder.j5.db_name'],
+            $this->inspector->populatedSecretKeys($properties)
+        );
+    }
+
+    /**
+     * The shipped template has these keys present but blank. Flagging them would
+     * make the guard fire on every clean sync and train people to ignore it.
+     */
+    public function testBlankCredentialKeysAreNotFlagged(): void
+    {
+        $properties = <<<'PROPS'
+        builder.j5.db_user     =
+        builder.j5.db_pass     =
+        builder.j5.db_name     =
+        PROPS;
+
+        self::assertSame([], $this->inspector->populatedSecretKeys($properties));
+    }
+
+    /**
+     * `admin_pass = admin` ships in the template as a documented placeholder for
+     * a throwaway local install, so it must stay outside the pattern.
+     */
+    public function testDocumentedPlaceholdersAreNotFlagged(): void
+    {
+        $properties = <<<'PROPS'
+        builder.j5.admin_user  = admin
+        builder.j5.admin_pass  = admin
+        builder.j5.admin_email = admin@example.com
+        builder.j5.url         = https://j5-dev.local
+        PROPS;
+
+        self::assertSame([], $this->inspector->populatedSecretKeys($properties));
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function nonAssignmentLineProvider(): array
+    {
+        return [
+            'hash comment'      => ['# builder.j5.db_pass = notreal'],
+            'semicolon comment' => ['; builder.j5.db_pass = notreal'],
+            'section header'    => ['[paths]'],
+            'no assignment'     => ['builder.j5.db_pass'],
+            'blank'             => ['   '],
+        ];
+    }
+
+    /**
+     * Commented-out credentials are not live values — the template ships whole
+     * sections commented out, and flagging those would be noise.
+     */
+    #[DataProvider('nonAssignmentLineProvider')]
+    public function testNonAssignmentLinesAreIgnored(string $line): void
+    {
+        self::assertSame([], $this->inspector->populatedSecretKeys($line));
+    }
+
+    public function testEmptyInputYieldsNothing(): void
+    {
+        self::assertSame([], $this->inspector->populatedSecretKeys(''));
+        self::assertSame([], $this->inspector->keysMissingFromTemplate('', ''));
+    }
+
+    /**
+     * The consumer being ahead of the shared schema is the case worth reporting:
+     * a project that added a role=test install before the template caught up
+     * would otherwise have it silently deleted on the next sync.
+     */
+    public function testReportsKeysTheTemplateWouldRemove(): void
+    {
+        $existing = <<<'PROPS'
+        builder.installs = j5, j6-test
+        builder.j6-test.role = test
+        builder.j6-test.path = /path/to/joomla6-test
+        PROPS;
+
+        $template = <<<'PROPS'
+        builder.installs = j5
+        PROPS;
+
+        self::assertSame(
+            ['builder.j6-test.role', 'builder.j6-test.path'],
+            $this->inspector->keysMissingFromTemplate($existing, $template)
+        );
+    }
+
+    /**
+     * A key the template also defines is being updated, not removed.
+     */
+    public function testKeysPresentInBothAreNotReported(): void
+    {
+        $properties = 'builder.j5.db_host = localhost';
+
+        self::assertSame(
+            [],
+            $this->inspector->keysMissingFromTemplate($properties, $properties)
+        );
+    }
+
+    /**
+     * Guards the real artifact: whatever ships in the repo must be clean, or
+     * every consumer inherits the leak on their next sync.
+     */
+    public function testShippedTemplateContainsNoPopulatedSecrets(): void
+    {
+        $template = \dirname(__DIR__, 2) . '/templates/build.properties.tmpl';
+
+        self::assertFileExists($template);
+
+        self::assertSame(
+            [],
+            $this->inspector->populatedSecretKeys((string) file_get_contents($template)),
+            'templates/build.properties.tmpl must never ship populated credential values'
+        );
+    }
+}


### PR DESCRIPTION
`build.dist.properties` is committed by every consumer; per-machine values belong in the gitignored `build.properties`. The two names differ by four characters, and the wrong one gets edited.

**Sync made that worse rather than better.** It overwrites the consumer's copy from the template, so a developer's database credentials disappeared from the working tree while remaining in whatever commit had already captured them — the mistake erased its own evidence.

Found in Proclaim: `db_user = root` / `db_pass = root` / `db_name = j5_dev` sitting in the committed template. History was clean that time, but nothing would have said so.

## Three checks before the write

Extracted into a new `Config\DistPropertiesInspector` so they're testable rather than buried in the script.

| check | behaviour |
|---|---|
| Template carries credentials | **Refuses to sync** — worst case, it propagates to every consumer |
| Consumer file carries credentials | **Warns**, naming the keys and pointing at `git log -p -- build.dist.properties` |
| Consumer has keys the template lacks | **Reports** them — they're about to be deleted |

That third one is not hypothetical. Proclaim's 11 `builder.j6-test.*` keys would have been dropped without a word:

```
build.dist.properties: NOTE — 11 key(s) present locally are not in
  the cwm-build-tools template and will be removed:
    builder.j6-test.role
    builder.j6-test.path
    ...
```

Matching is on **key name**, not value (`db_user`, `db_pass`, `db_name`, `password`, `secret`, `token`, `api_key`) — local credentials rarely look distinctive enough to detect by shape. The template's documented `admin_pass = admin` placeholder sits outside the pattern deliberately, so a clean sync stays quiet and the warning keeps its meaning.

## Also

`templates/build.properties.tmpl` gains a commented-out `j6-test` section, so a second `role = test` install is part of the shared schema rather than a local addition the next sync deletes. It carries the warning that a `role = test` target must be a real, **non-symlinked** install — the harness wipes and reinstalls it, which is what made #28 necessary.

## Verification

226 tests pass, 12 new. One asserts the **shipped template** never carries populated credentials, so this can't regress into the artifact consumers actually receive.

Both guards exercised end to end against a real consumer: the credential warning fires on a seeded file, the refusal fires on a poisoned template, and the drop-report fires on Proclaim.

Note: `parse_ini_file()` cannot validate this template (`#` comments) — it fails on the committed version too. `PropertiesReader` is the correct parser and reads the amended template cleanly: 3 installs, `j6-test` properly excluded while commented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)