### PR TITLE
feat(vendor-check): audit for advisories and scan nested Composer projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   distinctive. The template's documented `admin_pass = admin` placeholder is
   deliberately outside the pattern.
 
+- **`npm outdated` results were silently discarded, so dev dependency updates
+  were never reported.** `npm outdated` exits 1 when anything *is* outdated,
+  and `runFile()` treated any non-zero exit as failure and returned an empty
+  string. The Dev Dependencies table therefore printed `(all packages) ✓ OK`
+  regardless of actual state — a false clean bill of health. Verified against
+  Proclaim, which reported "OK" while carrying 11 outdated dev dependencies.
+
+  `runFile()` gains an `allowFailure` option that recovers stdout from the
+  thrown error, for the several tools that use a non-zero exit to signal
+  findings rather than failure (`npm outdated`, `npm audit`, `composer audit`).
+
 ### Added
 
 - `templates/build.properties.tmpl` — commented-out `j6-test` section, so a second
@@ -43,6 +54,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   real, non-symlinked install, since the harness wipes and reinstalls it.
 - `tests/Config/DistPropertiesInspectorTest.php` — 12 tests, including one asserting
   the shipped template never carries populated credentials.
+
+- **`vendor-check.js` now audits for security advisories.** A new *Security
+  Advisories* section runs `composer audit` and `npm audit`, reporting package,
+  severity, advisory ID and summary. Advisory IDs are displayed as GHSA where
+  available (Composer's native `advisoryId` is a `PKSA-*`, but the GHSA in
+  `sources[].remoteId` is what Dependabot and GitHub show).
+
+  Audits run against the **lock file** (`composer audit --locked`) rather than
+  the installed tree. Plain `composer audit` inspects `vendor/`, so a project
+  that has not been installed reports `No packages - skipping audit` and exits
+  0 — a silent false clean. The lock is also the honest record of what a
+  project ships.
+
+- **Nested Composer projects are now discovered and checked.** An extension may
+  bundle its own Composer project with a committed `vendor/` tree that ships to
+  end users. Those dependencies are invisible to a root-level `composer
+  outdated`, so a vulnerable bundled package can ship indefinitely unnoticed.
+  Auto-discovery walks the repo (skipping `vendor`, `node_modules`, `media`,
+  `dist` and dotfiles) and the *PHP Dependencies* table gains a `Scope` column.
+
+- **New optional `security` block in `cwm-build.config.json`** — `scanNested`,
+  `nestedPaths[]`, `maxDepth`, `ignore[]`. All have working defaults; existing
+  configs need no changes. `ignore[]` matches GHSA, PKSA or CVE identifiers.
+
+- **New exit code 2** for "security advisories found", taking precedence over
+  exit 1 ("updates available"). Exit 0 still means clean. Callers that only
+  test for non-zero are unaffected.
 
 ## [1.6.1] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,9 +78,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `nestedPaths[]`, `maxDepth`, `ignore[]`. All have working defaults; existing
   configs need no changes. `ignore[]` matches GHSA, PKSA or CVE identifiers.
 
