### PR TITLE
ci: run this repository's own tests on push and pull request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,110 @@
+name: Tests
+
+# Runs this repository's own test suite.
+#
+# joomla-package-ci.yml is a reusable workflow for *consuming* projects and
+# never runs here; docs.yml only builds the documentation site. So until this
+# existed, nothing verified this repo on push or pull request, and every PR
+# merged reporting "no checks reported" (see issue #46).
+#
+# That matters more here than in most repos: this package cuts the releases for
+# every CWM project, and its failure mode is quiet. A regression in release.sh
+# or ars-publish.sh does not throw — it publishes something wrong and reports
+# success.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # 8.3 is the composer.json floor; 8.4 is what the maintainers actually
+        # run day to day, and a release that only works on one of them should
+        # fail here rather than at a consumer.
+        php: ['8.3', '8.4']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: json, simplexml, zip
+          coverage: none
+          tools: composer:v2
+
+      - name: Set up Python
+        # scripts/sync-languages.py is tested by tests/python. Runners ship a
+        # Python, but pinning it keeps the Python half of `composer test` from
+        # depending on whatever the image happens to provide.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Cache Composer packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/composer
+          key: composer-${{ matrix.php }}-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-${{ matrix.php }}-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Run tests
+        # composer test runs PHPUnit and the Python suite.
+        run: composer test
+
+  lint:
+    name: Coding standards
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: json, simplexml, zip
+          coverage: none
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Check syntax of every PHP file
+        # Catches a parse error in scripts/, which has no unit coverage at all
+        # (issue #32) and is otherwise only exercised by running a release.
+        run: find src scripts tests -name '*.php' -print0 | xargs -0 -n1 -P4 php -l > /dev/null
+
+      - name: Check syntax of every shell script
+        # release.sh and ars-publish.sh are the release pipeline; a syntax error
+        # in either is discovered mid-release today.
+        # `rc`, not `status`: the latter is read-only in zsh, and this loop is
+        # the sort of thing someone pastes into a local shell to reproduce.
+        run: |
+          rc=0
+          for f in scripts/*.sh; do
+            bash -n "$f" || rc=1
+          done
+          exit $rc
+
+      - name: Check Python syntax
+        run: python3 -m py_compile scripts/*.py

--- a/tests/fixtures/installed/path-repo/sibling/CWMScriptureLinks/.gitkeep
+++ b/tests/fixtures/installed/path-repo/sibling/CWMScriptureLinks/.gitkeep
@@ -1,0 +1,8 @@
+InstalledPackageReaderTest::detects_path_repo_install_and_resolves_source_path
+resolves this directory with realpath() and compares the result to the reader's
+sourcePath. realpath() returns false for a path that does not exist, so without
+a tracked file here the directory is absent on a clean checkout and the test
+fails comparing a string to false.
+
+Git does not track empty directories. This file is what makes the fixture
+survive a clone — it has no other purpose and its contents are not read.


### PR DESCRIPTION
Closes #46.

## The problem

Nothing verified this repo. `docs.yml` builds the docs site; `joomla-package-ci.yml` is a reusable workflow **for consuming projects** and never runs here. So **247 PHPUnit tests and 25 Python tests never ran on push or PR**.

Every PR merged reported the same thing:

```
PR #44: no checks reported
PR #41: no checks reported
PR #39: no checks reported
```

Five PRs merged and three releases cut (v1.8.1–v1.8.3) on that basis.

## Why it matters more here than usual

This package cuts the releases for every CWM project, and it fails *quietly*. A regression in `release.sh` or `ars-publish.sh` doesn't throw — it publishes something wrong and reports success. All three bugs found on 2026-07-26 were exactly that shape:

- a lookup silently matching the wrong 20-row window → duplicate ARS releases (#37)
- staging untracked files into a commit the tag is then force-moved onto (#38)
- a translator renaming `{placeholder}` tokens → 21 broken strings shipped (#43)

Each now has a regression test. Those tests were worth nothing while nothing ran them.

## What this adds

**`test`** — `composer test` (PHPUnit + Python) on **PHP 8.3 and 8.4**. 8.3 is the `composer.json` floor; 8.4 is what the maintainers actually run. A release that works on only one should fail here, not at a consumer.

**`lint`** — syntax checks every PHP, shell and Python file. That's the only automated cover `scripts/` has until #32 lands, and a parse error in `release.sh` is currently discovered *mid-release*.

## Verified

Every step run locally first:

| Step | Result |
|---|---|
| `php -l` across `src scripts tests` | pass |
| `bash -n` across `scripts/*.sh` | pass |
| `py_compile scripts/*.py` | pass |
| `composer test` | 247 PHP + 25 Python, green |

No untrusted input reaches any `run:` — only `matrix.php` and `github.ref` in a concurrency key.

## Follow-up

Once this is green, consider making it a required check so "no checks reported" can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151X65uy1t64SDgxwq7mXmq