### PR TITLE
feat(template): two install examples, and lead with the symlink distinction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`build.properties.tmpl` now ships two install examples instead of four**, one
+  of each role, with a note that consumers should add as many as they need — one
+  per Joomla version supported, or several of the same version. Four examples
+  (two dev, two test) read as a fixed set to reproduce rather than a pattern to
+  copy, and left every consumer carrying blocks for installs they do not run.
+  Ids are arbitrary labels; nothing keys off the name.
+
+- **The role documentation now leads with symlinked vs not**, because that is the
+  consequential difference and it was buried in a three-line aside. `role = dev`
+  is symlinked at the working repo; `role = test` is a real file-backed install
+  that the release harness wipes and reinstalls. The warning against pointing a
+  `role = test` install at a symlink is stated in the roles block rather than on
+  one install example, and names both existing backstops (v1.6.1 `cwm-link`
+  filtering, v1.6.2 reset-harness link stripping) as backstops rather than
+  permission.
+
 ## [1.6.2] - 2026-07-25
 
 ### Fixed

--- a/templates/build.properties.tmpl
+++ b/templates/build.properties.tmpl
@@ -23,16 +23,39 @@
 # version is set).
 joomla.version = 5.4.2
 
-# Comma-separated list of install ids. Each id must have a matching block
-# of `builder.<id>.*` keys below.
-builder.installs = j5, j6, j5-test
+# Comma-separated list of install ids. Each id must have a matching block of
+# `builder.<id>.*` keys below.
+#
+# Two examples ship here — one of each role. **Add as many as you need**: one
+# per Joomla version you support, or several of the same version. To add one,
+# copy a block, change the id, and add that id to this list. Ids are arbitrary
+# labels (`j6`, `j7-test`, `client-staging`) — nothing keys off the name.
+builder.installs = j5, j5-test
 
-# ----- Joomla 5 development install ----------------------------------------
-# role values:
-#   dev  — symlink-style working install. `cwm-link` deploys here.
-#   test — artifact-style install. `cwm-install-zip` deploys the dist zip
-#          here and `cwm-verify --target test` queries it.
+# ----- ROLES ----------------------------------------------------------------
+# Every install declares a role, and the role decides how it is treated. This is
+# the most important line in each block:
+#
+#   role = dev    SYMLINKED. `cwm-link` points the install's extension
+#                 directories at your working repo, so edits appear on the site
+#                 immediately with no build step. Never wiped by any command.
+#
+#   role = test   NOT SYMLINKED — a real, file-backed install. `cwm-install-zip`
+#                 deploys the built dist zip here, and the release harness
+#                 (`composer test:install` / `test:upgrade`) WIPES AND
+#                 REINSTALLS it to verify the artifact from a clean slate.
+#
 # (Default role is `dev` when omitted.)
+#
+# Never point a `role = test` install at a symlinked directory. Those commands
+# delete extension directories, and is_dir() is true for a symlink to a
+# directory — so a linked test install means the delete walks through the link
+# and empties your working repo. `cwm-link` skips `role = test` installs for
+# this reason (v1.6.1), and the reset harness strips any stray link it finds
+# before deleting anything (v1.6.2). Both are backstops, not permission to
+# link one.
+
+# ----- Development install (symlinked) --------------------------------------
 builder.j5.role        = dev
 builder.j5.path        = /path/to/joomla5
 builder.j5.url         = https://j5-dev.local
@@ -45,24 +68,11 @@ builder.j5.admin_user  = admin
 builder.j5.admin_pass  = admin
 builder.j5.admin_email = admin@example.com
 
