### PR TITLE
fix(ars): render release notes as HTML, and let a release write its own

### DIFF
--- a/scripts/ars-publish.sh
+++ b/scripts/ars-publish.sh
@@ -34,7 +34,17 @@
 #                              1Password CLI for the configured tokenItem.
 #
 # Usage:
-#   bash scripts/ars-publish.sh -v <version> -f <path-to-zip>
+#   bash scripts/ars-publish.sh -v <version> -f <path-to-zip> [-n <notes-file>]
+#
+# Release notes:
+#   ARS renders a release's notes as HTML on the public download page. Notes are
+#   authored in Markdown and converted by scripts/render-notes.php before they
+#   are sent — publishing Markdown directly leaves "##" and "**" literal and
+#   collapses the whole changelog onto one line.
+#
+#   -n <file> (or ARS_NOTES_FILE) supplies notes written for the people reading
+#   that page. Without it the notes fall back to the GitHub release body, which
+#   is normally GitHub's auto-generated list of pull request titles.
 #
 set -euo pipefail
 
@@ -60,16 +70,23 @@ read_config_json() {
 # --- Parse args ---
 VERSION=""
 ZIP_PATH=""
-while getopts "v:f:" opt; do
+NOTES_FILE="${ARS_NOTES_FILE:-}"
+while getopts "v:f:n:" opt; do
     case "$opt" in
         v) VERSION="$OPTARG" ;;
         f) ZIP_PATH="$OPTARG" ;;
-        *) echo "Usage: ars-publish.sh -v <version> -f <path-to-zip>"; exit 1 ;;
+        n) NOTES_FILE="$OPTARG" ;;
+        *) echo "Usage: ars-publish.sh -v <version> -f <path-to-zip> [-n <notes-file>]"; exit 1 ;;
     esac
 done
 
 if [ -z "$VERSION" ] || [ -z "$ZIP_PATH" ]; then
-    echo "Usage: ars-publish.sh -v <version> -f <path-to-zip>"
+    echo "Usage: ars-publish.sh -v <version> -f <path-to-zip> [-n <notes-file>]"
+    exit 1
+fi
+
+if [ -n "$NOTES_FILE" ] && [ ! -f "$NOTES_FILE" ]; then
+    echo "Error: notes file not found: $NOTES_FILE"
     exit 1
 fi
 
@@ -179,8 +196,26 @@ SHA256=$(shasum -a 256 "$ZIP_PATH" 2>/dev/null | cut -d' ' -f1 || echo "")
 SHA384=$(shasum -a 384 "$ZIP_PATH" 2>/dev/null | cut -d' ' -f1 || echo "")
 SHA512=$(shasum -a 512 "$ZIP_PATH" 2>/dev/null | cut -d' ' -f1 || echo "")
 
-# --- Get GitHub release notes ---
-RELEASE_NOTES=$(gh release view "$TAG" --repo "${GH_OWNER}/${GH_REPO}" --json body --jq '.body' 2>/dev/null || echo "")
+# --- Assemble the release notes ---
+#
+# ARS renders `notes` as HTML, so Markdown cannot be handed over as-is: the
+# public 10.3.6 download page showed "## What's Changed * fix(api): ..." with
+# every marker literal and every newline collapsed. Whatever the source, the
+# text is Markdown and gets converted before it is sent.
+#
+# The source is a hand-written notes file when one is given (-n, or
+# ARS_NOTES_FILE), falling back to the GitHub release body. The fallback is
+# GitHub's auto-generated list of pull request titles, which is accurate but
+# written for us rather than for the administrator reading the download page.
+if [ -n "$NOTES_FILE" ]; then
+    echo "Using release notes from ${NOTES_FILE}"
+    RELEASE_NOTES=$(cat "$NOTES_FILE")
+else
+    RELEASE_NOTES=$(gh release view "$TAG" --repo "${GH_OWNER}/${GH_REPO}" --json body --jq '.body' 2>/dev/null || echo "")
+fi
+
+NOTES_HTML=$(printf '%s' "$RELEASE_NOTES" | php "${SCRIPT_DIR}/render-notes.php")
+NOTES_JSON=$(printf '%s' "$NOTES_HTML" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
 
 # --- Check if ARS release already exists ---
 echo "Checking for existing ARS release..."
@@ -212,7 +247,7 @@ if [ -n "$EXISTING_ID" ]; then
             \"version\": \"${VERSION}\",
             \"alias\": \"${ALIAS}\",
             \"maturity\": \"${ARS_MATURITY}\",
-            \"notes\": $(echo "$RELEASE_NOTES" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'),
+            \"notes\": ${NOTES_JSON},
             \"created\": \"${RELEASE_DATE}\",
             \"published\": 1
         }" \
@@ -230,7 +265,7 @@ else
             \"version\": \"${VERSION}\",
             \"alias\": \"${ALIAS}\",
             \"maturity\": \"${ARS_MATURITY}\",
