### PR TITLE
test(shell): behavioural tests for artifact selection, and shellcheck in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,21 @@ jobs:
         # (issue #32) and is otherwise only exercised by running a release.
         run: find src scripts tests -name '*.php' -print0 | xargs -0 -n1 -P4 php -l > /dev/null
 
+      - name: shellcheck every shell script
+        # Preinstalled on ubuntu runners. Catches quoting, unset variables and
+        # word-splitting — the class of shell bug bash -n cannot see. The
+        # semantic bugs (#37, #38, #51) need the behavioural tests in
+        # tests/shell for that; this covers the rest. See #52.
+        run: shellcheck -S warning scripts/*.sh scripts/lib/*.sh
+
+      - name: Run shell behavioural tests
+        run: |
+          rc=0
+          for t in tests/shell/*.test.sh; do
+            bash "$t" || rc=1
+          done
+          exit $rc
+
       - name: Check syntax of every shell script
         # release.sh and ars-publish.sh are the release pipeline; a syntax error
         # in either is discovered mid-release today.

--- a/scripts/lib/artifacts.sh
+++ b/scripts/lib/artifacts.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Artifact selection for the release pipeline.
+#
+# Sourceable rather than executable so the logic can be exercised by
+# tests/shell — see issue #52. The entry points in scripts/ are 400-line
+# procedural scripts that run on invocation, which is why nothing in them has
+# ever been tested, and why every bug found in them was found by reading.
+#
+# Functions here must stay free of network calls and of anything that writes
+# outside a path they were handed, so a test can run them against a temporary
+# directory.
+
+# Select the build artifact belonging to a specific version.
+#
+# The output glob is deliberately version-agnostic (pkg_x-*.zip), so anything
+# left in the output directory matches it too — a baseline downloaded by the
+# upgrade harness, or simply the previous release. Choosing by glob order picks
+# whatever sorts first, and bash sorts lexically, so releasing 10.3.3 next to a
+# stale 10.3.2 selects the 10.3.2 zip. Proclaim 10.3.3 shipped exactly that, to
+# both GitHub and ARS.
+#
+# Lexical order is wrong for versions in general: 10.3.10 sorts before 10.3.2.
+#
+# So match on the version and refuse to guess otherwise. Ambiguity is an error,
+# not something to resolve with a heuristic — a release publishes to the world
+# and reports success either way.
+#
+# Arguments:
+#   $1  version being released, e.g. 10.3.6
+#   $2  glob for candidate artifacts, relative or absolute
+#
+# Outputs:
+#   The selected path on stdout; diagnostics on stderr.
+#
+# Returns:
+#   0 selected, 1 nothing matched the glob, 2 nothing matched the version,
+#   3 more than one matched the version.
+cwm_select_artifact_for_version() {
+    local version="$1"
+    local output_glob="$2"
+    local all=() selected=() artifact
+
+    shopt -s nullglob
+    # shellcheck disable=SC2206  # intentional word-splitting: this is a glob
+    all=( $output_glob )
+    shopt -u nullglob
+
+    if [ "${#all[@]}" -eq 0 ]; then
+        echo "Error: No build artifact matched ${output_glob}" >&2
+
+        return 1
+    fi
+
+    for artifact in "${all[@]}"; do
+        case "$(basename "$artifact")" in
+            *"-${version}".zip) selected+=( "$artifact" ) ;;
+        esac
+    done
+
+    if [ "${#selected[@]}" -eq 0 ]; then
+        {
+            echo "Error: No build artifact for version ${version} matched ${output_glob}"
+            echo "       Found instead:"
+            printf '         %s\n' "${all[@]}"
+            echo "       The build step should have produced a file named *-${version}.zip."
+        } >&2
+
+        return 2
+    fi
+
+    if [ "${#selected[@]}" -gt 1 ]; then
+        {
+            echo "Error: ${#selected[@]} artifacts match version ${version}; refusing to guess:"
+            printf '         %s\n' "${selected[@]}"
+        } >&2
+
+        return 3
+    fi
+
+    if [ "${#all[@]}" -gt 1 ]; then
+        echo "  Note: ${#all[@]} files matched the glob; selected by version." >&2
+    fi
+
+    printf '%s\n' "${selected[0]}"
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -31,6 +31,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOOLS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/artifacts.sh
+source "${SCRIPT_DIR}/lib/artifacts.sh"
 PROJECT_ROOT="$(pwd)"
 
 CONFIG_FILE="${PROJECT_ROOT}/cwm-build.config.json"
@@ -170,54 +173,12 @@ fi
 
 # Resolve the artifact for *this* version.
 #
-# The glob is deliberately version-agnostic (pkg_x-*.zip), so anything left in
-# the output directory matches it too — a baseline downloaded by the upgrade
-# harness, or simply the previous release. Taking ARTIFACTS[0] from an
-# unsorted glob therefore picks whatever sorts first, and bash sorts
-# lexically: releasing 10.3.3 alongside a stale 10.3.2 selects the 10.3.2 zip.
-#
-# That is not hypothetical. Proclaim 10.3.3 shipped pkg_proclaim-10.3.2.zip as
-# its GitHub asset and its ARS item, and the standing mitigation has been to
-# remember to clear build/dist first. A manual step is a poor guard for a
-# failure this quiet — the wrong file uploads and everything reports success.
-#
-# Lexical order is wrong for versions anyway: 10.3.10 sorts before 10.3.2.
-#
-# So match on the version being released rather than on ordering, and refuse to
-# guess when the answer is not unambiguous.
-shopt -s nullglob
-ALL_ARTIFACTS=( $OUTPUT_GLOB )
-shopt -u nullglob
-
-if [ "${#ALL_ARTIFACTS[@]}" -eq 0 ]; then
-    echo "Error: No build artifact matched $OUTPUT_GLOB"
-    exit 1
-fi
-
-ARTIFACTS=()
-for artifact in "${ALL_ARTIFACTS[@]}"; do
-    case "$(basename "$artifact")" in
-        *"-${VERSION}".zip) ARTIFACTS+=( "$artifact" ) ;;
-    esac
-done
-
-if [ "${#ARTIFACTS[@]}" -eq 0 ]; then
-    echo "Error: No build artifact for version ${VERSION} matched $OUTPUT_GLOB"
-    echo "       Found instead:"
-    printf '         %s\n' "${ALL_ARTIFACTS[@]}"
-    echo "       The build step should have produced a file named *-${VERSION}.zip."
-    exit 1
-fi
-
-if [ "${#ARTIFACTS[@]}" -gt 1 ]; then
-    echo "Error: ${#ARTIFACTS[@]} artifacts match version ${VERSION}; refusing to guess:"
-    printf '         %s\n' "${ARTIFACTS[@]}"
-    exit 1
-fi
-
-if [ "${#ALL_ARTIFACTS[@]}" -gt 1 ]; then
-    echo "  Note: ${#ALL_ARTIFACTS[@]} files matched the glob; selected by version."
-fi
+# The selection lives in lib/artifacts.sh so it can be tested — see #52. It was
+# wrong once already: cwm-release took the first glob match, and bash sorts
+# lexically, so Proclaim 10.3.3 published pkg_proclaim-10.3.2.zip to GitHub and
+# ARS while reporting success.
+ARTIFACT="$(cwm_select_artifact_for_version "$VERSION" "$OUTPUT_GLOB")" || exit 1
+ARTIFACTS=( "$ARTIFACT" )
 
 echo "  Built: ${ARTIFACTS[*]}"
 echo ""

--- a/tests/shell/artifacts.test.sh
+++ b/tests/shell/artifacts.test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/lib/artifacts.sh.
+#
+# Plain bash rather than bats, so the suite runs anywhere `composer test` does
+# without adding a dependency. The assertions needed here are simple enough
+# that a runner is a few lines; if shell coverage grows much past this, bats
+# earns its place (issue #52).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../scripts/lib/artifacts.sh
+source "${SCRIPT_DIR}/../../scripts/lib/artifacts.sh"
+
+PASS=0
+FAIL=0
+
+# assert_equals <expected> <actual> <description>
+assert_equals() {
+    if [ "$1" = "$2" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $3"
+        echo "        expected: $1"
+        echo "        actual:   $2"
+    fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/dist"
+
+fixture() {
+    rm -f "$WORK"/dist/*.zip
+    for name in "$@"; do
+        touch "$WORK/dist/$name"
+    done
+}
+
+GLOB="$WORK/dist/pkg_proclaim-*.zip"
+
+# --- The Proclaim 10.3.3 incident -------------------------------------------
+# A stale 10.3.2 sat in build/dist and sorted first, so the release published
+# it as 10.3.3. This is the case the whole function exists for.
+fixture pkg_proclaim-10.3.2.zip pkg_proclaim-10.3.3.zip
+got="$(cwm_select_artifact_for_version 10.3.3 "$GLOB" 2>/dev/null)"
+assert_equals "$WORK/dist/pkg_proclaim-10.3.3.zip" "$got" \
+    "selects its own version when a stale earlier artifact is present"
+
+# --- Lexical ordering is wrong for versions ---------------------------------
+# 10.3.10 sorts before 10.3.2, so anything relying on glob order is wrong in
+# both directions, not merely "usually right".
+fixture pkg_proclaim-10.3.2.zip pkg_proclaim-10.3.10.zip
+got="$(cwm_select_artifact_for_version 10.3.2 "$GLOB" 2>/dev/null)"
+assert_equals "$WORK/dist/pkg_proclaim-10.3.2.zip" "$got" \
+    "selects 10.3.2 even though 10.3.10 sorts first"
+
+got="$(cwm_select_artifact_for_version 10.3.10 "$GLOB" 2>/dev/null)"
+assert_equals "$WORK/dist/pkg_proclaim-10.3.10.zip" "$got" \
+    "selects 10.3.10 even though it sorts first"
+
+# --- A single artifact still works ------------------------------------------
+fixture pkg_proclaim-10.3.6.zip
+got="$(cwm_select_artifact_for_version 10.3.6 "$GLOB" 2>/dev/null)"
+assert_equals "$WORK/dist/pkg_proclaim-10.3.6.zip" "$got" "selects the only artifact"
+
+# --- Pre-release versions ---------------------------------------------------
+# A hyphenated suffix must not confuse the *-<version>.zip match.
+fixture pkg_proclaim-10.3.6.zip pkg_proclaim-10.3.6-beta1.zip
+got="$(cwm_select_artifact_for_version 10.3.6-beta1 "$GLOB" 2>/dev/null)"
+assert_equals "$WORK/dist/pkg_proclaim-10.3.6-beta1.zip" "$got" "selects a pre-release build"
+
+got="$(cwm_select_artifact_for_version 10.3.6 "$GLOB" 2>/dev/null)"
+assert_equals "$WORK/dist/pkg_proclaim-10.3.6.zip" "$got" \
+    "10.3.6 does not match 10.3.6-beta1"
+
+# --- Failure modes ----------------------------------------------------------
+# Each must be an error, not a guess: a release publishes to the world and
+# reports success either way.
+fixture
+cwm_select_artifact_for_version 10.3.6 "$GLOB" >/dev/null 2>&1
+assert_equals "1" "$?" "empty directory returns 1"
+
+fixture pkg_proclaim-10.3.2.zip
+cwm_select_artifact_for_version 10.3.6 "$GLOB" >/dev/null 2>&1
+assert_equals "2" "$?" "no artifact for the requested version returns 2"
+
+# Two files that both end -10.3.6.zip: ambiguous, so refuse rather than pick.
+fixture pkg_proclaim-10.3.6.zip
+touch "$WORK/dist/pkg_proclaim-extra-10.3.6.zip"
+cwm_select_artifact_for_version 10.3.6 "$GLOB" >/dev/null 2>&1
+assert_equals "3" "$?" "an ambiguous match returns 3 rather than guessing"
+
+# --- Diagnostics ------------------------------------------------------------
+# "No artifact" is the error someone will actually hit, so it should say what
+# it did find rather than only what it wanted.
+fixture pkg_proclaim-10.3.2.zip
+err="$(cwm_select_artifact_for_version 10.3.6 "$GLOB" 2>&1 >/dev/null)"
+case "$err" in
+    *"10.3.2"*) PASS=$((PASS + 1)) ;;
+    *) FAIL=$((FAIL + 1)); echo "  FAIL: the error should list what was found instead" ;;
+esac
+
+# The selected path must be the only thing on stdout, so callers can capture it.
+fixture pkg_proclaim-10.3.2.zip pkg_proclaim-10.3.6.zip
+out="$(cwm_select_artifact_for_version 10.3.6 "$GLOB" 2>/dev/null)"
+assert_equals "1" "$(printf '%s' "$out" | grep -c .)" "stdout carries only the path"
+
+echo "  artifacts.test.sh: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
First step on #52.

## What this adds

**`scripts/lib/artifacts.sh`** — `cwm_select_artifact_for_version`, extracted from `release.sh` so a test can `source` it. The entry-point scripts run on invocation, which is why nothing in them has ever been testable.

**`tests/shell/artifacts.test.sh`** — 11 assertions, plain bash (no bats dependency; if shell coverage grows, bats earns its place). The first case is the Proclaim 10.3.3 incident verbatim:

```
files: pkg_proclaim-10.3.2.zip  pkg_proclaim-10.3.3.zip
selecting for 10.3.3 → must pick 10.3.3, not the lexically-first 10.3.2
```

Also covered: `10.3.10` vs lexical order, pre-release suffixes (`10.3.6` must not match `10.3.6-beta1`), all three failure modes as distinct exit codes, error output listing what *was* found, and stdout carrying only the path so callers can capture it.

**Negative control:** reintroducing the old first-glob-match behaviour fails **6 of 11** assertions. Verified, not assumed.

**CI:** the lint job now runs `shellcheck -S warning` (preinstalled on runners — no local install involved) plus the behavioural tests.

## Honest scope note

None of this week's three shell bugs (#37, #38, #51) would have been caught by shellcheck — all were semantic. shellcheck covers the quoting/expansion class; the behavioural tests cover the decisions. Both are now in CI.

I could not run shellcheck locally (not installed here), so this PR's own CI run is the first execution against the existing 1,862 lines — if it flags pre-existing warnings, I'll fix them on this branch.

## Verified locally

- 306 PHP + 25 Python tests green
- 11/11 shell assertions
- `bash -n` across all scripts including the new lib

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151X65uy1t64SDgxwq7mXmq