-- **New exit code 2** for "security advisories found", taking precedence over
-  exit 1 ("updates available"). Exit 0 still means clean. Callers that only
-  test for non-zero are unaffected.
+- **New exit code 2** for "security advisories found *or* security status
+  unverified", taking precedence over exit 1 ("updates available"). Exit 0
+  still means clean. Callers that only test for non-zero are unaffected.
+
+- **The security check fails closed.** A scope whose audit could not run —
+  `composer` missing from `PATH`, a timeout, a broken lock — is reported as
+  unverified and exits 2 rather than passing silently. Without this the section
+  had the exact flaw it was written to remove: with `composer` unavailable, a
+  tree carrying four known advisories reported *"All checked packages are up to
+  date, with no known advisories"* and exit 0. "We found nothing" and "we did
+  not look" are different answers. Scopes with no manifest to audit are skipped
+  rather than failed.
 
 ## [1.6.1] - 2026-07-25
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,8 @@ cwm-init` rather than authoring by hand. Minimal examples live in
 | `assets` | Source-tree asset staging (`images`, `vendorMediaSource`, `packages[]`). Source paths, not install paths. |
 | `dev` | Optional dev-link overrides — `deriveLinks`, `links[]`, `internalLinks[]`, `cwmSiblings`. |
 | `gitignore` | `{ outputPaths[], mediaPaths[] }` feeding the managed `.gitignore` block. |
+| `vendors` | Bundled npm libraries `vendor:check` reports on — `[{ npm, label?, notes? }]`. |
+| `security` | Optional `vendor:check` audit tuning. See [security block](#the-security-block). |
 
 ### The `build` block
 
@@ -50,6 +52,45 @@ Consumed by `cwm-build` / `cwm-package`.
 | `preBuild` | `{ mode: "ensure-minified", dirs[] }` or `{ mode: "run", command }` (e.g. `npm run build`). Runs before zipping. |
 | `verifyAssets` | `true` to fail the build if a `joomla.asset.json`-referenced file is missing. See the [JS guide](javascript-and-joomladialog.md#72-buildverifyassets-fail-loudly-if-an-asset-didnt-build). |
 | `versionPrompt` | `{ enabled, timeout }` for the interactive 3-way version prompt. |
+
+### The `security` block
+
+Consumed by `vendor:check` (`templates/vendor-check.js`). Entirely optional —
+every key has a working default, so existing configs need no changes.
+
+| Key | Default | Purpose |
+|---|---|---|
+| `scanNested` | `true` | Discover Composer projects nested inside the repo and audit them too. |
+| `nestedPaths[]` | *(unset)* | Explicit project dirs relative to the root. Setting this skips auto-discovery entirely — use it when the walk is too slow or picks up something unwanted. |
+| `maxDepth` | `6` | Auto-discovery depth limit. |
+| `ignore[]` | `[]` | Advisory IDs to suppress. Matches GHSA, PKSA or CVE. |
+
+**Why nested projects matter.** An extension may bundle its own Composer
+project whose `vendor/` tree is committed and ships to end users. Those
+dependencies are invisible to a root-level `composer outdated`, so a vulnerable
+bundled package can ship indefinitely without the tool noticing. Proclaim hit
+exactly this: `vendor:check` reported "all up to date" while the bundled YouTube
+addon carried a Guzzle with four open advisories.
+
+Auto-discovery skips `vendor`, `node_modules`, `media`, `dist` and dotfile
+directories, and does not descend into a nested project's own subtree.
+
+Audits read the **lock file**, not the installed tree — an uninstalled project
+would otherwise report `No packages - skipping audit` and pass silently.
+
+Use `ignore[]` sparingly and only for advisories you have assessed as
+inapplicable. Each entry silences a real finding:
+
+```json
+{
+  "security": {
+    "ignore": ["GHSA-xxxx-xxxx-xxxx"]
+  }
+}
+```
+
+**Exit codes:** `0` clean, `1` updates available, `2` advisories found (takes
+precedence over `1`). Callers that only test for non-zero are unaffected.
 
 !!! note "Trust model"
     Every value here is author-controlled (committed by the project author).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,8 +89,16 @@ inapplicable. Each entry silences a real finding:
 }
 ```
 
-**Exit codes:** `0` clean, `1` updates available, `2` advisories found (takes
-precedence over `1`). Callers that only test for non-zero are unaffected.
+**Exit codes:** `0` clean, `1` updates available, `2` advisories found *or
+security status unverified* (takes precedence over `1`). Callers that only test
+for non-zero are unaffected.
+
+The check **fails closed**. If a scope cannot be audited — `composer` missing
+from `PATH`, a timeout, a broken lock — it is reported as unverified and exits
+`2` rather than passing. "We found nothing" and "we did not look" are different
+answers, and conflating them is how a vulnerable tree earns a green check. A
+scope with no `composer.json` (or, for npm, no `package.json` + lockfile) is
+skipped rather than failed, since there is genuinely nothing to audit.
 
 !!! note "Trust model"
     Every value here is author-controlled (committed by the project author).

