### PR TITLE
fix(ars): use the query parameters ARS actually reads

### DIFF
--- a/scripts/ars-list.sh
+++ b/scripts/ars-list.sh
@@ -130,13 +130,14 @@ list_releases() {
     echo ""
     echo "ARS Releases in category ${cat_id} @ ${SITE_URL}"
     echo "================================================="
-    # The Joomla JSON:API filter[category_id] parameter is honored by
-    # categories/items but appears to be ignored by /releases on this
-    # ARS install — server returns the full release list regardless of
-    # the filter. Fetch with a generous page size and filter client-side
-    # so the output is always scoped to the requested category.
+    # ARS takes bare query parameters, not JSON:API `filter[...]` syntax — see
+    # component/api/src/Controller/ReleasesController.php, which maps the input
+    # key `category_id` onto `filter.category_id`. The previous note here blamed
+    # "this ARS install" for ignoring the filter; it was the parameter name.
+    #
+    # The client-side scoping below is kept as a guard rather than a workaround.
     curl -s -H "X-Joomla-Token: ${TOKEN}" -H "Accept: application/vnd.api+json" \
-        "${API_BASE}/releases?filter%5Bcategory_id%5D=${cat_id}&page%5Blimit%5D=200" \
+        "${API_BASE}/releases?category_id=${cat_id}&page%5Blimit%5D=200" \
         | CAT_ID="$cat_id" python3 -c "
 import json, os, sys
 data = json.load(sys.stdin)

--- a/scripts/ars-publish.sh
+++ b/scripts/ars-publish.sh
@@ -218,11 +218,25 @@ NOTES_HTML=$(printf '%s' "$RELEASE_NOTES" | php "${SCRIPT_DIR}/render-notes.php"
 NOTES_JSON=$(printf '%s' "$NOTES_HTML" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
 
 # --- Check if ARS release already exists ---
+#
+# ARS reads bare query parameters, not JSON:API `filter[...]` syntax — see
+# component/api/src/Controller/ReleasesController.php, which maps the input key
+# `category_id` onto `filter.category_id`. Sent as `filter[category_id]` it
+# arrives as a PHP array named `filter`, the lookup returns null, and the filter
+# is silently not applied.
+#
+# That mattered because the response is also capped at 20 rows by default: this
+# read was matching the wanted version against an arbitrary 20-row window of
+# every release on the site, in an order that is not id, version or date. A miss
+# takes the create branch below and publishes a *second* release for a version
+# that already exists, reporting success either way.
+#
+# `page[limit]` is the parameter that raises the cap; `list[limit]` is ignored.
 echo "Checking for existing ARS release..."
 EXISTING=$(curl -s \
     -H "X-Joomla-Token: ${TOKEN}" \
     -H "Accept: application/vnd.api+json" \
-    "${API_BASE}/releases?filter%5Bcategory_id%5D=${ARS_CATEGORY_ID}&filter%5Bsearch%5D=${VERSION}")
+    "${API_BASE}/releases?category_id=${ARS_CATEGORY_ID}&search=${VERSION}&page%5Blimit%5D=200")
 
 EXISTING_ID=$(echo "$EXISTING" | python3 -c "
 import json,sys
@@ -289,10 +303,14 @@ fi
 # --- Create or update download item ---
 echo "Adding download item..."
 
+# Same correction as the release lookup above: ItemsController maps the bare
+# input key `release_id`. Sent as `filter[release_id]` this returned 20 rows
+# spanning 19 different releases, and a miss here creates a duplicate download
+# item on the release.
 EXISTING_ITEM=$(curl -s \
     -H "X-Joomla-Token: ${TOKEN}" \
     -H "Accept: application/vnd.api+json" \
-    "${API_BASE}/items?filter%5Brelease_id%5D=${RELEASE_ID}")
+    "${API_BASE}/items?release_id=${RELEASE_ID}&page%5Blimit%5D=200")
 
 EXISTING_ITEM_ID=$(echo "$EXISTING_ITEM" | python3 -c "
 import json,sys


### PR DESCRIPTION
Closes #37.

## The bug

Both create-vs-update lookups in `ars-publish.sh` sent JSON:API `filter[...]` syntax. ARS reads **bare** input keys — `ReleasesController::displayList` and `ItemsController::displayList` map `category_id`, `search` and `release_id` onto their filter state. Sent as `filter[category_id]`, the value arrives as a PHP array named `filter`, the lookup returns null, and the filter is never applied.

That mattered because the response is *also* capped at 20 rows by default. Both lookups were matching against an arbitrary 20-row window of every release and item on the site, in an order that is neither id, version nor date. A miss takes the create branch → **duplicate release or duplicate download item**, reported as success.

| Query | Before | After |
|---|---|---|
| release lookup | 20 rows, all categories | **1 row** |
| item lookup | 20 rows spanning 19 release_ids | **1 row** |

## Verified live

- Release lookup scans 1 row and matches id 40; item lookup returns 1 row
- Full re-publish of 10.3.6 → "already exists, updating" for both release and item
- Afterwards: 31 category-1 releases, **no duplicated versions**, still exactly 1 item on release 40

`page[limit]` is kept — the 20-row cap is real and independent of the parameter bug (`list[limit]` is not honoured). The client-side exact version match is kept too, since `search` is a LIKE and `10.3.1` could one day also match `10.3.10`.

Also retires the comment in `ars-list.sh` blaming "this ARS install" for ignoring the filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151X65uy1t64SDgxwq7mXmq