### PR TITLE
Release v1.7.0 — two install examples, roles documented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-07-26
+
 ### Changed
 
 - **`build.properties.tmpl` now ships two install examples instead of four**, one


### PR DESCRIPTION
Promotes the `[Unreleased]` entry from #33 to **v1.7.0**. Changelog-only.

## Minor rather than patch

The template's *shape* changes: every consumer's `build.dist.properties` drops from four install examples to two on their next `composer sync-configs`. That's the intent — four read as a fixed set to reproduce rather than a pattern to copy — but it is a change to a committed file in every repo, which is what "minor" signals here.

v1.6.2's drift report names exactly which keys change rather than doing it silently, so no consumer gets a surprise diff.

## What ships

- **Two install examples**, one of each role, with an explicit note to add as many as needed. Ids are arbitrary labels; nothing keys off the name.
- **A `ROLES` section** that leads with the consequential difference — `role = dev` is symlinked at the working repo, `role = test` is a real file-backed install the release harness wipes and reinstalls. Previously a three-line aside above the first block.
- The warning against pointing a `role = test` install at a symlink now sits with the roles rather than on one example, explains why (`is_dir()` is true for a symlink to a directory), and frames v1.6.1 and v1.6.2 as **backstops rather than permission**.

226 tests pass. Tagged after merge; Proclaim's constraint bump follows and closes Joomla-Bible-Study/Proclaim#1323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)