--- a/templates/vendor-check.js
+++ b/templates/vendor-check.js
@@ -3,17 +3,32 @@
 /**
  * Vendor Dependency Version Checker.
  *
- * Reports the status of all project dependencies in three groups:
+ * Reports the status of all project dependencies in four groups:
  *   1. Vendor Libraries  — bundled libraries listed in cwm-build.config.json
  *   2. Dev Dependencies  — npm build tools (from package.json)
- *   3. PHP Dependencies  — Composer packages (composer outdated)
+ *   3. PHP Dependencies  — Composer packages (composer outdated), root + nested projects
+ *   4. Security          — known advisories (composer audit + npm audit)
  *
- * Exit code 0 = all current, 1 = updates available.
+ * Exit codes:
+ *   0 = everything current and no advisories
+ *   1 = updates available
+ *   2 = security advisories found (takes precedence over 1)
  *
  * Reads from <CWD>/cwm-build.config.json:
  *   vendors[]            { npm: "chart.js", label: "chart.js", notes: "..." }
+ *   security {}          optional, see below — all keys have working defaults
+ *     scanNested         bool, default true. Discover nested Composer projects.
+ *     nestedPaths[]      explicit project dirs, relative to root. Set this to
+ *                        skip auto-discovery entirely.
+ *     maxDepth           int, default 6. Auto-discovery depth limit.
+ *     ignore[]           advisory IDs to suppress (e.g. "GHSA-xxxx-xxxx-xxxx").
  *
- * If vendors[] is empty or missing, only sections 2 and 3 are reported.
+ * If vendors[] is empty or missing, only sections 2-4 are reported.
+ *
+ * Why nested projects matter: an extension may bundle its own Composer project
+ * (its vendor/ tree committed and shipped to end users). Those dependencies are
+ * invisible to a root-level `composer outdated`, so a vulnerable bundled package
+ * can ship indefinitely without this tool noticing.
  *
  * Usage from a consuming project's package.json:
  *   "vendor:check": "node vendor/cwm/build-tools/templates/vendor-check.js"
@@ -26,11 +41,39 @@ const path             = require('path');
 const ROOT        = process.cwd();
 const CONFIG      = readJson(path.join(ROOT, 'cwm-build.config.json')) || {};
 const VENDOR_LIST = (CONFIG.vendors || []);
+const SECURITY    = (CONFIG.security || {});
+const IGNORED     = new Set(SECURITY.ignore || []);
 
-function runFile(cmd, args) {
+const DEFAULT_MAX_DEPTH = 6;
+const TIMEOUT_MS        = 60000;
+
+/** Directories never worth descending into when hunting for nested projects. */
+const SKIP_DIRS = new Set(['vendor', 'node_modules', 'media', 'dist']);
+
+/** Normalised severity ranking, worst first. Composer says "medium", npm says "moderate". */
+const SEVERITY_RANK = { critical: 0, high: 1, moderate: 2, medium: 2, low: 3, info: 4 };
+
+/**
+ * Run a command and return its stdout.
+ *
+ * Several of the tools we shell out to use a non-zero exit status to report
+ * *findings* rather than failure — `npm outdated` exits 1 when anything is
+ * outdated, `npm audit` and `composer audit` exit non-zero when advisories
+ * exist. Their stdout is still the payload we want, so callers that expect
+ * that pass allowFailure and we recover it from the thrown error.
+ */
+function runFile(cmd, args, opts = {}) {
     try {
-        return execFileSync(cmd, args, { cwd: ROOT, encoding: 'utf8', timeout: 30000 }).trim();
-    } catch {
+        return execFileSync(cmd, args, {
+            cwd:      opts.cwd || ROOT,
+            encoding: 'utf8',
+            timeout:  TIMEOUT_MS,
+            stdio:    ['ignore', 'pipe', 'ignore'],
+        }).trim();
+    } catch (err) {
+        if (opts.allowFailure && err && typeof err.stdout === 'string') {
+            return err.stdout.trim();
+        }
         return '';
     }
 }
