### PR TITLE
test(link): lift cwm-link's decisions into a testable class

### DIFF
--- a/scripts/link.php
+++ b/scripts/link.php
@@ -20,9 +20,10 @@ require_once __DIR__ . '/../src/Dev/InstallConfig.php';
 require_once __DIR__ . '/../src/Dev/PropertiesReader.php';
 require_once __DIR__ . '/../src/Dev/LinkResolver.php';
 require_once __DIR__ . '/../src/Dev/Linker.php';
+require_once __DIR__ . '/../src/Dev/LinkPlanner.php';
 
 use CWM\BuildTools\Config\InstalledPackageReader;
-use CWM\BuildTools\Dev\InstallConfig;
+use CWM\BuildTools\Dev\LinkPlanner;
 use CWM\BuildTools\Dev\LinkResolver;
 use CWM\BuildTools\Dev\Linker;
 use CWM\BuildTools\Dev\PropertiesReader;
@@ -95,7 +96,18 @@ if (!$reader->exists()) {
 // install target for the built zip — linking one points the site's extension
 // dirs back at the working repo, which puts that source in the blast radius of
 // any teardown that deletes extension dirs (cwm-clean, reset harnesses).
-$installs = $reader->installsFor(InstallConfig::ROLE_DEV);
+//
+// That choice lives in LinkPlanner rather than here because this is where it
+// was got wrong in v1.6.1, and nothing in scripts/ can be tested. See #32.
+$plan     = LinkPlanner::selectInstalls($reader);
+$installs = $plan['linkable'];
+
+// Surfaced rather than skipped silently: a stale path usually means a machine
+// that was never set up, and "linked 0 installs" with no reason reads as a tool
+// failure.
+foreach ($plan['missing'] as $absent) {
+    echo "WARNING: Path not found, skipping: {$absent->path}\n";
+}
 
 if ($installs === []) {
     fwrite(STDERR, "No role=dev Joomla install configured in build.properties.\n");
@@ -116,12 +128,6 @@ foreach ($resolver->internalLinks() as $pair) {
 $linkedInstalls = 0;
 
 foreach ($installs as $install) {
-    if (!is_dir($install->path)) {
-        echo "WARNING: Path not found, skipping: {$install->path}\n";
-
-        continue;
-    }
-
     echo "\nLinking against: {$install->path}\n";
 
     $selfLinks = $resolver->externalLinks($install->path);
@@ -136,27 +142,12 @@ foreach ($installs as $install) {
     $totalConflicts += applyLinks($linker, 'Self (' . ($config['extension']['name'] ?? 'this project') . ')', $selfLinks, $force, $verbose, null);
 
     if ($depLinks !== []) {
-        $byPackage = [];
-
-        foreach ($depLinks as $link) {
-            $byPackage[$link['package']][] = $link;
-        }
+        $byPackage = LinkPlanner::groupByPackage($depLinks);
 
         echo "\n  CWM dependencies (" . count($byPackage) . ")\n";
 
         foreach ($byPackage as $pkgName => $links) {
-            $package = null;
-
-            foreach ($cwmPackages as $p) {
-                if ($p->name === $pkgName) {
-                    $package = $p;
-                    break;
-                }
-            }
-
-            $tag = $package === null
-                ? ''
-                : " @ {$package->version} (" . ($package->isPathRepo ? 'path' : 'registry') . ')';
+            $tag = LinkPlanner::describePackage(LinkPlanner::findPackage($cwmPackages, $pkgName));
 
             echo "    {$pkgName}{$tag}\n";
 

--- a/src/Dev/LinkPlanner.php
+++ b/src/Dev/LinkPlanner.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Dev;
+
+use CWM\BuildTools\Config\CwmPackage;
+
+/**
+ * The decisions `cwm-link` makes, separated from the printing and the symlinking.
+ *
+ * Those decisions used to live in scripts/link.php, where nothing could reach
+ * them. That is how the v1.6.1 defect shipped: the script called
+ * `PropertiesReader::installs()` instead of `installsFor(ROLE_DEV)`, so
+ * `composer symlink` linked test installs as well as dev ones — pointing a
+ * file-backed test install's extension directories back at the working repo,
+ * and putting a consumer's source inside the blast radius of any teardown that
+ * deletes extension dirs.
+ *
+ * `installsFor()` itself was thoroughly covered. The bug was in the caller, and
+ * 214 tests passed for as long as it existed. Moving the choice here is what
+ * makes it assertable — see issue #32.
+ */
+final class LinkPlanner
+{
+    /**
+     * Split configured installs into the ones cwm-link should touch and the
+     * ones it must not.
+     *
+     * Role filtering happens here rather than at the call site precisely
+     * because it is the part that was wrong before. `role=test` installs are
+     * excluded by design, not by omission: they are real file-backed
+     * installations that the release harness wipes and reinstalls, so a symlink
+     * into the working repo means the harness deletes the repo's source.
+     *
+     * A configured path that does not exist is reported separately rather than
+     * dropped. It is usually a stale entry or a machine that has not been set
+     * up yet, and silence there reads as "nothing to do".
+     *
+     * @param   PropertiesReader  $reader  Reader for the consumer's build.properties.
+     *
+     * @return  array{linkable: list<InstallConfig>, missing: list<InstallConfig>}
+     */
+    public static function selectInstalls(PropertiesReader $reader): array
+    {
+        $linkable = [];
+        $missing  = [];
+
+        foreach ($reader->installsFor(InstallConfig::ROLE_DEV) as $install) {
+            if (is_dir($install->path)) {
+                $linkable[] = $install;
+
+                continue;
+            }
+
+            $missing[] = $install;
+        }
+
+        return ['linkable' => $linkable, 'missing' => $missing];
+    }
+
+    /**
+     * Group dependency links by the package that owns them.
+     *
+     * Preserves both the order packages first appear and the order of links
+     * within a package, so the script's output is stable between runs. Unstable
+     * ordering in a tool people read line by line is its own small bug.
+     *
+     * @param   list<array{package: string, source: string, target: string}>  $depLinks
+     *
+     * @return  array<string, list<array{package: string, source: string, target: string}>>
+     */
+    public static function groupByPackage(array $depLinks): array
+    {
+        $grouped = [];
+
+        foreach ($depLinks as $link) {
+            $grouped[$link['package']][] = $link;
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * Find a package by name among those installed.
+     *
+     * @param   list<CwmPackage>  $packages
+     */
+    public static function findPackage(array $packages, string $name): ?CwmPackage
+    {
+        foreach ($packages as $package) {
+            if ($package->name === $name) {
+                return $package;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The " @ version (path|registry)" suffix shown beside a dependency.
+     *
+     * Whether a package came from a path repository or the registry decides
+     * whether editing it locally has any effect, so it is worth stating in the
+     * output rather than leaving someone to wonder why their changes vanished.
+     *
+     * Returns an empty string for a package that is not installed, so the
+     * caller can concatenate unconditionally.
+     */
+    public static function describePackage(?CwmPackage $package): string
+    {
+        if ($package === null) {
+            return '';
+        }
+
+        return ' @ ' . $package->version . ' (' . ($package->isPathRepo ? 'path' : 'registry') . ')';
+    }
+}

--- a/tests/Dev/LinkPlannerTest.php
+++ b/tests/Dev/LinkPlannerTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Dev;
+
+use CWM\BuildTools\Config\CwmPackage;
+use CWM\BuildTools\Dev\LinkPlanner;
+use CWM\BuildTools\Dev\PropertiesReader;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The first of these reproduces the v1.6.1 defect that motivated issue #32:
+ * cwm-link linked every configured install rather than only `role=dev`, so a
+ * file-backed test install had its extension directories pointed back at the
+ * working repo — and the release harness, which wipes and reinstalls that
+ * install, would delete the repo's own source.
+ *
+ * `installsFor()` was well covered at the time. The bug was in the caller, and
+ * 214 tests passed throughout.
+ */
+class LinkPlannerTest extends TestCase
+{
+    private string $tmp;
+
+    protected function setUp(): void
+    {
+        $this->tmp = sys_get_temp_dir() . '/cwm-link-planner-' . bin2hex(random_bytes(6));
+        mkdir($this->tmp, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->tmp);
+    }
+
+    private function removeTree(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $entry;
+            is_dir($path) && !is_link($path) ? $this->removeTree($path) : @unlink($path);
+        }
+
+        @rmdir($dir);
+    }
+
+    /**
+     * Write a build.properties and return a reader for it.
+     */
+    private function reader(string $ini): PropertiesReader
+    {
+        $path = $this->tmp . '/build.properties';
+        file_put_contents($path, $ini);
+
+        return new PropertiesReader($path);
+    }
+
+    private function makeInstallDir(string $name): string
+    {
+        $path = $this->tmp . '/' . $name;
+        mkdir($path, 0o777, true);
+
+        return $path;
+    }
+
+    #[Test]
+    public function only_dev_installs_are_linkable(): void
+    {
+        $dev  = $this->makeInstallDir('j6-dev');
+        $test = $this->makeInstallDir('j6-test');
+
+        $reader = $this->reader(<<<INI
+            builder.j6dev.path={$dev}
+            builder.j6dev.role=dev
+            builder.j6test.path={$test}
+            builder.j6test.role=test
+            INI);
+
+        $plan = LinkPlanner::selectInstalls($reader);
+
+        $paths = array_map(static fn($i) => $i->path, $plan['linkable']);
+
+        self::assertSame([$dev], $paths, 'A role=test install must never be linked');
+    }
+
+    #[Test]
+    public function a_test_install_is_excluded_even_when_it_is_the_only_one(): void
+    {
+        $test = $this->makeInstallDir('j6-test');
+
+        $reader = $this->reader(<<<INI
+            builder.j6test.path={$test}
+            builder.j6test.role=test
+            INI);
+
+        $plan = LinkPlanner::selectInstalls($reader);
+
+        self::assertSame([], $plan['linkable']);
+        self::assertSame([], $plan['missing'], 'Excluded by role, not reported as missing');
+    }
+
+    #[Test]
+    public function every_dev_install_is_linkable(): void
+    {
+        $one = $this->makeInstallDir('j5-dev');
+        $two = $this->makeInstallDir('j6-dev');
+
+        $reader = $this->reader(<<<INI
+            builder.j5dev.path={$one}
+            builder.j5dev.role=dev
+            builder.j6dev.path={$two}
+            builder.j6dev.role=dev
+            INI);
+
+        $plan = LinkPlanner::selectInstalls($reader);
+
+        self::assertCount(2, $plan['linkable']);
+    }
+
+    /**
+     * A stale entry should be visible, not silently dropped — otherwise the
+     * script reports success having linked nothing.
+     */
+    #[Test]
+    public function a_configured_path_that_does_not_exist_is_reported_as_missing(): void
+    {
+        $real = $this->makeInstallDir('j6-dev');
+
+        $reader = $this->reader(<<<INI
+            builder.j6dev.path={$real}
+            builder.j6dev.role=dev
+            builder.gone.path={$this->tmp}/not-here
+            builder.gone.role=dev
+            INI);
+
+        $plan = LinkPlanner::selectInstalls($reader);
+
+        self::assertSame([$real], array_map(static fn($i) => $i->path, $plan['linkable']));
+        self::assertCount(1, $plan['missing']);
+        self::assertStringEndsWith('not-here', $plan['missing'][0]->path);
+    }
+
+    #[Test]
+    public function no_installs_at_all_yields_two_empty_lists(): void
+    {
+        $plan = LinkPlanner::selectInstalls($this->reader(''));
+
+        self::assertSame(['linkable' => [], 'missing' => []], $plan);
+    }
+
+    #[Test]
+    public function dependency_links_group_by_package(): void
+    {
+        $links = [
+            ['package' => 'cwm/scripture', 'source' => 'a', 'target' => 'A'],
+            ['package' => 'cwm/links', 'source' => 'b', 'target' => 'B'],
+            ['package' => 'cwm/scripture', 'source' => 'c', 'target' => 'C'],
+        ];
+
+        $grouped = LinkPlanner::groupByPackage($links);
+
+        self::assertSame(['cwm/scripture', 'cwm/links'], array_keys($grouped), 'First-seen order preserved');
+        self::assertCount(2, $grouped['cwm/scripture']);
+        self::assertSame(['a', 'c'], array_column($grouped['cwm/scripture'], 'source'), 'Link order preserved');
+    }
+
+    #[Test]
+    public function grouping_nothing_yields_nothing(): void
+    {
+        self::assertSame([], LinkPlanner::groupByPackage([]));
+    }
+
+    #[Test]
+    public function a_package_is_found_by_name(): void
+    {
+        $wanted = $this->package('cwm/scripture');
+        $others = [$this->package('cwm/links'), $wanted];
+
+        self::assertSame($wanted, LinkPlanner::findPackage($others, 'cwm/scripture'));
+        self::assertNull(LinkPlanner::findPackage($others, 'cwm/absent'));
+        self::assertNull(LinkPlanner::findPackage([], 'cwm/scripture'));
+    }
+
+    /**
+     * Path versus registry decides whether editing the dependency locally does
+     * anything, which is why it is surfaced at all.
+     */
+    #[Test]
+    public function a_path_repo_package_is_labelled_as_such(): void
+    {
+        $described = LinkPlanner::describePackage($this->package('cwm/scripture', '1.2.3', true));
+
+        self::assertSame(' @ 1.2.3 (path)', $described);
+    }
+
+    #[Test]
+    public function a_registry_package_is_labelled_as_such(): void
+    {
+        $described = LinkPlanner::describePackage($this->package('cwm/scripture', '1.2.3', false));
+
+        self::assertSame(' @ 1.2.3 (registry)', $described);
+    }
+
+    /**
+     * The caller concatenates the result unconditionally, so an uninstalled
+     * package must contribute nothing rather than "null" or " @  ()".
+     */
+    #[Test]
+    public function an_absent_package_describes_as_an_empty_string(): void
+    {
+        self::assertSame('', LinkPlanner::describePackage(null));
+    }
+
+    private function package(string $name, string $version = '1.0.0', bool $isPathRepo = false): CwmPackage
+    {
+        return new CwmPackage(
+            name: $name,
+            version: $version,
+            versionNormalized: $version . '.0',
+            joomlaLinks: [],
+            installPath: '/tmp/' . $name,
+            isPathRepo: $isPathRepo,
+            sourcePath: $isPathRepo ? '/tmp/src/' . $name : null,
+            reference: null,
+        );
+    }
+}


### PR DESCRIPTION
First step on #32.

## Why

`scripts/` has no coverage because the scripts execute on include. #32 recommends lifting decision-making into `src/` opportunistically, and `link.php` is the exemplar it names:

> v1.6.1 fixed exactly such a bug: `link.php` selected every configured install via `installs()` instead of filtering to `role=dev`, so `composer symlink` linked test installs too — putting a consumer's working repo in the blast radius of any teardown that deletes extension dirs.
>
> `installsFor()` was well covered. The defect was in the *caller*. **214 tests passed the whole time it was broken.**

## What moved

`Dev\LinkPlanner` now owns:

- **`selectInstalls()`** — the role filter, i.e. the thing that was wrong. Also separates configured-but-absent paths instead of skipping them mid-loop, since a stale entry previously produced "linked 0 installs" with no reason.
- **`groupByPackage()`**, **`findPackage()`**, **`describePackage()`** — small, but each untestable inside a script.

`link.php` keeps its printing and symlinking and got shorter.

## Verified three ways

**Negative control.** I reintroduced the v1.6.1 defect (`installsFor(ROLE_DEV)` → `installs()`) and confirmed two tests go red, then restored it:

```
1) LinkPlannerTest::only_dev_installs_are_linkable
2) LinkPlannerTest::a_test_install_is_excluded_even_when_it_is_the_only_one
FAILURES! Tests: 11, Failures: 2
```

**End to end.** Ran the modified script against Proclaim, whose `build.properties` includes a real `role=test` install:

- linked its 4 `role=dev` installs, 12 links each, all `ok` (idempotent)
- **j6-test's `com_proclaim` directories remain real directories, not symlinks**

**Suite.** 258 PHP tests + 25 Python, green.

Worth noting `php -l` passed on a version of `link.php` missing the `use` statement for the new class — syntax checking doesn't catch class resolution, which is why the end-to-end run matters.

## Remaining under #32

`sync-configs.php`, `install-zip.php`, `build.php`, `package.php`, `bump.php` and the rest. #32 suggests black-box tests for the few where end-to-end wiring is the actual contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151X65uy1t64SDgxwq7mXmq