### PR TITLE
test(sync-configs): cover the .gitignore block and path derivation

### DIFF
--- a/scripts/sync-configs.php
+++ b/scripts/sync-configs.php
@@ -26,6 +26,8 @@
 
 require_once __DIR__ . '/../src/Config/ProfileResolver.php';
 require_once __DIR__ . '/../src/Config/DistPropertiesInspector.php';
+require_once __DIR__ . '/../src/Config/GitignorePaths.php';
+require_once __DIR__ . '/../src/Config/ManagedBlock.php';
 
 $projectRoot = getcwd();
 $toolsRoot   = realpath(__DIR__ . '/..');
@@ -59,8 +61,8 @@ function syncGitignore(string $projectRoot, string $templates, array $config, bo
     $managedBlock   = file_get_contents($templates . '/gitignore-managed.txt') ?: '';
     $extensionBlock = renderExtensionPathsBlock($config);
 
-    $newContent = upsertBlock($existing, 'managed',         $managedBlock);
-    $newContent = upsertBlock($newContent, 'extension paths', $extensionBlock);
+    $newContent = \CWM\BuildTools\Config\ManagedBlock::upsert($existing, 'managed', $managedBlock);
+    $newContent = \CWM\BuildTools\Config\ManagedBlock::upsert($newContent, 'extension paths', $extensionBlock);
 
     if ($newContent === $existing) {
         echo ".gitignore: up to date\n";
@@ -107,11 +109,11 @@ function renderExtensionPathsBlock(array $config): string
 
     $lines = [];
 
-    foreach (resolveOutputPaths($config) as $path) {
+    foreach (\CWM\BuildTools\Config\GitignorePaths::outputPaths($config) as $path) {
         $lines[] = $path;
     }
 
-    foreach (resolveMediaPaths($config, (string) $name, (string) $type) as $path) {
+    foreach (\CWM\BuildTools\Config\GitignorePaths::mediaPaths($config, (string) $name, (string) $type) as $path) {
         $lines[] = $path;
     }
 
@@ -120,60 +122,6 @@ function renderExtensionPathsBlock(array $config): string
     }
 
     return implode("\n", $lines) . "\n";
-}
-
-/**
- * @return list<string>
- */
-function resolveOutputPaths(array $config): array
-{
-    $explicit = $config['gitignore']['outputPaths'] ?? null;
-
-    if (is_array($explicit)) {
-        return array_values(array_map('strval', $explicit));
-    }
-
-    $glob = (string) ($config['build']['outputGlob'] ?? '');
-
-    if ($glob === '') {
-        return ['/build/dist/'];
-    }
-
-    $dir = trim(\dirname($glob), '/.');
-
-    if ($dir === '') {
-        return ['/build/dist/'];
-    }
-
-    return ['/' . $dir . '/'];
-}
-
-/**
- * @return list<string>
- */
-function resolveMediaPaths(array $config, string $name, string $type): array
-{
-    $explicit = $config['gitignore']['mediaPaths'] ?? null;
-
-    if (is_array($explicit)) {
-        return array_values(array_map('strval', $explicit));
-    }
-
-    // Auto-derive only for the extension types whose name maps cleanly to a
-    // single /media/<x>/ directory by Joomla convention. Packages own no
-    // media dir of their own, plugins/modules don't have a generic one.
-    if (!\in_array($type, ['library', 'component'], true)) {
-        return [];
-    }
-
-    $stripped = preg_replace('/^(lib_|com_)/', '', $name);
-
-    return [
-        "/media/{$stripped}/js/*.min.js",
-        "/media/{$stripped}/js/*.min.js.map",
-        "/media/{$stripped}/css/*.min.css",
-        "/media/{$stripped}/css/*.min.css.map",
-    ];
 }
 
 /**
@@ -382,36 +330,6 @@ function vendorDirFromComposer(string $projectRoot): string
     $dir = (string) ($data['config']['vendor-dir'] ?? 'vendor');
 
     return trim($dir, '/') ?: 'vendor';
-}
-
-/**
- * Insert or replace a marker-delimited block in $content. Lines outside
- * the markers are preserved verbatim.
- */
-function upsertBlock(string $content, string $blockId, string $blockBody): string
-{
-    $startMarker = "# === cwm-build-tools: {$blockId} (do not edit between markers) ===";
-    $endMarker   = "# === cwm-build-tools: end {$blockId} ===";
-
-    $blockBody = trim($blockBody, "\n");
-
-    // Block has no content for this project — strip if present.
-    if (trim($blockBody) === '') {
-        $pattern = '/' . preg_quote($startMarker, '/') . '.*?' . preg_quote($endMarker, '/') . "\n?/s";
-
-        return preg_replace($pattern, '', $content) ?? $content;
-    }
-
-    $newBlock = "{$startMarker}\n{$blockBody}\n{$endMarker}\n";
-
-    if (str_contains($content, $startMarker)) {
-        $pattern = '/' . preg_quote($startMarker, '/') . '.*?' . preg_quote($endMarker, '/') . "\n?/s";
-
-        return preg_replace($pattern, $newBlock, $content) ?? $content;
-    }
-
-    // Append, preserving trailing newline behavior
-    return rtrim($content, "\n") . "\n\n" . $newBlock;
 }
 
 /**

--- a/src/Config/GitignorePaths.php
+++ b/src/Config/GitignorePaths.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Config;
+
+/**
+ * Derives the generated-file paths `cwm-sync-configs` writes into a consumer's
+ * .gitignore.
+ *
+ * Extracted from scripts/sync-configs.php for #32. Getting these wrong is
+ * quiet in both directions: too narrow and build output gets committed, too
+ * broad and hand-written files stop being tracked. Proclaim has already been
+ * bitten by the neighbouring `OUTPUT_DIR` mismatch — built assets landing
+ * somewhere the site did not read from, which presents as stale files rather
+ * than an error.
+ */
+final class GitignorePaths
+{
+    /**
+     * Where the build writes its artifacts.
+     *
+     * Derived from `build.outputGlob` by taking its directory, because that is
+     * already declared and a second setting would be a second thing to keep in
+     * step. `gitignore.outputPaths` overrides it for projects whose output does
+     * not sit in one place.
+     *
+     * @param   array<string, mixed>  $config
+     *
+     * @return  list<string>
+     */
+    public static function outputPaths(array $config): array
+    {
+        $explicit = $config['gitignore']['outputPaths'] ?? null;
+
+        if (is_array($explicit)) {
+            return array_values(array_map('strval', $explicit));
+        }
+
+        $glob = (string) ($config['build']['outputGlob'] ?? '');
+
+        if ($glob === '') {
+            return ['/build/dist/'];
+        }
+
+        $dir = trim(\dirname($glob), '/.');
+
+        return $dir === '' ? ['/build/dist/'] : ['/' . $dir . '/'];
+    }
+
+    /**
+     * Minified media output, ignored so built assets are not committed.
+     *
+     * Auto-derivation is limited to libraries and components, the two types
+     * whose name maps cleanly onto a single `/media/<x>/` directory by Joomla
+     * convention. A package owns no media directory of its own, and plugins and
+     * modules have no generic one, so guessing for those would ignore paths
+     * that do not exist — or worse, paths that do and are hand-written.
+     *
+     * That conservatism has a real cost worth knowing about: `pkg_proclaim` is
+     * a package wrapper around a component that *does* own /media/, so it must
+     * set `gitignore.mediaPaths` explicitly. The override exists precisely
+     * because the default declines to guess.
+     *
+     * @param   array<string, mixed>  $config
+     * @param   string                $name    Extension name, e.g. com_example.
+     * @param   string                $type    Extension type from the config.
+     *
+     * @return  list<string>
+     */
+    public static function mediaPaths(array $config, string $name, string $type): array
+    {
+        $explicit = $config['gitignore']['mediaPaths'] ?? null;
+
+        if (is_array($explicit)) {
+            return array_values(array_map('strval', $explicit));
+        }
+
+        if (!\in_array($type, ['library', 'component'], true)) {
+            return [];
+        }
+
+        $stripped = preg_replace('/^(lib_|com_)/', '', $name) ?? $name;
+
+        return [
+            "/media/{$stripped}/js/*.min.js",
+            "/media/{$stripped}/js/*.min.js.map",
+            "/media/{$stripped}/css/*.min.css",
+            "/media/{$stripped}/css/*.min.css.map",
+        ];
+    }
+}

--- a/src/Config/ManagedBlock.php
+++ b/src/Config/ManagedBlock.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Config;
+
+/**
+ * Insert, replace or remove a marker-delimited block inside a hand-edited file.
+ *
+ * `cwm-sync-configs` maintains sections of a consumer's `.gitignore` while
+ * leaving everything the consumer wrote alone. The contract is the pair of
+ * marker comments: what sits between them belongs to the tool, and everything
+ * outside them is none of its business.
+ *
+ * Extracted from scripts/sync-configs.php for #32. This rewrites a file the
+ * consumer owns and has edited, so the failure modes are losing their content
+ * or accumulating duplicate blocks on every sync — neither loud, both bad, and
+ * neither previously covered by a test.
+ */
+final class ManagedBlock
+{
+    public static function startMarker(string $blockId): string
+    {
+        return "# === cwm-build-tools: {$blockId} (do not edit between markers) ===";
+    }
+
+    public static function endMarker(string $blockId): string
+    {
+        return "# === cwm-build-tools: end {$blockId} ===";
+    }
+
+    /**
+     * Return $content with the named block set to $blockBody.
+     *
+     * Three cases, each of which has to be right or a consumer's file drifts:
+     *
+     *   - **Body is empty.** The block no longer applies to this project, so an
+     *     existing one is removed rather than left as an empty pair of markers
+     *     that looks like a bug.
+     *   - **Block already present.** Replaced in place, preserving its position
+     *     in the file — moving it to the end on every sync would produce a diff
+     *     each time and train people to ignore them.
+     *   - **Block absent.** Appended, separated by a blank line.
+     *
+     * Markers are matched literally via preg_quote, so a block id containing
+     * regex metacharacters cannot turn the search into a wildcard that eats the
+     * rest of the file.
+     */
+    public static function upsert(string $content, string $blockId, string $blockBody): string
+    {
+        $startMarker = self::startMarker($blockId);
+        $endMarker   = self::endMarker($blockId);
+        $blockBody   = trim($blockBody, "\n");
+
+        $pattern = '/' . preg_quote($startMarker, '/') . '.*?' . preg_quote($endMarker, '/') . "\n?/s";
+
+        if (trim($blockBody) === '') {
+            return preg_replace($pattern, '', $content) ?? $content;
+        }
+
+        $newBlock = "{$startMarker}\n{$blockBody}\n{$endMarker}\n";
+
+        if (str_contains($content, $startMarker)) {
+            return preg_replace($pattern, $newBlock, $content) ?? $content;
+        }
+
+        return rtrim($content, "\n") . "\n\n" . $newBlock;
+    }
+
+    /**
+     * Whether the named block is present in $content.
+     */
+    public static function has(string $content, string $blockId): bool
+    {
+        return str_contains($content, self::startMarker($blockId));
+    }
+}

--- a/tests/Config/GitignorePathsTest.php
+++ b/tests/Config/GitignorePathsTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Config;
+
+use CWM\BuildTools\Config\GitignorePaths;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Getting these wrong is quiet in both directions: too narrow and build output
+ * is committed, too broad and hand-written files silently stop being tracked.
+ */
+class GitignorePathsTest extends TestCase
+{
+    #[Test]
+    public function output_path_is_derived_from_the_build_glob(): void
+    {
+        $config = ['build' => ['outputGlob' => 'build/dist/pkg_example-*.zip']];
+
+        self::assertSame(['/build/dist/'], GitignorePaths::outputPaths($config));
+    }
+
+    #[Test]
+    public function a_nested_output_glob_keeps_its_full_directory(): void
+    {
+        $config = ['build' => ['outputGlob' => 'dist/packages/out/*.zip']];
+
+        self::assertSame(['/dist/packages/out/'], GitignorePaths::outputPaths($config));
+    }
+
+    #[Test]
+    public function a_missing_glob_falls_back_to_the_conventional_directory(): void
+    {
+        self::assertSame(['/build/dist/'], GitignorePaths::outputPaths([]));
+        self::assertSame(['/build/dist/'], GitignorePaths::outputPaths(['build' => ['outputGlob' => '']]));
+    }
+
+    /**
+     * A glob with no directory part would otherwise derive '/' and ignore the
+     * entire repository.
+     */
+    #[Test]
+    public function a_bare_glob_falls_back_rather_than_ignoring_everything(): void
+    {
+        self::assertSame(['/build/dist/'], GitignorePaths::outputPaths(['build' => ['outputGlob' => '*.zip']]));
+        self::assertSame(['/build/dist/'], GitignorePaths::outputPaths(['build' => ['outputGlob' => './*.zip']]));
+    }
+
+    #[Test]
+    public function an_explicit_output_override_wins(): void
+    {
+        $config = [
+            'build'     => ['outputGlob' => 'build/dist/*.zip'],
+            'gitignore' => ['outputPaths' => ['/out/', '/other/']],
+        ];
+
+        self::assertSame(['/out/', '/other/'], GitignorePaths::outputPaths($config));
+    }
+
+    #[Test]
+    public function an_explicit_empty_override_means_no_output_paths(): void
+    {
+        $config = [
+            'build'     => ['outputGlob' => 'build/dist/*.zip'],
+            'gitignore' => ['outputPaths' => []],
+        ];
+
+        self::assertSame([], GitignorePaths::outputPaths($config), 'An empty list is a choice, not absence');
+    }
+
+    #[Test]
+    public function a_component_derives_media_paths_from_its_stripped_name(): void
+    {
+        $paths = GitignorePaths::mediaPaths([], 'com_example', 'component');
+
+        self::assertSame([
+            '/media/example/js/*.min.js',
+            '/media/example/js/*.min.js.map',
+            '/media/example/css/*.min.css',
+            '/media/example/css/*.min.css.map',
+        ], $paths);
+    }
+
+    #[Test]
+    public function a_library_strips_its_prefix_too(): void
+    {
+        $paths = GitignorePaths::mediaPaths([], 'lib_cwmscripture', 'library');
+
+        self::assertStringStartsWith('/media/cwmscripture/', $paths[0]);
+    }
+
+    /**
+     * A package owns no media directory of its own, and plugins and modules
+     * have no generic one, so guessing would ignore paths that either do not
+     * exist or are hand-written.
+     */
+    #[Test]
+    public function types_without_a_conventional_media_dir_derive_nothing(): void
+    {
+        foreach (['package', 'plugin', 'module', 'template', ''] as $type) {
+            self::assertSame([], GitignorePaths::mediaPaths([], 'pkg_example', $type), "type: {$type}");
+        }
+    }
+
+    /**
+     * pkg_proclaim is a package wrapper around a component that *does* own
+     * /media/, so it sets mediaPaths explicitly. The override exists precisely
+     * because the default declines to guess for packages.
+     */
+    #[Test]
+    public function an_explicit_media_override_applies_even_to_a_package(): void
+    {
+        $config = ['gitignore' => ['mediaPaths' => ['/media/js/', '/media/css/']]];
+
+        self::assertSame(['/media/js/', '/media/css/'], GitignorePaths::mediaPaths($config, 'pkg_proclaim', 'package'));
+    }
+
+    #[Test]
+    public function an_unprefixed_name_is_used_as_is(): void
+    {
+        $paths = GitignorePaths::mediaPaths([], 'example', 'component');
+
+        self::assertStringStartsWith('/media/example/', $paths[0]);
+    }
+
+    /**
+     * Values from JSON arrive as whatever the author typed; the block is built
+     * by string concatenation, so they must come back as strings.
+     */
+    #[Test]
+    public function override_values_are_coerced_to_strings(): void
+    {
+        $config = ['gitignore' => ['outputPaths' => [123, '/ok/']]];
+
+        self::assertSame(['123', '/ok/'], GitignorePaths::outputPaths($config));
+    }
+
+    /**
+     * An override given as an object rather than a list must not produce
+     * string keys in the rendered block.
+     */
+    #[Test]
+    public function override_keys_are_discarded(): void
+    {
+        $config = ['gitignore' => ['outputPaths' => ['a' => '/one/', 'b' => '/two/']]];
+
+        self::assertSame(['/one/', '/two/'], GitignorePaths::outputPaths($config));
+    }
+}

--- a/tests/Config/ManagedBlockTest.php
+++ b/tests/Config/ManagedBlockTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Config;
+
+use CWM\BuildTools\Config\ManagedBlock;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This rewrites a consumer's .gitignore — a file they own and have edited. The
+ * failure modes are losing their content or appending a duplicate block on
+ * every sync. Neither is loud, and neither was covered before #32.
+ */
+class ManagedBlockTest extends TestCase
+{
+    private const ID = 'managed';
+
+    private function wrapped(string $body, string $id = self::ID): string
+    {
+        return ManagedBlock::startMarker($id) . "\n" . $body . "\n" . ManagedBlock::endMarker($id) . "\n";
+    }
+
+    #[Test]
+    public function a_block_is_appended_when_absent(): void
+    {
+        $out = ManagedBlock::upsert("/vendor/\n/node_modules/\n", self::ID, "/build/dist/");
+
+        self::assertStringContainsString('/vendor/', $out, "The consumer's own entries survive");
+        self::assertStringContainsString('/node_modules/', $out);
+        self::assertStringContainsString($this->wrapped('/build/dist/'), $out);
+    }
+
+    #[Test]
+    public function an_existing_block_is_replaced_not_duplicated(): void
+    {
+        $first  = ManagedBlock::upsert("/vendor/\n", self::ID, '/build/dist/');
+        $second = ManagedBlock::upsert($first, self::ID, '/build/out/');
+
+        self::assertSame(1, substr_count($second, ManagedBlock::startMarker(self::ID)));
+        self::assertStringContainsString('/build/out/', $second);
+        self::assertStringNotContainsString('/build/dist/', $second);
+    }
+
+    /**
+     * Syncing twice with the same body must not change the file, or every sync
+     * produces a diff and people stop reading them.
+     */
+    #[Test]
+    public function upserting_the_same_body_twice_is_idempotent(): void
+    {
+        $once  = ManagedBlock::upsert("/vendor/\n", self::ID, '/build/dist/');
+        $twice = ManagedBlock::upsert($once, self::ID, '/build/dist/');
+
+        self::assertSame($once, $twice);
+    }
+
+    /**
+     * The block must be replaced where it stands. Moving it to the end on each
+     * sync would produce a spurious diff every time.
+     */
+    #[Test]
+    public function a_replaced_block_keeps_its_position(): void
+    {
+        $content = "# top\n" . $this->wrapped('/old/') . "\n# bottom\n";
+
+        $out = ManagedBlock::upsert($content, self::ID, '/new/');
+
+        self::assertLessThan(
+            strpos($out, '# bottom'),
+            strpos($out, '/new/'),
+            'Block should stay above the trailing content'
+        );
+        self::assertStringContainsString('# top', $out);
+        self::assertStringContainsString('# bottom', $out);
+    }
+
+    #[Test]
+    public function an_empty_body_removes_an_existing_block(): void
+    {
+        $content = ManagedBlock::upsert("/vendor/\n", self::ID, '/build/dist/');
+
+        $out = ManagedBlock::upsert($content, self::ID, '');
+
+        self::assertStringNotContainsString(ManagedBlock::startMarker(self::ID), $out);
+        self::assertStringNotContainsString('/build/dist/', $out);
+        self::assertStringContainsString('/vendor/', $out, "The consumer's entries must survive removal");
+    }
+
+    #[Test]
+    public function an_empty_body_on_content_with_no_block_changes_nothing(): void
+    {
+        self::assertSame('/vendor/', ManagedBlock::upsert('/vendor/', self::ID, ''));
+    }
+
+    /**
+     * Two blocks are maintained in .gitignore — 'managed' and 'extension
+     * paths'. Editing one must not disturb the other.
+     */
+    #[Test]
+    public function blocks_with_different_ids_do_not_interfere(): void
+    {
+        $out = ManagedBlock::upsert("/vendor/\n", 'managed', '/build/dist/');
+        $out = ManagedBlock::upsert($out, 'extension paths', '/media/foo/');
+
+        self::assertTrue(ManagedBlock::has($out, 'managed'));
+        self::assertTrue(ManagedBlock::has($out, 'extension paths'));
+
+        $out = ManagedBlock::upsert($out, 'managed', '/build/other/');
+
+        self::assertStringContainsString('/media/foo/', $out, 'The other block must be untouched');
+        self::assertStringContainsString('/build/other/', $out);
+    }
+
+    /**
+     * Removing one of two adjacent blocks must not swallow the other. The
+     * pattern is non-greedy, which is what makes this work — a greedy one would
+     * match from the first start marker to the last end marker.
+     */
+    #[Test]
+    public function removing_one_of_two_adjacent_blocks_leaves_the_other(): void
+    {
+        $out = ManagedBlock::upsert('', 'managed', '/a/');
+        $out = ManagedBlock::upsert($out, 'extension paths', '/b/');
+
+        $out = ManagedBlock::upsert($out, 'managed', '');
+
+        self::assertFalse(ManagedBlock::has($out, 'managed'));
+        self::assertTrue(ManagedBlock::has($out, 'extension paths'));
+        self::assertStringContainsString('/b/', $out);
+    }
+
+    /**
+     * A block id is interpolated into a regex. preg_quote is what stops one
+     * containing metacharacters from turning the search into a wildcard.
+     */
+    #[Test]
+    public function a_block_id_containing_regex_metacharacters_is_matched_literally(): void
+    {
+        $id = 'weird.id(*)';
+
+        $out = ManagedBlock::upsert("/vendor/\n", $id, '/x/');
+        $out = ManagedBlock::upsert($out, $id, '/y/');
+
+        self::assertSame(1, substr_count($out, ManagedBlock::startMarker($id)));
+        self::assertStringContainsString('/y/', $out);
+        self::assertStringContainsString('/vendor/', $out);
+    }
+
+    #[Test]
+    public function a_multi_line_body_round_trips(): void
+    {
+        $body = "/build/dist/\n/media/js/\n/media/css/";
+
+        $out = ManagedBlock::upsert('', self::ID, $body);
+
+        self::assertStringContainsString($body, $out);
+
+        // And replacing it with a shorter body leaves no remnant of the longer.
+        $shorter = ManagedBlock::upsert($out, self::ID, '/build/dist/');
+
+        self::assertStringNotContainsString('/media/css/', $shorter);
+    }
+
+    #[Test]
+    public function surrounding_blank_lines_do_not_accumulate(): void
+    {
+        $out = "/vendor/\n";
+
+        for ($i = 0; $i < 5; $i++) {
+            $out = ManagedBlock::upsert($out, self::ID, '/build/dist/');
+        }
+
+        self::assertStringNotContainsString("\n\n\n", $out, 'Repeated syncs must not add blank lines');
+    }
+
+    #[Test]
+    public function has_reports_presence_accurately(): void
+    {
+        self::assertFalse(ManagedBlock::has('/vendor/', self::ID));
+        self::assertTrue(ManagedBlock::has(ManagedBlock::upsert('', self::ID, '/x/'), self::ID));
+    }
+}


### PR DESCRIPTION
Third step on #32, after #48 (`link.php`) and #49 (`bump.php`).

## Why this one

`sync-configs` **rewrites a file the consumer owns and has edited**. Failure modes: losing their content, or appending a duplicate managed block on every sync. Neither is loud. Neither was covered.

## What moved

**`Config\ManagedBlock`** — marker-delimited insert / replace / remove. The load-bearing tests:

- **replaces in place**, rather than moving the block to the end — otherwise every sync produces a diff and people stop reading them
- **removing one of two adjacent blocks leaves the other** — only works because the pattern is non-greedy
- **block ids are matched literally** via `preg_quote`, so one containing regex metacharacters can't turn the search into a wildcard that eats the rest of the file

**`Config\GitignorePaths`** — the derivations. Two cases worth naming:

- a bare glob like `*.zip` must fall back, not derive `/` and **ignore the entire repository**
- auto-derivation stays limited to libraries and components. That's why `pkg_proclaim` — a package wrapper around a component that *does* own `/media/` — has to set `gitignore.mediaPaths` explicitly. The override exists because the default declines to guess, and the test now records that rather than leaving it as folklore.

## Verified end to end

Against a throwaway project:

| | |
|---|---|
| consumer's own rules | preserved |
| both managed blocks | written |
| output path | `/build/dist/` derived from the glob |
| media paths | `/media/example/` derived from `com_example` |
| **two further runs** | **byte-identical** |

306 PHP tests + 25 Python, green. (247 before CI existed.)

## Remaining under #32

`install-zip.php`, `package.php`, `build.php`, `verify.php`, and `setup.php` — the last being 490 lines and interactive, so likely the black-box approach the issue suggests rather than extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151X65uy1t64SDgxwq7mXmq