@@ -38,6 +81,17 @@ function runFile(cmd, args) {
 function readJson(filePath) {
     try {
         return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    } catch {
+        return null;
+    }
+}
+
+function parseJson(raw) {
+    if (!raw) {
+        return null;
+    }
+    try {
+        return JSON.parse(raw);
     } catch {
         return null;
     }
@@ -62,6 +116,55 @@ function renderTable(headers, rows) {
     console.log(sep);
     rows.forEach(r => console.log(fmt(r)));
     console.log(sep);
+}
+
+/**
+ * Locate Composer projects nested inside the repository.
+ *
+ * Returns paths relative to ROOT. Does not descend into a nested project's own
+ * subtree — its dependencies belong to it, not to a deeper project.
+ */
+function discoverNestedComposerProjects() {
+    if (SECURITY.scanNested === false) {
+        return [];
+    }
+
+    if (Array.isArray(SECURITY.nestedPaths) && SECURITY.nestedPaths.length > 0) {
+        return SECURITY.nestedPaths.filter(p => fs.existsSync(path.join(ROOT, p, 'composer.json')));
+    }
+
+    const maxDepth = Number.isInteger(SECURITY.maxDepth) ? SECURITY.maxDepth : DEFAULT_MAX_DEPTH;
+    const found    = [];
+
+    (function walk(dir, depth) {
+        if (depth > maxDepth) {
+            return;
+        }
+
+        let entries;
+        try {
+            entries = fs.readdirSync(dir, { withFileTypes: true });
+        } catch {
+            return;
+        }
+
+        for (const entry of entries) {
+            if (!entry.isDirectory() || entry.name.startsWith('.') || SKIP_DIRS.has(entry.name)) {
+                continue;
+            }
+
+            const full = path.join(dir, entry.name);
+
+            if (fs.existsSync(path.join(full, 'composer.json'))) {
+                found.push(path.relative(ROOT, full));
+                continue;
+            }
+
+            walk(full, depth + 1);
+        }
+    })(ROOT, 1);
+
+    return found.sort();
 }
 
 function checkVendors() {
@@ -95,15 +198,8 @@ function checkVendors() {
 function checkDevDependencies() {
     console.log('\nDev Dependencies (build tools)');
 
-    const json = runFile('npm', ['outdated', '--json']);
-    let outdated = {};
-    if (json) {
-        try {
-            outdated = JSON.parse(json);
-        } catch {
-            // ignore
-        }
-    }
+    // npm outdated exits 1 when anything is outdated — allowFailure keeps the JSON.
+    const outdated = parseJson(runFile('npm', ['outdated', '--json'], { allowFailure: true })) || {};
 
     const pkgJson    = readJson(path.join(ROOT, 'package.json'));
     const allDevDeps = pkgJson ? Object.keys(pkgJson.devDependencies || {}).sort() : [];
@@ -127,47 +223,172 @@ function checkDevDependencies() {
     return hasUpdates;
 }
 
-function checkPhpDependencies() {
+function composerOutdated(cwd) {
+    const data = parseJson(runFile('composer', ['outdated', '--direct', '--format=json'], { cwd, allowFailure: true }));
+    return (data && data.installed) || [];
+}
+
+function checkPhpDependencies(nestedProjects) {
     console.log('\nPHP Dependencies (composer)');
 
-    const json = runFile('composer', ['outdated', '--direct', '--format=json']);
-    let packages = [];
-    if (json) {
-        try {
-            const data = JSON.parse(json);
-            packages = data.installed || [];
-        } catch {
-            // ignore
+    const scopes = [{ label: '(root)', cwd: ROOT }].concat(
+        nestedProjects.map(p => ({ label: p, cwd: path.join(ROOT, p) }))
+    );
+
+    let hasUpdates = false;
+    const rows = [];
+
+    for (const scope of scopes) {
+        for (const p of composerOutdated(scope.cwd)) {
+            hasUpdates = true;
+            rows.push([scope.label, p.name, p.version || '?', p.latest || '?', '✗ Update']);
         }
     }
 
-    let hasUpdates = false;
-    const rows = packages.map(p => {
-        hasUpdates = true;
-        return [p.name, p.version || '?', p.latest || '?', '✗ Update'];
-    });
-
     if (rows.length === 0) {
-        rows.push(['(all packages)', '', '', '✓ OK']);
+        rows.push(['(root)', '(all packages)', '', '', '✓ OK']);
     }
 
-    renderTable(['Package', 'Current', 'Latest', 'Status'], rows);
+    renderTable(['Scope', 'Package', 'Current', 'Latest', 'Status'], rows);
     return hasUpdates;
+}
+
+/**
+ * Collect Composer advisories for one project directory.
+ *
+ * Unlike `composer outdated --direct`, audit covers transitive packages too —
+ * which is the point, since bundled vulnerabilities are usually transitive.
+ *
+ * Audits the lock file rather than the installed tree. Plain `composer audit`
+ * inspects vendor/, so a project that has not been installed reports
+ * "No packages - skipping audit" and exits 0 — a silent false clean. The lock
+ * is also the honest source of truth for what a project ships.
+ */
+function composerAdvisories(label, cwd) {
+    const args = ['audit', '--format=json'];
+    if (fs.existsSync(path.join(cwd, 'composer.lock'))) {
+        args.splice(1, 0, '--locked');
+    }
+
+    const data = parseJson(runFile('composer', args, { cwd, allowFailure: true }));
+    if (!data || !data.advisories) {
+        return [];
+    }
+
+    const out = [];
+    for (const [pkg, list] of Object.entries(data.advisories)) {
+        for (const adv of (Array.isArray(list) ? list : [])) {
+            // Every identifier this advisory is known by. Composer's own
+            // advisoryId is a PKSA-*; the GHSA lives in sources[].remoteId and
+            // is what Dependabot and GitHub display, so prefer it for output
+            // and accept any of them in the ignore list.
+            const remoteIds = (adv.sources || []).map(s => s.remoteId).filter(Boolean);
+            const ids       = [...remoteIds, adv.advisoryId, adv.cve].filter(Boolean);
+
+            if (ids.some(id => IGNORED.has(id))) {
+                continue;
+            }
+
+            out.push({
+                scope:    label,
+                pkg,
+                severity: String(adv.severity || 'unknown').toLowerCase(),
+                id:       remoteIds.find(id => id.startsWith('GHSA-')) || adv.advisoryId || adv.cve || '?',
+                title:    adv.title || '',
+            });
+        }
+    }
+    return out;
+}
+
+function npmAdvisories() {
+    const data = parseJson(runFile('npm', ['audit', '--json'], { allowFailure: true }));
+    if (!data || !data.vulnerabilities) {
+        return [];
+    }
+
+    const out = [];
+    for (const [pkg, info] of Object.entries(data.vulnerabilities)) {
+        // `via` holds either advisory objects or names of packages pulling it in.
+        const sources = (info.via || []).filter(v => typeof v === 'object');
+        if (sources.length === 0) {
+            continue;
+        }
+        for (const src of sources) {
+            const id = src.url ? src.url.split('/').pop() : (src.source ? String(src.source) : '?');
+            if (IGNORED.has(id)) {
+                continue;
+            }
+            out.push({
+                scope:    '(npm)',
+                pkg,
+                severity: String(src.severity || info.severity || 'unknown').toLowerCase(),
+                id,
+                title:    src.title || '',
+            });
+        }
+    }
+    return out;
+}
+
+function checkSecurity(nestedProjects) {
+    console.log('\nSecurity Advisories');
+
+    const findings = [
+        ...composerAdvisories('(root)', ROOT),
+        ...nestedProjects.flatMap(p => composerAdvisories(p, path.join(ROOT, p))),
+        ...npmAdvisories(),
+    ];
+
+    if (findings.length === 0) {
+        renderTable(['Scope', 'Package', 'Severity', 'Advisory', 'Summary'], [
+            ['(all)', '(no known advisories)', '', '', ''],
+        ]);
+        return false;
+    }
+
+    findings.sort((a, b) =>
+        (SEVERITY_RANK[a.severity] ?? 9) - (SEVERITY_RANK[b.severity] ?? 9)
+        || a.pkg.localeCompare(b.pkg)
+    );
+
+    renderTable(
+        ['Scope', 'Package', 'Severity', 'Advisory', 'Summary'],
+        findings.map(f => [f.scope, f.pkg, f.severity, f.id, truncate(f.title, 60)])
+    );
+    return true;
+}
+
+function truncate(text, max) {
+    const s = String(text || '');
+    return s.length > max ? s.slice(0, max - 1) + '…' : s;
 }
 
 console.log('Vendor / Dependency Status');
 console.log('==========================');
 
+const nestedProjects = discoverNestedComposerProjects();
+
+if (nestedProjects.length > 0) {
+    console.log('\nNested Composer projects: ' + nestedProjects.join(', '));
+}
+
 const vendorUpdates = checkVendors();
 const devUpdates    = checkDevDependencies();
-const phpUpdates    = checkPhpDependencies();
+const phpUpdates    = checkPhpDependencies(nestedProjects);
+const hasAdvisories = checkSecurity(nestedProjects);
 
 console.log('');
+
+if (hasAdvisories) {
+    console.log('Security advisories found — see the table above.');
+    process.exit(2);
+}
 
 if (vendorUpdates || devUpdates || phpUpdates) {
     console.log('Some packages have updates available.');
     process.exit(1);
-} else {
-    console.log('All checked packages are up to date.');
-    process.exit(0);
 }
+
+console.log('All checked packages are up to date, with no known advisories.');
+process.exit(0);

--- a/templates/vendor-check.js
+++ b/templates/vendor-check.js
@@ -265,14 +265,28 @@ function checkPhpDependencies(nestedProjects) {
  * is also the honest source of truth for what a project ships.
  */
 function composerAdvisories(label, cwd) {
+    const hasLock      = fs.existsSync(path.join(cwd, 'composer.lock'));
+    const hasInstalled = fs.existsSync(path.join(cwd, 'vendor', 'composer', 'installed.php'));
+
+    // Nothing resolved to audit — no lock and nothing installed. That is a
+    // skip, not a failure; a project with only a composer.json has no
+    // dependency set for audit to reason about.
+    if (!fs.existsSync(path.join(cwd, 'composer.json')) || (!hasLock && !hasInstalled)) {
+        return { ok: true, findings: [] };
+    }
+
     const args = ['audit', '--format=json'];
-    if (fs.existsSync(path.join(cwd, 'composer.lock'))) {
+    if (hasLock) {
         args.splice(1, 0, '--locked');
     }
 
     const data = parseJson(runFile('composer', args, { cwd, allowFailure: true }));
-    if (!data || !data.advisories) {
-        return [];
+
+    // No parsable output means the audit did not run — composer missing from
+    // PATH, a timeout, a broken lock. Report it rather than treating an absent
+    // answer as a clean one.
+    if (!data || typeof data.advisories !== 'object' || data.advisories === null) {
+        return { ok: false, findings: [], scope: label, reason: 'composer audit produced no parsable output' };
     }
 
     const out = [];
@@ -298,13 +312,20 @@ function composerAdvisories(label, cwd) {
             });
         }
     }
-    return out;
+    return { ok: true, findings: out };
 }
 
 function npmAdvisories() {
+    // Nothing to audit deterministically without a manifest and a lockfile.
+    if (!fs.existsSync(path.join(ROOT, 'package.json'))
+        || !fs.existsSync(path.join(ROOT, 'package-lock.json'))) {
+        return { ok: true, findings: [] };
+    }
+
     const data = parseJson(runFile('npm', ['audit', '--json'], { allowFailure: true }));
-    if (!data || !data.vulnerabilities) {
-        return [];
+
+    if (!data || typeof data.vulnerabilities !== 'object' || data.vulnerabilities === null) {
+        return { ok: false, findings: [], scope: '(npm)', reason: 'npm audit produced no parsable output' };
     }
 
     const out = [];
@@ -328,35 +349,54 @@ function npmAdvisories() {
             });
         }
     }
-    return out;
+    return { ok: true, findings: out };
 }
 
+/**
+ * Report known advisories across every audited scope.
+ *
+ * Fails closed. A scope whose audit could not run is reported as unverified and
+ * treated as a failure, because "we did not find anything" and "we did not
+ * look" are not the same answer — and silently conflating them is how a
+ * vulnerable tree earns a green check.
+ */
 function checkSecurity(nestedProjects) {
     console.log('\nSecurity Advisories');
 
-    const findings = [
-        ...composerAdvisories('(root)', ROOT),
-        ...nestedProjects.flatMap(p => composerAdvisories(p, path.join(ROOT, p))),
-        ...npmAdvisories(),
+    const results = [
+        composerAdvisories('(root)', ROOT),
+        ...nestedProjects.map(p => composerAdvisories(p, path.join(ROOT, p))),
+        npmAdvisories(),
     ];
 
+    const findings   = results.flatMap(r => r.findings);
+    const unverified = results.filter(r => !r.ok);
+
     if (findings.length === 0) {
+        // Don't claim a clean result when some scope never reported.
         renderTable(['Scope', 'Package', 'Severity', 'Advisory', 'Summary'], [
-            ['(all)', '(no known advisories)', '', '', ''],
+            unverified.length > 0
+                ? ['(partial)', '(none found in audited scopes)', '', '', '']
+                : ['(all)', '(no known advisories)', '', '', ''],
         ]);
-        return false;
+    } else {
+        findings.sort((a, b) =>
+            (SEVERITY_RANK[a.severity] ?? 9) - (SEVERITY_RANK[b.severity] ?? 9)
+            || a.pkg.localeCompare(b.pkg)
+        );
+
+        renderTable(
+            ['Scope', 'Package', 'Severity', 'Advisory', 'Summary'],
+            findings.map(f => [f.scope, f.pkg, f.severity, f.id, truncate(f.title, 60)])
+        );
     }
 
-    findings.sort((a, b) =>
-        (SEVERITY_RANK[a.severity] ?? 9) - (SEVERITY_RANK[b.severity] ?? 9)
-        || a.pkg.localeCompare(b.pkg)
-    );
+    if (unverified.length > 0) {
+        console.log('\n  Could not be audited — treat as unknown, not clean:');
+        unverified.forEach(u => console.log(`    ${u.scope}: ${u.reason}`));
+    }
 
-    renderTable(
-        ['Scope', 'Package', 'Severity', 'Advisory', 'Summary'],
-        findings.map(f => [f.scope, f.pkg, f.severity, f.id, truncate(f.title, 60)])
-    );
-    return true;
+    return { hasAdvisories: findings.length > 0, unverified: unverified.length > 0 };
 }
 
 function truncate(text, max) {
@@ -376,12 +416,17 @@ if (nestedProjects.length > 0) {
 const vendorUpdates = checkVendors();
 const devUpdates    = checkDevDependencies();
 const phpUpdates    = checkPhpDependencies(nestedProjects);
-const hasAdvisories = checkSecurity(nestedProjects);
+const security      = checkSecurity(nestedProjects);
 
 console.log('');
 
-if (hasAdvisories) {
+if (security.hasAdvisories) {
     console.log('Security advisories found — see the table above.');
+    process.exit(2);
+}
+
+if (security.unverified) {
+    console.log('Security status unverified — one or more scopes could not be audited.');
     process.exit(2);
 }
 


### PR DESCRIPTION
`vendor:check` could report a project fully healthy while it shipped known vulnerabilities. Proclaim hit all three problems below simultaneously — the tool printed **"All checked packages are up to date"** while carrying 11 outdated dev dependencies *and* a bundled Guzzle with four open Dependabot advisories.

Rebased onto `main` after #29; the `CHANGELOG.md` overlap is merged so both sets of entries survive under a single `Fixed` / `Added` pair.

---

## 🐛 Fixed: `npm outdated` results silently discarded

`npm outdated` **exits 1 when anything *is* outdated**. `runFile()` treated any non-zero exit as failure and returned `''`, so the Dev Dependencies table printed `(all packages) ✓ OK` regardless of actual state — a false clean bill of health.

Proclaim, before and after:

```
Dev Dependencies (build tools)          Dev Dependencies (build tools)
+----------------+-----+-----+------+   +------------------------+---------+--------+----------+
| (all packages) |     |     | ✓ OK |   | @babel/cli             | 7.28.6  | 8.0.4  | ✗ Update |
+----------------+-----+-----+------+   | @babel/core            | 7.29.6  | 8.0.1  | ✗ Update |
                                        | eslint                 | 10.2.1  | 10.8.0 | ✗ Update |
                                        | jest                   | 30.3.0  | 30.4.2 | ✗ Update |
                                        | … 7 more                                            |
                                        +------------------------+---------+--------+----------+
```

`runFile()` gains an `allowFailure` option recovering stdout from the thrown error — needed for the several tools that use a non-zero exit to signal *findings* rather than failure (`npm outdated`, `npm audit`, `composer audit`).

## ✨ Added: security advisory reporting

New section running `composer audit` + `npm audit`, reporting package, severity, advisory ID and summary.

IDs display as **GHSA** where available. Composer's native `advisoryId` is a `PKSA-*`, but the GHSA lives in `sources[].remoteId` and is what Dependabot and GitHub show — so it's the one a reader can actually act on.

Audits read the **lock file** (`composer audit --locked`), not the installed tree. Plain `composer audit` inspects `vendor/`, so an uninstalled project reports `No packages - skipping audit` and **exits 0** — a silent false clean.

## ✨ Added: nested Composer project discovery

An extension may bundle its own Composer project whose `vendor/` tree is committed and ships to end users. Those dependencies are invisible to a root-level `composer outdated`.

Auto-discovery walks the repo (skipping `vendor`, `node_modules`, `media`, `dist`, dotfiles; not descending into a nested project's own subtree). The PHP Dependencies table gains a `Scope` column. On Proclaim it finds three previously-unchecked projects:

```
Nested Composer projects: admin/src/Addons/Servers/Youtube,
                          libraries/lib_cwmscripture,
                          plugins/content/scripturelinks
```

**Worth noting:** `outdated --direct` alone still wouldn't have caught Proclaim's case — the addon's only direct dep (`google/apiclient`) *was* current, and the vulnerable Guzzle was transitive beneath it. The audit pass is what closes the gap; nested discovery points it at the right directories.

## 🔒 Second commit: the security check fails closed

The first commit reproduced, in the new section, the very flaw it was written to remove. `runFile()` returns `''` when a command can't run *at all*, which collapsed to an empty findings list and printed "no known advisories".

Same fixture, four known Guzzle advisories, the only difference being whether `composer` is on `PATH`:

| `composer` | Output | Exit |
|---|---|---|
| available | 4 advisories listed | `2` |
| **off PATH** | **"All checked packages are up to date, with no known advisories"** | **`0`** |

In a CI job without composer on PATH, that's a green check on a vulnerable tree.

Audit helpers now return `{ok, findings}`. A scope producing no parsable output is reported as unverified and exits 2. Failing closed only works if *"nothing to audit"* stays distinct from *"audit failed"* — otherwise every project without a resolved dependency set becomes a false alarm — so a scope is skipped when it has nothing to reason about (no `composer.json`, or neither a lock nor an installed vendor tree; for npm, no `package.json` or lockfile). With empty findings but an unverified scope, the table reads `(none found in audited scopes)` rather than claiming clean.

## Config & compatibility

New optional `security` block — `scanNested`, `nestedPaths[]`, `maxDepth`, `ignore[]`. All defaulted; **existing configs need no changes**. `ignore[]` matches GHSA, PKSA or CVE.

**Exit code 2** now means "advisories found *or* status unverified", taking precedence over `1` (updates). `0` still means clean; callers testing only for non-zero are unaffected.

Also documents `vendors[]` in the top-level key table — previously undocumented.

## Verification

Fixture built by reconstructing Proclaim's pre-fix addon lock, exercised through the real code path. Full matrix re-run after the rebase:

| Scenario | Expected | Result |
|---|---|---|
| Vulnerable nested lock | detect 4, exit 2 | ✅ 4 GHSA rows, exit 2 |
| GHSA IDs match Dependabot | exact | ✅ `GHSA-h95v-h523-3mw8`, `-wm3w-8rrp-j577`, `-f283-ghqc-fg79`, `-94pj-82f3-465w` |
| composer off PATH | fail closed, exit 2 | ✅ exit 2, unverified reported |
| `ignore[]` by GHSA | suppress → exit 0 | ✅ exit 0 |
| `scanNested: false` | no discovery → exit 0 | ✅ exit 0 |
| Real (patched) Proclaim | 0 advisories, 0 unverified, exit 1 | ✅ exit 1, updates only |
| `node --check` | parses | ✅ |

The rebase re-run caught two false positives the fail-closed change had introduced (the `ignore[]` and `scanNested` cases regressed to exit 2 because the fixture root has a `composer.json` but no resolved dependencies) — that's what the skip gate above fixes.

Not run: the PHPUnit suite. This changes a JS template only and touches no PHP — flagged as deliberate rather than overlooked.

## Downstream

Proclaim is the motivating consumer — it just merged four PRs (Joomla-Bible-Study/Proclaim#1317-1320) clearing 5 Dependabot alerts `vendor:check` never surfaced. Once this releases, that class of drift gets caught locally instead of by Dependabot after the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)