-# ----- Joomla 6 development install ----------------------------------------
-builder.j6.role        = dev
-builder.j6.path        = /path/to/joomla6
-builder.j6.url         = https://j6-dev.local
-builder.j6.version     = 6.0.0
-builder.j6.db_host     = localhost
-builder.j6.db_user     =
-builder.j6.db_pass     =
-builder.j6.db_name     =
-builder.j6.admin_user  = admin
-builder.j6.admin_pass  = admin
-builder.j6.admin_email = admin@example.com
-
-# ----- Joomla 5 test install (artifact verification) ----------------------
-# `cwm-install-zip` deploys the built dist zip into this install so you can
-# exercise the install scriptfile, manifest declarations, and schema
-# migrations end-to-end before release. Remove if you don't run a separate
-# test install — or delete j5-test from `builder.installs` above.
+# ----- Test install (real files, wiped by the release harness) --------------
+# Exercises the install scriptfile, manifest declarations and schema migrations
+# end-to-end before release. Remove this block and drop `j5-test` from
+# `builder.installs` if you don't run one — the harness reports having no
+# target rather than failing.
 builder.j5-test.role        = test
 builder.j5-test.path        = /path/to/joomla5-test
 builder.j5-test.url         = https://j5-test.local
@@ -74,25 +84,6 @@ builder.j5-test.db_name     =
 builder.j5-test.admin_user  = admin
 builder.j5-test.admin_pass  = admin
 builder.j5-test.admin_email = admin@example.com
-
-# ----- Joomla 6 test install (artifact verification) ----------------------
-# A second role = test install, so the release harness can verify the built
-# package against both supported major versions. Commented out by default —
-# uncomment and add `j6-test` to `builder.installs` above if you run one.
-# Must be a real, non-symlinked install: role = test targets are wiped and
-# reinstalled by the harness, and a symlink would put the working repo in
-# the blast radius.
-#builder.j6-test.role        = test
-#builder.j6-test.path        = /path/to/joomla6-test
-#builder.j6-test.url         = https://j6-test.local
-#builder.j6-test.version     = 6.0.0
-#builder.j6-test.db_host     = localhost
-#builder.j6-test.db_user     =
-#builder.j6-test.db_pass     =
-#builder.j6-test.db_name     =
-#builder.j6-test.admin_user  = admin
-#builder.j6-test.admin_pass  = admin
-#builder.j6-test.admin_email = admin@example.com
 
 # ----- CWM sibling paths --------------------------------------------------
 # Per-developer absolute paths to CWM siblings declared in


### PR DESCRIPTION
Addresses the direction on Joomla-Bible-Study/Proclaim#1323:

> *"We should only have two examples and state that you can always add more, and maybe do something to state if we have a non-symlink version."*

## Two examples, not four

The template shipped **four** install blocks — two `dev`, two `test`. That reads as a fixed set to reproduce rather than a pattern to copy, and left every consumer carrying blocks for installs they don't run.

Proclaim is the evidence: its committed dist carried four, while its actual environment has five, none of which match the template's ids.

Now **one of each role**, with an explicit note to add as many as needed — one per Joomla version supported, or several of the same version. Ids are arbitrary labels (`j6`, `j7-test`, `client-staging`); nothing keys off the name.

## Lead with symlinked vs not

Previously a three-line aside above the first install block. It's now its own `ROLES` section, because it's the consequential difference:

```
#   role = dev    SYMLINKED. `cwm-link` points the install's extension
#                 directories at your working repo ... Never wiped.
#
#   role = test   NOT SYMLINKED — a real, file-backed install ... the release
#                 harness WIPES AND REINSTALLS it
```

The warning against pointing a `role = test` install at a symlink now sits in the roles block rather than attached to one example, explains *why* (`is_dir()` is true for a symlink to a directory, so the delete walks through the link and empties the working repo), and names the two existing backstops **as backstops rather than permission**:

- `cwm-link` filtering to `role = dev` (v1.6.1, #28)
- the reset harness stripping stray links (v1.6.2, #29)

Both exist because this already happened once.

## Verified

`PropertiesReader` reads the reshaped template correctly:

```
j5 (role=dev)
j5-test (role=test)
```

Used the real parser rather than `parse_ini_file()`, which cannot read this file's `#` comments and fails on the committed version too.

226 tests pass — including the v1.6.2 guard asserting the shipped template carries no populated credentials.

## Follow-up

Consumers pick this up on their next `composer sync-configs`. For Proclaim that resolves #1323: its dist currently declares four installs and will sync down to these two, with the v1.6.2 drift report naming exactly what changes rather than doing it silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)