### PR TITLE
fix(release): select the artifact by version, not by glob order

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -168,15 +168,57 @@ if [ -z "$OUTPUT_GLOB" ]; then
     exit 1
 fi
 
-# Resolve glob — should match exactly one file
+# Resolve the artifact for *this* version.
+#
+# The glob is deliberately version-agnostic (pkg_x-*.zip), so anything left in
+# the output directory matches it too — a baseline downloaded by the upgrade
+# harness, or simply the previous release. Taking ARTIFACTS[0] from an
+# unsorted glob therefore picks whatever sorts first, and bash sorts
+# lexically: releasing 10.3.3 alongside a stale 10.3.2 selects the 10.3.2 zip.
+#
+# That is not hypothetical. Proclaim 10.3.3 shipped pkg_proclaim-10.3.2.zip as
+# its GitHub asset and its ARS item, and the standing mitigation has been to
+# remember to clear build/dist first. A manual step is a poor guard for a
+# failure this quiet — the wrong file uploads and everything reports success.
+#
+# Lexical order is wrong for versions anyway: 10.3.10 sorts before 10.3.2.
+#
+# So match on the version being released rather than on ordering, and refuse to
+# guess when the answer is not unambiguous.
 shopt -s nullglob
-ARTIFACTS=( $OUTPUT_GLOB )
+ALL_ARTIFACTS=( $OUTPUT_GLOB )
 shopt -u nullglob
 
-if [ "${#ARTIFACTS[@]}" -eq 0 ]; then
+if [ "${#ALL_ARTIFACTS[@]}" -eq 0 ]; then
     echo "Error: No build artifact matched $OUTPUT_GLOB"
     exit 1
 fi
+
+ARTIFACTS=()
+for artifact in "${ALL_ARTIFACTS[@]}"; do
+    case "$(basename "$artifact")" in
+        *"-${VERSION}".zip) ARTIFACTS+=( "$artifact" ) ;;
+    esac
+done
+
+if [ "${#ARTIFACTS[@]}" -eq 0 ]; then
+    echo "Error: No build artifact for version ${VERSION} matched $OUTPUT_GLOB"
+    echo "       Found instead:"
+    printf '         %s\n' "${ALL_ARTIFACTS[@]}"
+    echo "       The build step should have produced a file named *-${VERSION}.zip."
+    exit 1
+fi
+
+if [ "${#ARTIFACTS[@]}" -gt 1 ]; then
+    echo "Error: ${#ARTIFACTS[@]} artifacts match version ${VERSION}; refusing to guess:"
+    printf '         %s\n' "${ARTIFACTS[@]}"
+    exit 1
+fi
+
+if [ "${#ALL_ARTIFACTS[@]}" -gt 1 ]; then
+    echo "  Note: ${#ALL_ARTIFACTS[@]} files matched the glob; selected by version."
+fi
+
 echo "  Built: ${ARTIFACTS[*]}"
 echo ""
 


### PR DESCRIPTION
Found while working through #32. This is a live bug in the release pipeline, not test coverage.

## The bug

```bash
ARTIFACTS=( $OUTPUT_GLOB )   # then ${ARTIFACTS[0]} is uploaded
```

The glob is version-agnostic (`pkg_x-*.zip`), so anything left in the output directory matches — a baseline downloaded by the upgrade harness, or the previous release. Bash expands globs **lexically**, so:

```
files: pkg_proclaim-10.3.2.zip  pkg_proclaim-10.3.3.zip
releasing 10.3.3 → would upload: pkg_proclaim-10.3.2.zip
```

**Proclaim 10.3.3 shipped exactly this** — 10.3.2's zip as both the GitHub asset and the ARS item. The mitigation since has been "remember to clear `build/dist` first": a manual step guarding a failure where the wrong file uploads and every step reports success.

Lexical order is wrong for versions anyway — `10.3.10` sorts before `10.3.2`.

## The fix

The version being released is already known, so match `*-${VERSION}.zip` instead of relying on ordering. Nothing is guessed:

- **no match for the version** → error, listing what *was* found
- **more than one match** → error rather than a silent pick
- **glob matches several files** → still allowed (normal during iterative testing), but prints a note that selection was by version

## Verified

Reproduced the original incident first, then confirmed the fix against the same directory:

| Releasing | Before | After |
|---|---|---|
| 10.3.3 | `pkg_proclaim-10.3.2.zip` ✗ | `pkg_proclaim-10.3.3.zip` ✓ |
| 10.3.10 | luck | `pkg_proclaim-10.3.10.zip` ✓ |
| 10.3.99 (absent) | would upload something | loud error ✓ |

306 PHP tests + 25 Python still green.

## Note on coverage

`release.sh` is bash, so this is covered by the `lint` job's `bash -n` and by the manual reproduction above — not by unit tests. Worth remembering that the three highest-consequence scripts in this repo (`release.sh`, `ars-publish.sh`, `cwm-article.sh`) are all shell and therefore outside #32's extraction approach entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151X65uy1t64SDgxwq7mXmq