### PR TITLE
test(bump): lift manifest version rewriting into a testable class

### DIFF
--- a/scripts/bump.php
+++ b/scripts/bump.php
@@ -28,6 +28,7 @@
  * @license GPL-2.0-or-later
  */
 
+require_once __DIR__ . '/../src/Build/ManifestVersionWriter.php';
 require_once __DIR__ . '/../src/Release/VersionTracker.php';
 require_once __DIR__ . '/../src/Config/ProfileResolver.php';
 
@@ -49,7 +50,7 @@ if (!$version) {
     exit(1);
 }
 
-if (!preg_match('/^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$/', $version)) {
+if (!CWM\BuildTools\Build\ManifestVersionWriter::isValidVersion($version)) {
     fwrite(STDERR, "Error: Version '$version' does not look like semver (e.g., 1.2.3 or 1.2.3-beta1)\n");
     exit(1);
 }
@@ -116,31 +117,10 @@ if ($only === null && $tracking !== null) {
  */
 function bumpManifest(string $path, string $version, string $date): void
 {
-    $content = file_get_contents($path);
-
-    if ($content === false) {
-        throw new RuntimeException("Could not read $path");
-    }
-
-    $original = $content;
-
-    $content = preg_replace(
-        '~<version>[^<]*</version>~',
-        '<version>' . $version . '</version>',
-        $content,
-        1
-    );
-
-    $content = preg_replace(
-        '~<creationDate>[^<]*</creationDate>~',
-        '<creationDate>' . $date . '</creationDate>',
-        $content,
-        1
-    );
-
-    if ($content !== $original) {
-        file_put_contents($path, $content);
-        echo "  $path → $version\n";
+    // The rewriting itself lives in ManifestVersionWriter so it can be tested;
+    // this keeps only the reporting. See issue #32.
+    if (CWM\BuildTools\Build\ManifestVersionWriter::rewriteFile($path, $version, $date)) {
+        echo "  $path \u{2192} $version\n";
     } else {
         echo "  $path (no change)\n";
     }

--- a/scripts/clean.php
+++ b/scripts/clean.php
@@ -77,6 +77,19 @@ foreach ($resolver->internalLinks() as $pair) {
     }
 }
 
+// installs(), not installsFor(ROLE_DEV) — deliberately wider than cwm-link.
+//
+// This reads like the v1.6.1 defect that PR #48 extracted out of link.php, and
+// it is not. Linking a role=test install is destructive: it points a real
+// install's extension directories back at the working repo, which the release
+// harness then deletes. Unlinking one is the cure, so cleaning has to be able
+// to reach installs that linking must never touch — including symlinks left
+// behind by the buggy version.
+//
+// Safe because Linker::unlink() returns false for anything that is not a
+// symlink, so a role=test install with real directories is a no-op. That guard
+// is load-bearing and covered by LinkerTest::unlink_returns_false_for_real_files;
+// anything that makes unlink() more aggressive has to reconsider this loop.
 foreach ($reader->installs() as $install) {
     if (!is_dir($install->path)) {
         continue;

--- a/src/Build/ManifestVersionWriter.php
+++ b/src/Build/ManifestVersionWriter.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Build;
+
+use RuntimeException;
+
+/**
+ * Rewrites the version and creation date in a Joomla extension manifest.
+ *
+ * Lifted out of scripts/bump.php so it can be tested — see issue #32. What this
+ * writes ends up in every shipped manifest, and a mistake is not noticed until
+ * a site refuses to update or updates to the wrong version, so it is a poor
+ * candidate for the "scripts are untestable" status quo.
+ *
+ * Deliberately string-based rather than DOM-based. Joomla manifests are hand-
+ * edited XML carrying comments, ordering and whitespace that maintainers care
+ * about, and a DOM round-trip reformats all three. Rewriting the two elements
+ * in place changes exactly what was asked for and leaves the rest byte-identical.
+ */
+final class ManifestVersionWriter
+{
+    /** Semver, optionally with a pre-release suffix: 1.2.3, 1.2.3-beta1. */
+    private const VERSION_PATTERN = '/^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$/';
+
+    /**
+     * Whether a string is acceptable as a release version.
+     *
+     * The bumper refuses anything else rather than writing it, because a
+     * malformed version reaches every manifest before anyone notices, and
+     * Joomla's update system compares versions rather than validating them.
+     */
+    public static function isValidVersion(string $version): bool
+    {
+        return preg_match(self::VERSION_PATTERN, $version) === 1;
+    }
+
+    /**
+     * Return the manifest content with version and creationDate rewritten.
+     *
+     * Only the first occurrence of each element is replaced. A Joomla manifest
+     * declares its own version once, near the top, and later matches would
+     * belong to something else — an update-server block, or a nested package
+     * child. Replacing all of them would silently rewrite those too.
+     *
+     * A null date leaves creationDate alone, for callers that want to bump a
+     * version without claiming the manifest was authored today.
+     *
+     * @return string The rewritten content; identical to the input when neither
+     *                element is present.
+     */
+    public static function rewrite(string $content, string $version, ?string $date = null): string
+    {
+        $content = preg_replace(
+            '~<version>[^<]*</version>~',
+            '<version>' . $version . '</version>',
+            $content,
+            1
+        ) ?? $content;
+
+        if ($date === null) {
+            return $content;
+        }
+
+        return preg_replace(
+            '~<creationDate>[^<]*</creationDate>~',
+            '<creationDate>' . $date . '</creationDate>',
+            $content,
+            1
+        ) ?? $content;
+    }
+
+    /**
+     * Rewrite a manifest on disk.
+     *
+     * Returns false when the content would be unchanged, so the caller can say
+     * "no change" rather than reporting a write that did not happen. An
+     * unreadable path throws: a manifest listed in the config but missing is a
+     * configuration error, and skipping it quietly would ship one extension at
+     * the old version.
+     *
+     * @throws RuntimeException When the file cannot be read or written.
+     */
+    public static function rewriteFile(string $path, string $version, ?string $date = null): bool
+    {
+        $original = @file_get_contents($path);
+
+        if ($original === false) {
+            throw new RuntimeException("Could not read $path");
+        }
+
+        $updated = self::rewrite($original, $version, $date);
+
+        if ($updated === $original) {
+            return false;
+        }
+
+        if (@file_put_contents($path, $updated) === false) {
+            throw new RuntimeException("Could not write $path");
+        }
+
+        return true;
+    }
+}

--- a/tests/Build/ManifestVersionWriterTest.php
+++ b/tests/Build/ManifestVersionWriterTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Build;
+
+use CWM\BuildTools\Build\ManifestVersionWriter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * What this class writes reaches every shipped manifest. A mistake surfaces as
+ * a site refusing to update, or updating to the wrong version — both a long way
+ * from the code that caused them. It lived in scripts/bump.php with no coverage
+ * at all until issue #32.
+ */
+class ManifestVersionWriterTest extends TestCase
+{
+    private string $tmp;
+
+    protected function setUp(): void
+    {
+        $this->tmp = sys_get_temp_dir() . '/cwm-manifest-writer-' . bin2hex(random_bytes(6));
+        mkdir($this->tmp, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->tmp . '/*') ?: [] as $f) {
+            @unlink($f);
+        }
+
+        @rmdir($this->tmp);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: bool}>
+     */
+    public static function versionProvider(): array
+    {
+        return [
+            'release'              => ['1.2.3', true],
+            'zero'                 => ['0.0.0', true],
+            'large'                => ['10.3.6', true],
+            'beta'                 => ['1.2.3-beta1', true],
+            'rc with dot'          => ['1.2.3-rc.2', true],
+            'alpha'                => ['2.0.0-alpha', true],
+            'two segments'         => ['1.2', false],
+            'four segments'        => ['1.2.3.4', false],
+            'leading v'            => ['v1.2.3', false],
+            'empty'                => ['', false],
+            'words'                => ['next', false],
+            'trailing hyphen'      => ['1.2.3-', false],
+            'space'                => ['1.2.3 ', false],
+            'dev suffix is a version, refused elsewhere' => ['1.2.3-dev', true],
+        ];
+    }
+
+    #[DataProvider('versionProvider')]
+    #[Test]
+    public function version_validation_matches_semver(string $version, bool $expected): void
+    {
+        self::assertSame($expected, ManifestVersionWriter::isValidVersion($version));
+    }
+
+    #[Test]
+    public function version_and_date_are_rewritten(): void
+    {
+        $xml = '<extension><version>1.0.0</version><creationDate>2020-01-01</creationDate></extension>';
+
+        $out = ManifestVersionWriter::rewrite($xml, '2.0.0', '2026-07-27');
+
+        self::assertStringContainsString('<version>2.0.0</version>', $out);
+        self::assertStringContainsString('<creationDate>2026-07-27</creationDate>', $out);
+    }
+
+    /**
+     * A manifest declares its own version once, near the top. Later matches
+     * belong to something else — an update-server block, or a package child —
+     * and rewriting those would corrupt them silently.
+     */
+    #[Test]
+    public function only_the_first_version_element_is_rewritten(): void
+    {
+        $xml = '<extension><version>1.0.0</version>'
+            . '<updateservers><server><version>9.9.9</version></server></updateservers></extension>';
+
+        $out = ManifestVersionWriter::rewrite($xml, '2.0.0');
+
+        self::assertStringContainsString('<version>2.0.0</version>', $out);
+        self::assertStringContainsString('<version>9.9.9</version>', $out, 'Nested version must survive');
+        self::assertSame(1, substr_count($out, '2.0.0'));
+    }
+
+    #[Test]
+    public function a_null_date_leaves_the_creation_date_alone(): void
+    {
+        $xml = '<extension><version>1.0.0</version><creationDate>2020-01-01</creationDate></extension>';
+
+        $out = ManifestVersionWriter::rewrite($xml, '2.0.0', null);
+
+        self::assertStringContainsString('<creationDate>2020-01-01</creationDate>', $out);
+    }
+
+    #[Test]
+    public function a_manifest_without_a_creation_date_is_still_bumped(): void
+    {
+        $out = ManifestVersionWriter::rewrite('<extension><version>1.0.0</version></extension>', '2.0.0', '2026-07-27');
+
+        self::assertStringContainsString('<version>2.0.0</version>', $out);
+        self::assertStringNotContainsString('creationDate', $out, 'Must not invent the element');
+    }
+
+    /**
+     * Manifests are hand-edited and carry comments, ordering and indentation
+     * that maintainers care about. Only the two elements should move.
+     */
+    #[Test]
+    public function surrounding_content_is_untouched(): void
+    {
+        $xml = <<<XML
+            <?xml version="1.0" encoding="utf-8"?>
+            <!-- deliberate comment -->
+            <extension type="component" method="upgrade">
+                <name>COM_EXAMPLE</name>
+                <version>1.0.0</version>
+                <author>Someone</author>
+            </extension>
+            XML;
+
+        $out = ManifestVersionWriter::rewrite($xml, '2.0.0');
+
+        self::assertSame(
+            str_replace('<version>1.0.0</version>', '<version>2.0.0</version>', $xml),
+            $out
+        );
+    }
+
+    #[Test]
+    public function content_without_either_element_comes_back_unchanged(): void
+    {
+        $xml = '<extension><name>COM_EXAMPLE</name></extension>';
+
+        self::assertSame($xml, ManifestVersionWriter::rewrite($xml, '2.0.0', '2026-07-27'));
+    }
+
+    #[Test]
+    public function rewriting_a_file_reports_whether_it_changed(): void
+    {
+        $path = $this->tmp . '/manifest.xml';
+        file_put_contents($path, '<extension><version>1.0.0</version></extension>');
+
+        self::assertTrue(ManifestVersionWriter::rewriteFile($path, '2.0.0'));
+        self::assertStringContainsString('<version>2.0.0</version>', file_get_contents($path));
+
+        // Same version again: nothing to write, and the caller should be able
+        // to say "no change" rather than claiming a write.
+        self::assertFalse(ManifestVersionWriter::rewriteFile($path, '2.0.0'));
+    }
+
+    /**
+     * A manifest listed in the config but absent is a configuration error.
+     * Skipping it quietly would ship one extension still on the old version.
+     */
+    #[Test]
+    public function an_unreadable_manifest_throws(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not read');
+
+        ManifestVersionWriter::rewriteFile($this->tmp . '/does-not-exist.xml', '2.0.0');
+    }
+
+    /**
+     * The real shape, taken from Proclaim's package manifest.
+     */
+    #[Test]
+    public function a_realistic_package_manifest_bumps_correctly(): void
+    {
+        $xml = <<<XML
+            <?xml version="1.0" encoding="utf-8"?>
+            <extension type="package" method="upgrade">
+                <name>Proclaim</name>
+                <version>10.3.5</version>
+                <creationDate>2026-07-01</creationDate>
+                <updateservers>
+                    <server type="extension" priority="1" name="Proclaim">https://example.org/update.xml</server>
+                </updateservers>
+            </extension>
+            XML;
+
+        $out = ManifestVersionWriter::rewrite($xml, '10.3.6', '2026-07-27');
+
+        self::assertStringContainsString('<version>10.3.6</version>', $out);
+        self::assertStringContainsString('<creationDate>2026-07-27</creationDate>', $out);
+        self::assertStringContainsString('https://example.org/update.xml', $out);
+    }
+}


### PR DESCRIPTION
Second step on #32, after #48.

## Why bump.php next

What it writes reaches **every shipped manifest**, and a mistake surfaces as a site refusing to update or updating to the wrong version — a long way from the code that caused it. It had no coverage at all.

## What moved

`Build\ManifestVersionWriter` owns the semver check and the rewriting; `bump.php` keeps the reporting.

Kept string-based rather than moving to DOM deliberately: Joomla manifests are hand-edited XML carrying comments, element ordering and indentation that maintainers care about, and a DOM round-trip reformats all three.

## The behaviour most worth pinning

**Only the first `<version>` is rewritten.** A manifest declares its own version once near the top; later matches belong to an update-server block or a package child, and replacing those would corrupt them silently.

No Proclaim manifest currently has a second `<version>` — which is precisely why this needed a test rather than being left to chance. The next person to add an `<updateservers>` block with a version in it shouldn't discover this the hard way.

## Verified end to end, not just by unit test

Ran the modified `bump.php` against a throwaway project:

| | |
|---|---|
| `<version>` | 1.0.0 → 2.5.0 |
| `<creationDate>` | updated |
| **nested `<version>9.9.9</version>`** | **survived** |
| comment and indentation | untouched |
| invalid version | still rejected |
| re-running same version | still reports "no change" |

281 PHP tests + 25 Python, green.

## Also in here: a comment on clean.php

`clean.php` uses `installs()`, not `installsFor(ROLE_DEV)`. That reads exactly like the v1.6.1 defect #48 just extracted from `link.php`, and **it's the opposite** — linking a `role=test` install is the damage, so unlinking one is the cure. Clean has to reach installs that link must never touch, including symlinks left behind by the buggy version.

Safe because `Linker::unlink()` returns false for anything that isn't a symlink — a guard that is load-bearing and covered by `LinkerTest`. Documented so the next reader doesn't "fix" it into a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151X65uy1t64SDgxwq7mXmq