-            \"notes\": $(echo "$RELEASE_NOTES" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'),
+            \"notes\": ${NOTES_JSON},
             \"created\": \"${RELEASE_DATE}\",
             \"published\": 1,
             \"access\": 1,

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -208,6 +208,34 @@ else
     NOTES="Release ${VERSION}"
 fi
 
+# Hand-written notes, if this release has any.
+#
+# What GitHub generates is a list of pull request titles — accurate, and written
+# for us rather than for the person deciding whether to update. Those same notes
+# are republished on the ARS download page, where they are the only changelog a
+# site administrator following an update link ever sees.
+#
+# So a notes file, when present, leads; the generated list is kept beneath it so
+# nothing is lost. Configure `release.notesFile` with a {version} placeholder,
+# e.g. "build/release-notes-{version}.md". Absent file, absent config, or a
+# release nobody wrote notes for: unchanged behaviour.
+NOTES_FILE=""
+NOTES_FILE_PATTERN=$(read_config "release.notesFile")
+if [ -n "$NOTES_FILE_PATTERN" ]; then
+    CANDIDATE="${NOTES_FILE_PATTERN//\{version\}/$VERSION}"
+    if [ -f "$CANDIDATE" ]; then
+        NOTES_FILE="$CANDIDATE"
+        echo "  Using hand-written release notes: ${NOTES_FILE}"
+        NOTES="$(cat "$NOTES_FILE")
+
+## Changes
+
+${NOTES}"
+    else
+        echo "  No hand-written notes at ${CANDIDATE}; using generated notes."
+    fi
+fi
+
 GH_REPO_ARG=""
 if [ -n "$GH_OWNER" ] && [ -n "$GH_REPO" ]; then
     GH_REPO_ARG="--repo ${GH_OWNER}/${GH_REPO}"
@@ -245,6 +273,8 @@ echo ""
 echo "[7/9] Publishing to ARS..."
 ARS_ENDPOINT=$(read_config "ars.endpoint")
 if [ -n "$ARS_ENDPOINT" ]; then
+    # The GitHub release now carries the hand-written notes plus the generated
+    # list, so ARS reads them back from there and both pages agree.
     bash "${TOOLS_DIR}/scripts/ars-publish.sh" -v "$VERSION" -f "${ARTIFACTS[0]}"
 else
     echo "  Skipped: no ars.endpoint configured."

--- a/scripts/render-notes.php
+++ b/scripts/render-notes.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Render Markdown release notes as the HTML fragment ARS expects.
+ *
+ * Reads Markdown on stdin, writes HTML on stdout, so ars-publish.sh can pipe
+ * the GitHub release body (or a hand-written notes file) straight through.
+ *
+ * Usage:
+ *   printf '%s' "$RELEASE_NOTES" | php scripts/render-notes.php
+ */
+
+use CWM\BuildTools\Release\ReleaseNotesFormatter;
+
+$autoloaders = [
+    __DIR__ . '/../vendor/autoload.php',       // standalone checkout
+    __DIR__ . '/../../../autoload.php',        // installed as a dependency
+];
+
+foreach ($autoloaders as $autoloader) {
+    if (is_file($autoloader)) {
+        require $autoloader;
+        break;
+    }
+}
+
+if (!class_exists(ReleaseNotesFormatter::class)) {
+    fwrite(STDERR, "render-notes.php: could not locate the Composer autoloader.\n");
+    exit(1);
+}
+
+$markdown = stream_get_contents(STDIN);
+
+if ($markdown === false) {
+    fwrite(STDERR, "render-notes.php: could not read stdin.\n");
+    exit(1);
+}
+
+echo (new ReleaseNotesFormatter())->toHtml($markdown);

