### PR TITLE
fix(languages): never write a translation that changed a placeholder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ Thumbs.db
 .env
 .env.local
 /composer.lock
+
+# Python bytecode from scripts/ and tests/python/
+__pycache__/
+*.pyc

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,13 @@
     "description": "Shared build, release, and CI tooling for CWM Joomla extensions",
     "type": "library",
     "license": "GPL-2.0-or-later",
-    "keywords": ["joomla", "build", "release", "ars", "cwm"],
+    "keywords": [
+        "joomla",
+        "build",
+        "release",
+        "ars",
+        "cwm"
+    ],
     "authors": [
         {
             "name": "CWM Team",
@@ -77,6 +83,11 @@
         ]
     },
     "scripts": {
-        "test": "phpunit"
+        "test": [
+            "@test:php",
+            "@test:python"
+        ],
+        "test:php": "phpunit",
+        "test:python": "python3 -m unittest discover -s tests/python -v"
     }
 }

--- a/scripts/sync-languages.py
+++ b/scripts/sync-languages.py
@@ -369,6 +369,108 @@ def get_cache_key(text, target_lang):
     """Generate a cache key for a translation."""
     return hashlib.md5(f"{text}:{target_lang}".encode('utf-8')).hexdigest()
 
+# --- Protecting the parts of a string that must not be translated ---------
+#
+# Joomla language values carry {placeholder} tokens, inline HTML and printf
+# specifiers. Sent to a translation engine as prose, all three get translated
+# as ordinary words, and the result is a string that is still valid INI and
+# silently wrong at runtime. One real run produced:
+#
+#   en-GB  User <a href='{accountlink}'>{username}</a> updated ...
+#   nl-NL  Gebruiker <a href='{accountlink}'>{gebruikersnaam}> heeft ...
+#
+# {username} became {gebruikersnaam}, so it never matches the substitution
+# Joomla performs at render time, and the literal token reaches the user.
+# hu-HU lost a closing brace; cs-CZ closed anchors with <a> instead of </a>.
+#
+# Two defences below, and the second is the one that matters: masking reduces
+# how often the engine mangles something, but validation is what guarantees
+# nothing broken is ever written.
+
+# Any %<letter> is treated as a substitution token, not just the printf ones
+# Text::sprintf understands. Proclaim's own strings include "Migrating %d of %t
+# files...", where %t is filled in by the component rather than by sprintf —
+# from a translator's point of view the distinction does not exist, and both
+# break the same way if translated.
+PROTECTED_PATTERN = re.compile(
+    r'(\{[A-Za-z0-9_]+\}'      # {placeholder}
+    r'|</?[A-Za-z][^<>]*>'     # HTML tag, opening or closing
+    r'|%%'                     # escaped literal percent
+    r'|%\d+\$[A-Za-z]'         # positional: %1$s, %2$d
+    r'|%[A-Za-z])'             # plain: %s, %d, %t
+)
+
+PLACEHOLDER_PATTERN = re.compile(r'\{[A-Za-z0-9_]+\}')
+PRINTF_PATTERN = re.compile(r'%%|%\d+\$[A-Za-z]|%[A-Za-z]')
+
+def mask_protected(text):
+    """
+    Replace everything that must survive translation with opaque sentinels.
+
+    Returns (masked_text, tokens). The sentinel is a short alphanumeric run
+    because engines pass those through far more reliably than punctuation or
+    private-use characters — but it is not trusted, which is what
+    translation_is_safe() is for.
+    """
+    tokens = []
+
+    def take(match):
+        tokens.append(match.group(0))
+        return f'ZQX{len(tokens) - 1}ZQX'
+
+    return PROTECTED_PATTERN.sub(take, text), tokens
+
+def unmask_protected(text, tokens):
+    """
+    Put the protected fragments back.
+
+    Engines routinely alter a sentinel's case or wedge spaces into it, so the
+    match is deliberately loose. Anything still not recovered is left as-is and
+    caught by validation.
+    """
+    for index, token in reversed(list(enumerate(tokens))):
+        pattern = re.compile(
+            r'Z\s*Q\s*X\s*' + str(index) + r'\s*Z\s*Q\s*X',
+            re.IGNORECASE
+        )
+        text = pattern.sub(lambda _m, t=token: t, text)
+
+    return text
+
+def translation_signature(text):
+    """
+    The parts of a string a translation must reproduce exactly.
+
+    Placeholders and printf specifiers are compared as sorted multisets, so
+    reordering for grammar is fine while renaming, dropping or duplicating is
+    not. Anchors are compared by count, which catches both the unclosed-tag
+    case and a tag being translated away.
+    """
+    return (
+        sorted(PLACEHOLDER_PATTERN.findall(text)),
+        sorted(PRINTF_PATTERN.findall(text)),
+        len(re.findall(r'<a\b', text, re.IGNORECASE)),
+        len(re.findall(r'</a\s*>', text, re.IGNORECASE)),
+    )
+
+def translation_is_safe(source, translated):
+    """
+    Whether a translation may be written.
+
+    A rejected translation falls back to the English source, which Joomla
+    already handles per key — an untranslated string is strictly better than
+    one whose placeholders no longer resolve.
+    """
+    if translated is None:
+        return False
+
+    # An empty result is a failure for real text, but language files legitimately
+    # contain empty values (KEY="") and those have nothing to translate.
+    if not translated.strip():
+        return not source.strip()
+
+    return translation_signature(source) == translation_signature(translated)
+
 def translate_text(text, target_lang, source_lang='en'):
     """
     Translate text using Google Translate API.
@@ -391,9 +493,11 @@ def translate_text(text, target_lang, source_lang='en'):
         # Google Translate API v2 endpoint
         url = 'https://translation.googleapis.com/language/translate/v2'
 
+        masked, tokens = mask_protected(text)
+
         params = {
             'key': GOOGLE_API_KEY,
-            'q': text,
+            'q': masked,
             'source': source_lang,
             'target': target_lang,
             'format': 'text'
@@ -406,7 +510,14 @@ def translate_text(text, target_lang, source_lang='en'):
             result = json.loads(response.read().decode('utf-8'))
 
         if 'data' in result and 'translations' in result['data']:
-            translated = result['data']['translations'][0]['translatedText']
+            translated = unmask_protected(
+                result['data']['translations'][0]['translatedText'], tokens
+            )
+
+            if not translation_is_safe(text, translated):
+                print(f"    Rejected translation (placeholders changed): {text[:60]}")
+                return None
+
             # Cache the result
             _translation_cache[cache_key] = translated
             return translated
@@ -458,8 +569,16 @@ def translate_batch(texts, target_lang, source_lang='en'):
             ('target', target_lang),
             ('format', 'text')
         ]
+        # Mask before sending; the token list is kept per text so each result
+        # can be restored and then checked against its own source.
+        masked_texts, masked_tokens = [], []
         for text in uncached_texts:
-            params.append(('q', text))
+            masked, tokens = mask_protected(text)
+            masked_texts.append(masked)
+            masked_tokens.append(tokens)
+
+        for masked in masked_texts:
+            params.append(('q', masked))
 
         data = urllib.parse.urlencode(params).encode('utf-8')
         req = urllib.request.Request(url, data=data, method='POST')
@@ -469,13 +588,28 @@ def translate_batch(texts, target_lang, source_lang='en'):
 
         if 'data' in result and 'translations' in result['data']:
             translations = result['data']['translations']
+            rejected = 0
             for i, trans in enumerate(translations):
                 original_idx = uncached_indices[i]
-                translated = trans['translatedText']
+                source = uncached_texts[i]
+                translated = unmask_protected(trans['translatedText'], masked_tokens[i])
+
+                # A translation that lost, renamed or unbalanced any protected
+                # fragment is discarded rather than written. Falling back to
+                # English is something Joomla handles per key; a placeholder
+                # that no longer resolves is not.
+                if not translation_is_safe(source, translated):
+                    rejected += 1
+                    results[original_idx] = source
+                    continue
+
                 results[original_idx] = translated
                 # Cache the result
-                cache_key = get_cache_key(uncached_texts[i], target_lang)
+                cache_key = get_cache_key(source, target_lang)
                 _translation_cache[cache_key] = translated
+
+            if rejected:
+                print(f"    Kept English for {rejected} string(s): translation altered placeholders or markup")
 
         # Small delay to avoid rate limiting
         time.sleep(0.1)

--- a/tests/python/test_sync_languages.py
+++ b/tests/python/test_sync_languages.py
@@ -1,0 +1,226 @@
+"""
+Tests for the placeholder/markup protection in scripts/sync-languages.py.
+
+Every corruption asserted here was produced by a real translation run against
+Proclaim's action-log strings, and shipped as valid INI that failed silently at
+runtime. Joomla substitutes {placeholder} tokens when it renders each log row,
+so a renamed token never matches and the literal text reaches the user.
+
+Stdlib unittest, no dependencies:
+
+    python3 -m unittest discover -s tests/python -v
+"""
+
+import importlib.util
+import os
+import unittest
+
+# The script is not an importable module (hyphenated, and it runs work at
+# import time only under __main__), so load it by path.
+_SCRIPT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    'scripts', 'sync-languages.py'
+)
+_spec = importlib.util.spec_from_file_location('sync_languages', _SCRIPT)
+sync = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sync)
+
+
+# The en-GB source that was corrupted in the wild.
+ACTION_LOG = (
+    "User <a href='{accountlink}'>{username}</a> updated {type} "
+    "<a href='{itemlink}'>{title}</a> ({origin})"
+)
+
+
+class MaskProtectedTest(unittest.TestCase):
+    def test_placeholders_are_replaced_by_sentinels(self):
+        masked, tokens = sync.mask_protected('Hello {username}')
+
+        self.assertNotIn('{username}', masked)
+        self.assertIn('{username}', tokens)
+
+    def test_html_tags_are_protected(self):
+        masked, tokens = sync.mask_protected("<a href='{link}'>x</a>")
+
+        self.assertNotIn('<a', masked)
+        self.assertNotIn('</a>', masked)
+        self.assertIn('</a>', tokens)
+
+    def test_printf_specifiers_are_protected(self):
+        _, tokens = sync.mask_protected('Copied %1$s files in %s seconds')
+
+        self.assertIn('%1$s', tokens)
+        self.assertIn('%s', tokens)
+
+    def test_every_specifier_style_in_the_real_files_is_protected(self):
+        """
+        A survey of Proclaim's en-GB files turned up %s, %d, %1$d..%4$d, %2$s,
+        %t and %%. An earlier pattern covered only %s and %d, which would have
+        left "Migrating %d of %t files..." half-protected.
+        """
+        source = 'Migrating %d of %t files, %1$d done, %2$s left, 100%% sure'
+        masked, tokens = sync.mask_protected(source)
+
+        for spec in ('%d', '%t', '%1$d', '%2$s', '%%'):
+            self.assertIn(spec, tokens, f'{spec} must be protected')
+
+        self.assertEqual(source, sync.unmask_protected(masked, tokens))
+
+    def test_real_migrating_string_round_trips(self):
+        source = 'Migrating %d of %t files...'
+        masked, tokens = sync.mask_protected(source)
+
+        self.assertEqual(source, sync.unmask_protected(masked, tokens))
+
+    def test_translatable_words_survive_masking(self):
+        masked, _ = sync.mask_protected(ACTION_LOG)
+
+        for word in ('User', 'updated'):
+            self.assertIn(word, masked)
+
+    def test_round_trip_is_lossless(self):
+        masked, tokens = sync.mask_protected(ACTION_LOG)
+
+        self.assertEqual(ACTION_LOG, sync.unmask_protected(masked, tokens))
+
+    def test_round_trip_with_ten_or_more_tokens(self):
+        """ZQX1ZQX must not be mistaken for part of ZQX10ZQX."""
+        text = ' '.join('{p%d}' % i for i in range(12))
+        masked, tokens = sync.mask_protected(text)
+
+        self.assertEqual(text, sync.unmask_protected(masked, tokens))
+
+    def test_sentinel_recovered_despite_case_change(self):
+        masked, tokens = sync.mask_protected('Hello {username}')
+
+        self.assertIn('{username}', sync.unmask_protected(masked.lower(), tokens))
+
+    def test_sentinel_recovered_despite_injected_spaces(self):
+        masked, tokens = sync.mask_protected('Hello {username}')
+        mangled = masked.replace('ZQX', 'Z Q X')
+
+        self.assertIn('{username}', sync.unmask_protected(mangled, tokens))
+
+
+class TranslationIsSafeTest(unittest.TestCase):
+    def test_faithful_translation_is_accepted(self):
+        translated = (
+            "Benutzer <a href='{accountlink}'>{username}</a> aktualisierte {type} "
+            "<a href='{itemlink}'>{title}</a> ({origin})"
+        )
+
+        self.assertTrue(sync.translation_is_safe(ACTION_LOG, translated))
+
+    def test_reordered_placeholders_are_accepted(self):
+        """Word order differs per language; only the set must match."""
+        translated = (
+            "<a href='{accountlink}'>{username}</a> felhasznalo frissitette {type} "
+            "<a href='{itemlink}'>{title}</a> ({origin})"
+        )
+
+        self.assertTrue(sync.translation_is_safe(ACTION_LOG, translated))
+
+    def test_translated_placeholder_name_is_rejected(self):
+        """The nl-NL failure: {username} -> {gebruikersnaam}, never substitutes."""
+        translated = (
+            "Gebruiker <a href='{accountlink}'>{gebruikersnaam}</a> heeft {type} "
+            "<a href='{itemlink}'>{titel}</a> bijgewerkt ({origin})"
+        )
+
+        self.assertFalse(sync.translation_is_safe(ACTION_LOG, translated))
+
+    def test_eaten_closing_brace_is_rejected(self):
+        """The hu-HU failure: {username</a> is an unmatchable token."""
+        translated = (
+            "<a href='{accountlink}'>{username</a> felhasznalo frissitette {type} "
+            "<a href='{itemlink}'>{title</a> ({origin})"
+        )
+
+        self.assertFalse(sync.translation_is_safe(ACTION_LOG, translated))
+
+    def test_unbalanced_anchor_is_rejected(self):
+        """The cs-CZ failure: <a> used as a closer, leaving tags open."""
+        translated = (
+            "Uzivatel <a href='{accountlink}'>{username}<a> aktualizoval {type} "
+            "<a href='{itemlink}'>{title}<a> ({origin})"
+        )
+
+        self.assertFalse(sync.translation_is_safe(ACTION_LOG, translated))
+
+    def test_closing_tag_reduced_to_angle_bracket_is_rejected(self):
+        """Also seen in nl-NL: </a> collapsed to >."""
+        translated = (
+            "Gebruiker <a href='{accountlink}'>{username}> heeft {type} "
+            "<a href='{itemlink}'>{title}> bijgewerkt ({origin})"
+        )
+
+        self.assertFalse(sync.translation_is_safe(ACTION_LOG, translated))
+
+    def test_dropped_placeholder_is_rejected(self):
+        self.assertFalse(sync.translation_is_safe('Hello {username}', 'Hallo'))
+
+    def test_duplicated_placeholder_is_rejected(self):
+        self.assertFalse(
+            sync.translation_is_safe('Hello {username}', 'Hallo {username} {username}')
+        )
+
+    def test_changed_printf_specifier_is_rejected(self):
+        self.assertFalse(sync.translation_is_safe('Copied %1$s files', 'Kopierte %2$s Dateien'))
+
+    def test_dropped_custom_token_is_rejected(self):
+        """%t is filled in by the component, and breaks the same way if lost."""
+        self.assertFalse(
+            sync.translation_is_safe('Migrating %d of %t files...', 'Migration von %d Dateien...')
+        )
+
+    def test_reordered_specifiers_are_accepted(self):
+        self.assertTrue(
+            sync.translation_is_safe('Copied %1$s of %2$s', 'Von %2$s wurden %1$s kopiert')
+        )
+
+    def test_empty_translation_is_rejected(self):
+        self.assertFalse(sync.translation_is_safe('Hello {username}', ''))
+        self.assertFalse(sync.translation_is_safe('Hello {username}', None))
+        self.assertFalse(sync.translation_is_safe('Save', '   '))
+
+    def test_empty_source_may_stay_empty(self):
+        """
+        Language files legitimately contain KEY="". Rejecting those would have
+        logged a spurious failure for every one — found by round-tripping all
+        4145 real en-GB strings, where this was the only reported problem.
+        """
+        self.assertTrue(sync.translation_is_safe('', ''))
+        self.assertTrue(sync.translation_is_safe('  ', ''))
+
+    def test_plain_string_with_no_protected_parts_is_accepted(self):
+        self.assertTrue(sync.translation_is_safe('Save', 'Speichern'))
+
+
+class RealWorldRegressionTest(unittest.TestCase):
+    """
+    Each of these shipped. The mask/unmask cycle must reproduce the source
+    exactly, so that a well-behaved engine returns something acceptable and a
+    misbehaving one is caught rather than written.
+    """
+
+    CASES = [
+        ACTION_LOG,
+        "User <a href='{accountlink}'>{username}</a> deleted {type} {title} ({origin})",
+        "<b><u>Embedded code:</u></b> Paste embed code. Use {mp3remote}-{/mp3remote}.",
+        'Plain text with no placeholders at all',
+        '{onlyplaceholder}',
+    ]
+
+    def test_all_round_trip(self):
+        for source in self.CASES:
+            with self.subTest(source=source[:40]):
+                masked, tokens = sync.mask_protected(source)
+                restored = sync.unmask_protected(masked, tokens)
+
+                self.assertEqual(source, restored)
+                self.assertTrue(sync.translation_is_safe(source, restored))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #43.

## The bug

`translate_text`/`translate_batch` posted the whole string to Google Translate with nothing protecting the parts that must not change. Joomla language values carry `{placeholder}` tokens, inline HTML and `%s`-style specifiers — all three were translated as ordinary words.

```
en-GB  User <a href='{accountlink}'>{username}</a> updated {type} ...
nl-NL  Gebruiker <a href='{accountlink}'>{gebruikersnaam}> heeft {type} ...
```

`{username}` became `{gebruikersnaam}`, which never matches the substitution Joomla performs when rendering each log row (`ActionlogsHelper:201`), so the literal token reaches the user. hu-HU lost a closing brace → the unmatchable `{username</a>`. cs-CZ closed anchors with `<a>`, which also survives the `str_replace('</a>', '')` Joomla uses to strip links from notification emails.

**21 strings across three languages shipped. All valid INI, all silently wrong** — there is no build step that would catch it.

## The fix

Two defences, and the second is the one that matters:

**Masking** — `mask_protected`/`unmask_protected` swap protected fragments for sentinels around the API call. Engines alter sentinel case and inject spaces, so recovery is deliberately loose, and tokens are restored highest-index-first so `ZQX1ZQX` isn't mistaken for part of `ZQX10ZQX`.

**Validation** — `translation_is_safe` compares placeholders and specifiers as sorted multisets, anchors by count. Reordering for grammar passes (Hungarian moves the username to the front); renaming, dropping, duplicating or unbalancing does not. **A rejected translation falls back to English**, which Joomla already handles per key — an untranslated string is strictly better than one whose placeholders no longer resolve.

Masking covers any `%<letter>`, not just what `sprintf` knows. Surveying Proclaim's real files turned up `%s`, `%d`, `%1$d`..`%4$d`, `%2$s`, `%%` and `%t` — the last filled in by the component, as in `"Migrating %d of %t files..."`. My first, narrower pattern left that string half-protected.

## Verified

- **25 tests**, each driven by corruption actually observed rather than invented
- **Every real string in Proclaim round-trips unchanged: 29,273 across 159 language files**
- That corpus run is also what caught a false rejection I'd introduced — empty values (`KEY=""`) are legitimate and were being reported as failures
- `composer test` now runs Python alongside PHPUnit: 247 PHP + 25 Python, green

Stdlib `unittest`, no new dependency. This is also a first foothold against #32, which notes `scripts/` has no coverage at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151X65uy1t64SDgxwq7mXmq