### PR TITLE
Release v1.6.2 — build.dist.properties credential guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.6.2] - 2026-07-25
+
 ### Fixed
 
 - **`cwm-sync-configs` now guards `build.dist.properties` against leaked credentials


### PR DESCRIPTION
Promotes the `[Unreleased]` entry from #29 to **v1.6.2**. Changelog-only.

## What ships

`cwm-sync-configs` now guards `build.dist.properties` — the file every consumer commits, as opposed to the gitignored `build.properties` it's one word away from:

- **Refuses to sync** if the cwm-build-tools template itself carries populated credentials (that would reach every consumer)
- **Warns** when a consumer's file has real values in credential keys, pointing at `git log -p -- build.dist.properties` — because sync overwrites the file, which previously erased the evidence while leaving anything already committed in history
- **Reports keys about to be deleted** because the template lacks them — Proclaim's 11 `builder.j6-test.*` keys would have gone silently

Plus a commented-out `j6-test` section in the template, so a second `role = test` install is part of the shared schema rather than a local addition the next sync removes.

226 tests, 12 new — including one asserting the shipped template never carries populated credentials, so this cannot regress into the artifact consumers receive.

Tagged after merge; Proclaim's constraint bump follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)