--- a/src/Release/ReleaseNotesFormatter.php
+++ b/src/Release/ReleaseNotesFormatter.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Release;
+
+/**
+ * Converts release notes written in Markdown into the HTML that Akeeba Release
+ * System stores and renders verbatim.
+ *
+ * ARS treats a release's `notes` as an HTML fragment: it is echoed into the
+ * public download page without any Markdown processing. Feeding it the body of
+ * a GitHub release — which is Markdown, and which GitHub generates
+ * automatically unless a human replaces it — produced a download page reading
+ *
+ *     ## What's Changed * fix(api): ... by @bcordis in https://... **Full
+ *     Changelog**: https://...
+ *
+ * with the markers literal and every line collapsed into one paragraph, because
+ * HTML folds newlines into spaces. That is the entire visible changelog for
+ * anyone following an update link, so it has to be real markup.
+ *
+ * This is deliberately a small subset — the constructs GitHub's generated notes
+ * and our hand-written notes actually use — rather than a Markdown engine. It
+ * takes no dependency, which matters for a script that runs during a release.
+ */
+final class ReleaseNotesFormatter
+{
+    /**
+     * Render a Markdown document as an HTML fragment.
+     */
+    public function toHtml(string $markdown): string
+    {
+        $lines = explode("\n", str_replace(["\r\n", "\r"], "\n", trim($markdown)));
+
+        $html      = [];
+        $paragraph = [];
+        $list      = [];
+
+        $flush = function () use (&$html, &$paragraph, &$list): void {
+            if ($paragraph !== []) {
+                $html[]    = '<p>' . implode("<br>\n", $paragraph) . '</p>';
+                $paragraph = [];
+            }
+
+            if ($list !== []) {
+                $html[] = "<ul>\n" . implode("\n", array_map(
+                    static fn(string $item): string => '<li>' . $item . '</li>',
+                    $list
+                )) . "\n</ul>";
+                $list = [];
+            }
+        };
+
+        foreach ($lines as $line) {
+            $line = rtrim($line);
+
+            // A blank line closes whatever block is open.
+            if (trim($line) === '') {
+                $flush();
+                continue;
+            }
+
+            // Headings. GitHub's generated notes open with "## What's Changed";
+            // h2 is demoted to h3 so the notes sit under the page's own title
+            // rather than competing with it.
+            if (preg_match('/^(#{1,6})\s+(.*)$/', $line, $m) === 1) {
+                $flush();
+                $level  = min(\strlen($m[1]) + 1, 6);
+                $html[] = '<h' . $level . '>' . $this->inline(trim($m[2])) . '</h' . $level . '>';
+                continue;
+            }
+
+            // Horizontal rule.
+            if (preg_match('/^\s*([-*_])(\s*\1){2,}\s*$/', $line) === 1) {
+                $flush();
+                $html[] = '<hr>';
+                continue;
+            }
+
+            // List items. Nesting is flattened: these notes do not use it, and a
+            // wrong guess about depth is worse than a flat list.
+            if (preg_match('/^\s*[-*+]\s+(.*)$/', $line, $m) === 1) {
+                if ($paragraph !== []) {
+                    $html[]    = '<p>' . implode("<br>\n", $paragraph) . '</p>';
+                    $paragraph = [];
+                }
+
+                $list[] = $this->inline(trim($m[1]));
+                continue;
+            }
+
+            // Anything else is paragraph text. A list is closed first so trailing
+            // prose does not get swallowed into the last bullet.
+            if ($list !== []) {
+                $flush();
+            }
+
+            $paragraph[] = $this->inline(trim($line));
+        }
+
+        $flush();
+
+        return implode("\n", $html);
+    }
+
+    /**
+     * Apply inline formatting to one line of already-block-classified text.
+     *
+     * Everything is escaped first, so no Markdown source can inject markup. The
+     * constructs that produce their own tags — code spans and links — are then
+     * stashed behind placeholders before emphasis is applied, which stops a URL
+     * containing underscores or asterisks from being mangled into <em>.
+     */
+    private function inline(string $text): string
+    {
+        $text = htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+        /** @var array<string, string> $stashed */
+        $stashed = [];
+        $stash   = static function (string $html) use (&$stashed): string {
+            $key           = "\x00" . \count($stashed) . "\x00";
+            $stashed[$key] = $html;
+
+            return $key;
+        };
+
+        // Code spans are opaque: nothing inside them is formatting.
+        $text = preg_replace_callback(
+            '/`([^`]+)`/',
+            static fn(array $m): string => $stash('<code>' . $m[1] . '</code>'),
+            $text
+        ) ?? $text;
+
+        // [label](url)
+        $text = preg_replace_callback(
+            '/\[([^\]]*)\]\((https?:\/\/[^\s)]+)\)/',
+            static fn(array $m): string => $stash(
+                '<a href="' . $m[2] . '" rel="noopener">' . ($m[1] !== '' ? $m[1] : $m[2]) . '</a>'
+            ),
+            $text
+        ) ?? $text;
+
+        // Bare URLs — GitHub's generated notes are full of them. Trailing
+        // sentence punctuation is left outside the link.
+        $text = preg_replace_callback(
+            '~https?://[^\s<>()\[\]]+[^\s<>()\[\].,;:!?\'"]~',
+            static fn(array $m): string => $stash('<a href="' . $m[0] . '" rel="noopener">' . $m[0] . '</a>'),
+            $text
+        ) ?? $text;
+
+        $text = preg_replace('/\*\*(.+?)\*\*/s', '<strong>$1</strong>', $text) ?? $text;
+        $text = preg_replace('/(?<!\*)\*(?!\*)([^*]+)\*(?!\*)/', '<em>$1</em>', $text) ?? $text;
+
+        return strtr($text, $stashed);
+    }
+}

--- a/src/Release/ReleaseNotesFormatter.php
+++ b/src/Release/ReleaseNotesFormatter.php
@@ -34,18 +34,20 @@ final class ReleaseNotesFormatter
         $lines = explode("\n", str_replace(["\r\n", "\r"], "\n", trim($markdown)));
 
         $html      = [];
-        $paragraph = [];
+        $paragraph = '';
         $list      = [];
 
-        $flush = function () use (&$html, &$paragraph, &$list): void {
-            if ($paragraph !== []) {
-                $html[]    = '<p>' . implode("<br>\n", $paragraph) . '</p>';
-                $paragraph = [];
+        $flushParagraph = function () use (&$html, &$paragraph): void {
+            if ($paragraph !== '') {
+                $html[]    = '<p>' . $this->inline($paragraph) . '</p>';
+                $paragraph = '';
             }
+        };
 
+        $flushList = function () use (&$html, &$list): void {
             if ($list !== []) {
                 $html[] = "<ul>\n" . implode("\n", array_map(
-                    static fn(string $item): string => '<li>' . $item . '</li>',
+                    fn(string $item): string => '<li>' . $this->inline($item) . '</li>',
                     $list
                 )) . "\n</ul>";
                 $list = [];
@@ -57,7 +59,8 @@ final class ReleaseNotesFormatter
 
             // A blank line closes whatever block is open.
             if (trim($line) === '') {
-                $flush();
+                $flushParagraph();
+                $flushList();
                 continue;
             }
 
@@ -65,7 +68,8 @@ final class ReleaseNotesFormatter
             // h2 is demoted to h3 so the notes sit under the page's own title
             // rather than competing with it.
             if (preg_match('/^(#{1,6})\s+(.*)$/', $line, $m) === 1) {
-                $flush();
+                $flushParagraph();
+                $flushList();
                 $level  = min(\strlen($m[1]) + 1, 6);
                 $html[] = '<h' . $level . '>' . $this->inline(trim($m[2])) . '</h' . $level . '>';
                 continue;
@@ -73,7 +77,8 @@ final class ReleaseNotesFormatter
 
             // Horizontal rule.
             if (preg_match('/^\s*([-*_])(\s*\1){2,}\s*$/', $line) === 1) {
-                $flush();
+                $flushParagraph();
+                $flushList();
                 $html[] = '<hr>';
                 continue;
             }
@@ -81,25 +86,26 @@ final class ReleaseNotesFormatter
             // List items. Nesting is flattened: these notes do not use it, and a
             // wrong guess about depth is worse than a flat list.
             if (preg_match('/^\s*[-*+]\s+(.*)$/', $line, $m) === 1) {
-                if ($paragraph !== []) {
-                    $html[]    = '<p>' . implode("<br>\n", $paragraph) . '</p>';
-                    $paragraph = [];
-                }
-
-                $list[] = $this->inline(trim($m[1]));
+                $flushParagraph();
+                $list[] = trim($m[1]);
                 continue;
             }
 
-            // Anything else is paragraph text. A list is closed first so trailing
-            // prose does not get swallowed into the last bullet.
+            // Anything else continues the block already open. Notes are written
+            // as wrapped Markdown, so a line is a continuation far more often
+            // than it is a new block: joining is what keeps a bullet whose text
+            // ran past the margin as one bullet, and what lets emphasis or a
+            // link span the wrap. Only a blank line starts something new.
             if ($list !== []) {
-                $flush();
+                $list[array_key_last($list)] .= ' ' . trim($line);
+                continue;
             }
 
-            $paragraph[] = $this->inline(trim($line));
+            $paragraph = $paragraph === '' ? trim($line) : $paragraph . ' ' . trim($line);
         }
 
-        $flush();
+        $flushParagraph();
+        $flushList();
 
         return implode("\n", $html);
     }

--- a/tests/Release/ReleaseNotesFormatterTest.php
+++ b/tests/Release/ReleaseNotesFormatterTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Release;
+
+use CWM\BuildTools\Release\ReleaseNotesFormatter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ARS renders a release's notes as HTML. Publishing Markdown into that field
+ * put this on the public Proclaim 10.3.6 download page — the only changelog a
+ * site administrator following an update link ever sees:
+ *
+ *     ## What's Changed * fix(api): make the API switchable ... **Full
+ *     Changelog**: https://...
+ *
+ * markers literal, everything on one line.
+ */
+class ReleaseNotesFormatterTest extends TestCase
+{
+    private ReleaseNotesFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new ReleaseNotesFormatter();
+    }
+
+    /**
+     * The exact body GitHub generated for Proclaim 10.3.6.
+     */
+    public function testGitHubGeneratedNotesBecomeStructuredHtml(): void
+    {
+        $markdown = <<<'MD'
+            ## What's Changed
+            * fix(api): make the API switchable by @bcordis in https://github.com/Joomla-Bible-Study/Proclaim/pull/1331
+            * chore: bump active_development to 10.3.6 by @bcordis in https://github.com/Joomla-Bible-Study/Proclaim/pull/1332
+
+            **Full Changelog**: https://github.com/Joomla-Bible-Study/Proclaim/compare/v10.3.5...v10.3.6
+            MD;
+
+        $html = $this->formatter->toHtml($markdown);
+
+        $this->assertStringContainsString("<h3>What&#039;s Changed</h3>", $html);
+        $this->assertStringContainsString('<ul>', $html);
+        $this->assertSame(2, substr_count($html, '<li>'), 'One bullet per changed item');
+        $this->assertStringContainsString('<strong>Full Changelog</strong>', $html);
+
+        // Nothing may survive as a literal Markdown marker.
+        $this->assertStringNotContainsString('##', $html);
+        $this->assertStringNotContainsString('**', $html);
+        $this->assertDoesNotMatchRegularExpression('/(^|\n)\s*\*\s/', $html, 'No literal bullet markers');
+    }
+
+    public function testBareUrlsBecomeLinks(): void
+    {
+        $html = $this->formatter->toHtml('See https://example.org/a_b for details.');
+
+        $this->assertStringContainsString(
+            '<a href="https://example.org/a_b" rel="noopener">https://example.org/a_b</a>',
+            $html
+        );
+    }
+
+    /**
+     * A URL is stashed before emphasis runs, so its punctuation is not eaten.
+     */
+    public function testUrlWithUnderscoresIsNotItalicised(): void
+    {
+        $html = $this->formatter->toHtml('https://example.org/a_b_c');
+
+        $this->assertStringNotContainsString('<em>', $html);
+    }
+
+    public function testMarkdownLinkUsesItsLabel(): void
+    {
+        $html = $this->formatter->toHtml('[the issue](https://example.org/1)');
+
+        $this->assertStringContainsString('<a href="https://example.org/1" rel="noopener">the issue</a>', $html);
+    }
+
+    /**
+     * Trailing sentence punctuation belongs outside the anchor.
+     */
+    public function testTrailingPunctuationIsNotPartOfTheLink(): void
+    {
+        $html = $this->formatter->toHtml('Read https://example.org/x.');
+
+        $this->assertStringContainsString('>https://example.org/x</a>.', $html);
+    }
+
+    /**
+     * Notes come from a GitHub release body, which anyone with write access can
+     * edit — it must not be able to inject markup into our site.
+     */
+    public function testHtmlInSourceIsEscaped(): void
+    {
+        $html = $this->formatter->toHtml('Fixed <script>alert(1)</script> handling');
+
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testCodeSpansAreNotTreatedAsFormatting(): void
+    {
+        $html = $this->formatter->toHtml('Use `**not bold**` here');
+
+        $this->assertStringContainsString('<code>**not bold**</code>', $html);
+        $this->assertStringNotContainsString('<strong>', $html);
+    }
+
+    /**
+     * Consecutive prose lines are one paragraph with real breaks, not one run-on
+     * line — the collapse that made the published notes unreadable.
+     */
+    public function testAdjacentLinesKeepTheirBreaks(): void
+    {
+        $html = $this->formatter->toHtml("First line\nSecond line");
+
+        $this->assertSame("<p>First line<br>\nSecond line</p>", $html);
+    }
+
+    public function testBlankLineStartsANewParagraph(): void
+    {
+        $html = $this->formatter->toHtml("One\n\nTwo");
+
+        $this->assertSame(2, substr_count($html, '<p>'));
+    }
+
+    /**
+     * Prose after a list must not be absorbed into the final bullet.
+     */
+    public function testProseFollowingAListClosesIt(): void
+    {
+        $html = $this->formatter->toHtml("- item\nTrailing note");
+
+        $this->assertStringContainsString('</ul>', $html);
+        $this->assertStringContainsString('<p>Trailing note</p>', $html);
+        $this->assertStringNotContainsString('Trailing note</li>', $html);
+    }
+
+    #[DataProvider('headingProvider')]
+    public function testHeadingsAreDemotedOneLevel(string $markdown, string $expected): void
+    {
+        $this->assertStringContainsString($expected, $this->formatter->toHtml($markdown));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function headingProvider(): array
+    {
+        return [
+            'h1 becomes h2' => ['# Title', '<h2>Title</h2>'],
+            'h2 becomes h3' => ['## Title', '<h3>Title</h3>'],
+            'h3 becomes h4' => ['### Title', '<h4>Title</h4>'],
+            'h6 stays h6'   => ['###### Title', '<h6>Title</h6>'],
+        ];
+    }
+
+    #[DataProvider('bulletMarkerProvider')]
+    public function testEachBulletMarkerProducesAListItem(string $marker): void
+    {
+        $html = $this->formatter->toHtml("$marker one\n$marker two");
+
+        $this->assertSame(2, substr_count($html, '<li>'));
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function bulletMarkerProvider(): array
+    {
+        return ['asterisk' => ['*'], 'hyphen' => ['-'], 'plus' => ['+']];
+    }
+
+    /**
+     * Hand-written release bullets are plain prose lines with no Markdown at
+     * all — the other thing we feed this. Each must become its own paragraph.
+     */
+    public function testPlainProseBulletsFileBecomesParagraphs(): void
+    {
+        $notes = "The REST API now works.\n\nTurning it on is one step.\n";
+
+        $html = $this->formatter->toHtml($notes);
+
+        $this->assertSame('<p>The REST API now works.</p>' . "\n" . '<p>Turning it on is one step.</p>', $html);
+    }
+
+    public function testEmptyInputProducesEmptyOutput(): void
+    {
+        $this->assertSame('', $this->formatter->toHtml(''));
+        $this->assertSame('', $this->formatter->toHtml("\n\n  \n"));
+    }
+}

--- a/tests/Release/ReleaseNotesFormatterTest.php
+++ b/tests/Release/ReleaseNotesFormatterTest.php
@@ -111,14 +111,42 @@ class ReleaseNotesFormatterTest extends TestCase
     }
 
     /**
-     * Consecutive prose lines are one paragraph with real breaks, not one run-on
-     * line — the collapse that made the published notes unreadable.
+     * Notes are written as wrapped Markdown, so consecutive lines are one
+     * paragraph — joined, as Markdown joins them, not hard-broken at whatever
+     * column the author's editor happened to wrap at.
      */
-    public function testAdjacentLinesKeepTheirBreaks(): void
+    public function testWrappedProseLinesJoinIntoOneParagraph(): void
     {
         $html = $this->formatter->toHtml("First line\nSecond line");
 
-        $this->assertSame("<p>First line<br>\nSecond line</p>", $html);
+        $this->assertSame('<p>First line Second line</p>', $html);
+    }
+
+    /**
+     * A bullet whose text ran past the margin is still one bullet. Treating the
+     * continuation as a new block split every wrapped item in the 10.3.6 notes
+     * into a one-line list followed by an orphaned paragraph.
+     */
+    public function testWrappedListItemStaysOneItem(): void
+    {
+        $html = $this->formatter->toHtml("* an item whose text\n  continues on the next line\n* second");
+
+        $this->assertSame(2, substr_count($html, '<li>'));
+        $this->assertStringContainsString('<li>an item whose text continues on the next line</li>', $html);
+        $this->assertSame(1, substr_count($html, '<ul>'), 'One list, not one per line');
+        $this->assertStringNotContainsString('<p>', $html);
+    }
+
+    /**
+     * Emphasis that spans the wrap still resolves, because the item is joined
+     * before inline formatting runs.
+     */
+    public function testEmphasisSpanningAWrapIsResolved(): void
+    {
+        $html = $this->formatter->toHtml("* the *quoted\n  phrase* here");
+
+        $this->assertStringContainsString('<em>quoted phrase</em>', $html);
+        $this->assertStringNotContainsString('*', $html);
     }
 
     public function testBlankLineStartsANewParagraph(): void
@@ -129,11 +157,12 @@ class ReleaseNotesFormatterTest extends TestCase
     }
 
     /**
-     * Prose after a list must not be absorbed into the final bullet.
+     * A blank line is what ends a list — the same rule Markdown uses, and the
+     * one that keeps a wrapped bullet intact.
      */
-    public function testProseFollowingAListClosesIt(): void
+    public function testBlankLineEndsAListSoProseFollowsIt(): void
     {
-        $html = $this->formatter->toHtml("- item\nTrailing note");
+        $html = $this->formatter->toHtml("- item\n\nTrailing note");
 
         $this->assertStringContainsString('</ul>', $html);
         $this->assertStringContainsString('<p>Trailing note</p>', $html);


### PR DESCRIPTION
## The problem

The Proclaim 10.3.6 download page — where an update link sends people — showed this as its entire changelog:

> \#\# What's Changed \* fix(api): make the API switchable — drop api_access for the plugin's own state by @bcordis in https://... \*\*Full Changelog\*\*: https://...

ARS stores `notes` as an HTML fragment and renders it verbatim. `ars-publish.sh` was posting the GitHub release body, which is Markdown, so every marker stayed literal and every newline collapsed into one paragraph.

## The fix

**Formatting.** Notes now go through `ReleaseNotesFormatter` — a dependency-free subset covering what release notes actually contain: headings, lists, emphasis, code spans, Markdown and bare links. Source is escaped before any markup is added, so a GitHub release body cannot inject HTML into the site. Links are stashed before emphasis runs, so a URL containing underscores is not mangled into `<em>`.

**Content.** GitHub generates a list of PR titles — accurate, but written for us, not for the administrator deciding whether to update. Two optional ways to do better:

- `release.notesFile` in `cwm-build.config.json`, with a `{version}` placeholder (e.g. `build/release-notes-{version}.md`). When the file exists it leads the release notes and the generated list is kept beneath it, so both the GitHub release and the ARS page carry it.
- `ars-publish.sh -n <file>` / `ARS_NOTES_FILE`, for publishing notes on their own.

Both are opt-in. Without the config, behaviour is unchanged apart from the notes now being valid HTML.

## Verification

- 19 new tests, including the exact 10.3.6 body as a regression case, XSS escaping, and the newline collapse itself
- Full suite: 245 tests, 675 assertions, green
- Rendered the real v10.3.6 body end to end and confirmed the assembled API payload is valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151X65uy1t64SDgxwq7mXmq