### PR TITLE
test(shell): lift version, notes, ARS lookup and bullets logic into testable libs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,9 +85,11 @@
     "scripts": {
         "test": [
             "@test:php",
-            "@test:python"
+            "@test:python",
+            "@test:shell"
         ],
         "test:php": "phpunit",
-        "test:python": "python3 -m unittest discover -s tests/python -v"
+        "test:python": "python3 -m unittest discover -s tests/python -v",
+        "test:shell": "rc=0; for t in tests/shell/*.test.sh; do bash \"$t\" || rc=1; done; exit $rc"
     }
 }

--- a/scripts/ars-publish.sh
+++ b/scripts/ars-publish.sh
@@ -51,6 +51,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(pwd)"
 
+# shellcheck source=lib/version.sh
+source "${SCRIPT_DIR}/lib/version.sh"
+# shellcheck source=lib/ars.sh
+source "${SCRIPT_DIR}/lib/ars.sh"
+
 CONFIG_FILE="${PROJECT_ROOT}/cwm-build.config.json"
 
 if [ ! -f "$CONFIG_FILE" ]; then
@@ -121,27 +126,21 @@ if [ -z "$GH_OWNER" ] || [ -z "$GH_REPO" ]; then
 fi
 
 ZIP_PREFIX="${ZIP_PREFIX:-$EXT_NAME}"
-ALIAS_PREFIX="${ALIAS_PREFIX:-$(echo "$EXT_NAME" | sed -E 's/^(pkg_|com_|lib_|plg_|mod_|tpl_)//')}"
 TOKEN_ITEM="${TOKEN_ITEM:-CWM ARS API Token}"
 TOKEN_VAULT="${TOKEN_VAULT:-CWM}"
 ARS_ENVIRONMENTS="${ARS_ENVIRONMENTS:-null}"
 
+# Naming and version derivation live in lib/ars.sh and lib/version.sh so
+# they can be tested — see #52.
+ALIAS_PREFIX=$(cwm_ars_alias_prefix "$EXT_NAME" "$ALIAS_PREFIX")
+
 API_BASE="${SITE_URL%/}/api/index.php/v1/ars"
-TAG="v${VERSION}"
-ALIAS=$(echo "${ALIAS_PREFIX}-${VERSION}" | tr '.' '-')
+TAG=$(cwm_tag_for_version "$VERSION")
+ALIAS=$(cwm_ars_release_alias "$ALIAS_PREFIX" "$VERSION")
 ZIP_NAME=$(basename "$ZIP_PATH")
 GITHUB_DOWNLOAD_URL="https://github.com/${GH_OWNER}/${GH_REPO}/releases/download/${TAG}/${ZIP_NAME}"
 
-# Determine ARS maturity from version string
-if [[ "$VERSION" == *-alpha* ]]; then
-    ARS_MATURITY="alpha"
-elif [[ "$VERSION" == *-beta* ]]; then
-    ARS_MATURITY="beta"
-elif [[ "$VERSION" == *-rc* ]]; then
-    ARS_MATURITY="rc"
-else
-    ARS_MATURITY="stable"
-fi
+ARS_MATURITY=$(cwm_maturity_for_version "$VERSION")
 
 echo "Publishing ${EXT_NAME} ${VERSION} to ARS (maturity: ${ARS_MATURITY})..."
 echo "  endpoint:      ${SITE_URL}"
@@ -238,14 +237,8 @@ EXISTING=$(curl -s \
     -H "Accept: application/vnd.api+json" \
     "${API_BASE}/releases?category_id=${ARS_CATEGORY_ID}&search=${VERSION}&page%5Blimit%5D=200")
 
-EXISTING_ID=$(echo "$EXISTING" | python3 -c "
-import json,sys
-d=json.load(sys.stdin)
-for r in d.get('data',[]):
-    if r['attributes']['version'] == '${VERSION}':
-        print(r['attributes']['id'])
-        break
-" 2>/dev/null || echo "")
+# The exact-version match lives in lib/ars.sh so it can be tested — see #52.
+EXISTING_ID=$(echo "$EXISTING" | cwm_ars_find_release_id "$VERSION")
 
 if [ -n "$EXISTING_ID" ]; then
     echo "ARS release already exists (ID: ${EXISTING_ID}). Updating..."
@@ -312,14 +305,8 @@ EXISTING_ITEM=$(curl -s \
     -H "Accept: application/vnd.api+json" \
     "${API_BASE}/items?release_id=${RELEASE_ID}&page%5Blimit%5D=200")
 
-EXISTING_ITEM_ID=$(echo "$EXISTING_ITEM" | python3 -c "
-import json,sys
-d=json.load(sys.stdin)
-for i in d.get('data',[]):
-    if i['attributes'].get('url','').endswith('${ZIP_NAME}'):
-        print(i['attributes']['id'])
-        break
-" 2>/dev/null || echo "")
+# Basename match in lib/ars.sh, same reason.
+EXISTING_ITEM_ID=$(echo "$EXISTING_ITEM" | cwm_ars_find_item_id "$ZIP_NAME")
 
 DESCRIPTION_TEXT="${ITEM_DESCRIPTION:-$EXT_NAME}"
 DESCRIPTION_JSON=$(printf '%s' "$DESCRIPTION_TEXT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')

--- a/scripts/cwm-article.sh
+++ b/scripts/cwm-article.sh
@@ -64,8 +64,14 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(pwd)"
 CONFIG_FILE="${PROJECT_ROOT}/cwm-build.config.json"
+
+# shellcheck source=lib/version.sh
+source "${SCRIPT_DIR}/lib/version.sh"
+# shellcheck source=lib/bullets.sh
+source "${SCRIPT_DIR}/lib/bullets.sh"
 
 if [ ! -f "$CONFIG_FILE" ]; then
     echo "Error: $CONFIG_FILE not found"
@@ -126,8 +132,7 @@ else
         echo "       configure manifests.package in cwm-build.config.json."
         exit 1
     fi
-    VERSION=$(grep -oE '<version>[^<]+</version>' "$VERSION_MANIFEST" | head -1 | sed -E 's|</?version>||g')
-    if [ -z "$VERSION" ]; then
+    if ! VERSION=$(cwm_version_from_manifest "$VERSION_MANIFEST"); then
         echo "Error: No <version> element in ${VERSION_MANIFEST}."
         exit 1
     fi
@@ -214,46 +219,11 @@ AUTH_HEADER="Authorization: Bearer ${TOKEN}"
 JSON_HEADER="Content-Type: application/json"
 ACCEPT_HEADER="Accept: application/vnd.api+json"
 
-# --- HTML helpers ---
-# Escape <, >, & for safe inclusion as text content
-html_escape() {
-    sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g'
-}
-
-# Convert one-line markdown to inline HTML:
-#   **text**       → <strong>text</strong>
-#   <https://…>    → <a href="…">…</a>
-#   bare https://… → <a href="…">…</a>
-inline_md() {
-    local s="$1"
-    # **bold**
-    s=$(echo "$s" | sed -E 's@\*\*([^*]+)\*\*@<strong>\1</strong>@g')
-    # <https://…>  → keep as proper link
-    s=$(echo "$s" | sed -E 's@<(https?://[^>]+)>@<a href="\1">\1</a>@g')
-    # bare URLs not already inside an anchor — best-effort
-    s=$(echo "$s" | sed -E 's@(^|[[:space:]])(https?://[^[:space:]<]+)@\1<a href="\2">\2</a>@g')
-    echo "$s"
-}
-
-# Build <li>…</li> entries from RAW_BULLETS (one per non-empty line)
-build_li() {
-    local out=""
-    while IFS= read -r line; do
-        # Trim leading dashes/spaces and a leading "- " marker if present
-        line=$(echo "$line" | sed -E 's@^[[:space:]]*[-*][[:space:]]+@@; s@^[[:space:]]+@@; s@[[:space:]]+$@@')
-        [ -z "$line" ] && continue
-        # Escape HTML, then re-apply minimal markdown (escape happens BEFORE inline_md
-        # would otherwise reintroduce angle-bracket links — so escape only here for text).
-        local esc
-        esc=$(printf '%s' "$line" | html_escape)
-        local rendered
-        rendered=$(inline_md "$esc")
-        out+="<li>${rendered}</li>"$'\n'
-    done <<< "$RAW_BULLETS"
-    printf '%s' "$out"
-}
-
-LIST_ITEMS=$(build_li)
+# --- Render bullets as list items ---
+# Escaping, inline markdown and <li> assembly live in lib/bullets.sh so
+# they can be tested — see #52. (The move also fixed the documented
+# <https://…> link form, which the old in-script version never rendered.)
+LIST_ITEMS=$(printf '%s\n' "$RAW_BULLETS" | cwm_bullets_to_li)
 
 # --- Compose article HTML (mirrors the CWM 10.2.2-style announcement structure) ---
 # Everything goes in introtext so the article shows in full on category /

--- a/scripts/lib/ars.sh
+++ b/scripts/lib/ars.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# ARS lookup and naming for the publish pipeline.
+#
+# Sourceable rather than executable so the logic can be exercised by
+# tests/shell — see issue #52. The lookups take the API response on stdin
+# and never talk to the network themselves, so a test can feed them
+# fixture JSON; the caller owns curl, the token, and the endpoint.
+#
+# These matchers exist because the surrounding create-or-update flow
+# publishes either way: a lookup that misses takes the create branch and
+# ships a duplicate release or download item, reporting success (#37).
+# They are exactly the code that must not be wrong silently.
+
+# Derive the ARS release-alias prefix from the extension name.
+#
+# An explicit configuration wins; otherwise the conventional Joomla type
+# prefix is stripped, so pkg_proclaim releases get "proclaim-10-3-6"
+# aliases rather than "pkg_proclaim-10-3-6".
+#
+# Arguments:
+#   $1  extension.name, e.g. pkg_proclaim
+#   $2  configured ars.aliasPrefix, may be empty
+#
+# Outputs:
+#   The prefix on stdout.
+cwm_ars_alias_prefix() {
+    local ext_name="$1" configured="${2:-}"
+
+    if [ -n "$configured" ]; then
+        printf '%s\n' "$configured"
+
+        return 0
+    fi
+
+    printf '%s\n' "$ext_name" | sed -E 's/^(pkg_|com_|lib_|plg_|mod_|tpl_)//'
+}
+
+# The ARS release alias for a version: prefix-version with dots dashed,
+# because the alias becomes a URL slug.
+#
+# Arguments:
+#   $1  alias prefix, e.g. proclaim
+#   $2  version, e.g. 10.3.6
+#
+# Outputs:
+#   The alias on stdout, e.g. proclaim-10-3-6
+cwm_ars_release_alias() {
+    printf '%s-%s\n' "$1" "$2" | tr '.' '-'
+}
+
+# Find the ARS release id for an exact version in a releases response.
+#
+# The API-side filters are advisory at best (`search` substring-matches, so
+# 10.3.1 also matches 10.3.10), which is why the match on the exact version
+# string happens here, client-side.
+#
+# Arguments:
+#   $1  version to match exactly
+#
+# Input:
+#   The JSON body of GET /releases on stdin.
+#
+# Outputs:
+#   The release id on stdout, or nothing when no release has that version.
+#   Malformed JSON also outputs nothing: the caller treats "not found" as
+#   "create", which is the safe reading of a response it cannot parse —
+#   an update PATCHed at a guessed id would land on the wrong release.
+cwm_ars_find_release_id() {
+    python3 -c "
+import json, sys
+
+version = sys.argv[1]
+try:
+    d = json.load(sys.stdin)
+except ValueError:
+    sys.exit(0)
+for r in d.get('data', []):
+    if r.get('attributes', {}).get('version') == version:
+        print(r['attributes']['id'])
+        break
+" "$1" 2>/dev/null || true
+}
+
+# Find the ARS download-item id whose URL points at a zip name, in an
+# items response.
+#
+# Items point at GitHub download URLs; the basename is the stable part,
+# the path carries the tag and can be rewritten. The match is on the
+# exact basename, not a suffix — endswith("pkg_x-1.0.zip") would also
+# claim "other-pkg_x-1.0.zip", the same shape of near-miss the artifact
+# selection in lib/artifacts.sh refuses.
+#
+# Arguments:
+#   $1  zip file name, e.g. pkg_proclaim-10.3.6.zip
+#
+# Input:
+#   The JSON body of GET /items on stdin.
+#
+# Outputs:
+#   The item id on stdout, or nothing when no item matches. Malformed
+#   JSON also outputs nothing, for the same reason as the release lookup.
+cwm_ars_find_item_id() {
+    python3 -c "
+import json, sys
+
+zip_name = sys.argv[1]
+try:
+    d = json.load(sys.stdin)
+except ValueError:
+    sys.exit(0)
+for i in d.get('data', []):
+    url = i.get('attributes', {}).get('url', '')
+    if url.rsplit('/', 1)[-1] == zip_name:
+        print(i['attributes']['id'])
+        break
+" "$1" 2>/dev/null || true
+}

--- a/scripts/lib/bullets.sh
+++ b/scripts/lib/bullets.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Bullets-to-HTML parsing for the release announcement article.
+#
+# Sourceable rather than executable so the logic can be exercised by
+# tests/shell — see issue #52. Filters over stdin or arguments; nothing
+# here touches the network or the filesystem.
+#
+# The input format is the bullets file: one bullet per line, blank lines
+# ignored, an optional leading "-" or "*" marker tolerated, with minimal
+# inline markdown — **bold**, <https://…> links, bare https://… links.
+
+# Escape &, <, > for safe inclusion as HTML text content. Filter: stdin
+# to stdout. Ampersand first, or it would re-escape the entities the
+# other two produce.
+cwm_html_escape() {
+    sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g'
+}
+
+# Convert one already-escaped line of minimal markdown to inline HTML:
+#   **text**          → <strong>text</strong>
+#   &lt;https://…&gt; → <a href="…">…</a>
+#   bare https://…    → <a href="…">…</a>
+#
+# The input has been through cwm_html_escape, so an angle-bracket link
+# arrives as &lt;…&gt; — that is the form to match. (The pre-extraction
+# version of this matched literal <…>, which the escape had already
+# rewritten, so the documented <url> syntax never worked: the bare-URL
+# rule claimed it instead and dragged the trailing &gt; into the href.)
+#
+# A URL may contain &amp; (an escaped query separator); any other entity
+# ends it, which is what anchors the closing &gt; of an angle link.
+#
+# Arguments:
+#   $1  one escaped line
+#
+# Outputs:
+#   The rendered line on stdout.
+cwm_inline_md() {
+    local s="$1"
+
+    # **bold**
+    s=$(echo "$s" | sed -E 's@\*\*([^*]+)\*\*@<strong>\1</strong>@g')
+    # &lt;https://…&gt; → proper link
+    s=$(echo "$s" | sed -E 's@&lt;(https?://(&amp;|[^&[:space:]])+)&gt;@<a href="\1">\1</a>@g')
+    # bare URLs — best-effort; the leading (^|space) keeps this off the
+    # hrefs and link texts the previous rule just produced.
+    s=$(echo "$s" | sed -E 's@(^|[[:space:]])(https?://[^[:space:]<]+)@\1<a href="\2">\2</a>@g')
+    echo "$s"
+}
+
+# Build <li>…</li> entries from a bullets file.
+#
+# One bullet per non-empty line; leading list markers and surrounding
+# whitespace are trimmed, then each line is HTML-escaped and rendered.
+#
+# Input:
+#   Raw bullets text on stdin.
+#
+# Outputs:
+#   One <li> line per bullet on stdout; nothing when every line is blank.
+cwm_bullets_to_li() {
+    local line esc
+
+    while IFS= read -r line; do
+        # Trim a leading "- " / "* " marker and surrounding whitespace.
+        line=$(echo "$line" | sed -E 's@^[[:space:]]*[-*][[:space:]]+@@; s@^[[:space:]]+@@; s@[[:space:]]+$@@')
+        [ -z "$line" ] && continue
+        esc=$(printf '%s' "$line" | cwm_html_escape)
+        printf '<li>%s</li>\n' "$(cwm_inline_md "$esc")"
+    done
+}

--- a/scripts/lib/notes.sh
+++ b/scripts/lib/notes.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Release-notes assembly for the release pipeline.
+#
+# Sourceable rather than executable so the logic can be exercised by
+# tests/shell — see issue #52. Pure functions of their arguments and of
+# files they are handed; fetching the generated notes from GitHub stays
+# with the caller.
+
+# Resolve the hand-written notes file for a version.
+#
+# The configured pattern carries a {version} placeholder, e.g.
+# "build/release-notes-{version}.md". A release nobody wrote notes for is
+# normal, so a missing file is not an error — it just means the generated
+# notes stand alone.
+#
+# Arguments:
+#   $1  configured pattern, may be empty (feature unconfigured)
+#   $2  version
+#
+# Outputs:
+#   The path on stdout when the file exists; nothing otherwise.
+#
+# Returns:
+#   0 found, 1 no file (unconfigured, or nothing written for this version).
+cwm_resolve_notes_file() {
+    local pattern="$1" version="$2" candidate
+
+    if [ -z "$pattern" ]; then
+        return 1
+    fi
+
+    candidate="${pattern//\{version\}/$version}"
+
+    if [ ! -f "$candidate" ]; then
+        return 1
+    fi
+
+    printf '%s\n' "$candidate"
+}
+
+# Assemble the release-notes body from a hand-written file and the
+# generated notes.
+#
+# What GitHub generates is a list of pull request titles — accurate, and
+# written for us rather than for the person deciding whether to update.
+# So the hand-written notes lead when they exist, and the generated list
+# is kept beneath a "## Changes" heading so nothing is lost. Without a
+# file, the generated notes pass through untouched.
+#
+# Arguments:
+#   $1  path to the hand-written notes file, may be empty
+#   $2  the generated notes text
+#
+# Outputs:
+#   The assembled body on stdout.
+cwm_assemble_release_notes() {
+    local notes_file="$1" generated="$2"
+
+    if [ -z "$notes_file" ] || [ ! -f "$notes_file" ]; then
+        printf '%s\n' "$generated"
+
+        return 0
+    fi
+
+    printf '%s\n\n## Changes\n\n%s\n' "$(cat "$notes_file")" "$generated"
+}

--- a/scripts/lib/version.sh
+++ b/scripts/lib/version.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# Version and tag derivation for the release pipeline.
+#
+# Sourceable rather than executable so the logic can be exercised by
+# tests/shell — see issue #52. Everything here is a pure function of its
+# arguments (or of a file it was handed), so a test can run it without a
+# network, a git checkout, or a Joomla site.
+
+# Validate a version string for release.
+#
+# Arguments:
+#   $1  version string as typed or passed on the command line
+#
+# Outputs:
+#   Diagnostics on stderr when invalid.
+#
+# Returns:
+#   0 releasable, 1 empty, 2 a -dev version (never releasable; -alpha,
+#   -beta and -rc are the pre-release channels).
+cwm_validate_release_version() {
+    local version="$1"
+
+    if [ -z "$version" ]; then
+        echo "Error: No version provided." >&2
+
+        return 1
+    fi
+
+    if [[ "$version" == *-dev* ]]; then
+        echo "Error: Development versions cannot be released. Use -alpha, -beta, or -rc for testing." >&2
+
+        return 2
+    fi
+
+    return 0
+}
+
+# The git tag for a version: v-prefixed, nothing else.
+#
+# Arguments:
+#   $1  version, e.g. 10.3.6
+#
+# Outputs:
+#   The tag on stdout, e.g. v10.3.6
+cwm_tag_for_version() {
+    printf 'v%s\n' "$1"
+}
+
+# Whether a version is a pre-release.
+#
+# Any hyphenated suffix marks a pre-release; validation has already
+# rejected -dev before this is asked.
+#
+# Arguments:
+#   $1  version
+#
+# Returns:
+#   0 pre-release, 1 stable.
+cwm_is_prerelease() {
+    [[ "$1" == *-* ]]
+}
+
+# The `gh release create` flag for a version: "--prerelease" or nothing.
+#
+# Arguments:
+#   $1  version
+#
+# Outputs:
+#   The flag on stdout, or nothing for a stable version.
+cwm_prerelease_flag() {
+    if cwm_is_prerelease "$1"; then
+        printf -- '--prerelease\n'
+    fi
+}
+
+# ARS maturity for a version string.
+#
+# ARS classifies each release as alpha / beta / rc / stable, and the
+# version's own suffix already says which it is.
+#
+# Arguments:
+#   $1  version
+#
+# Outputs:
+#   One of: alpha, beta, rc, stable.
+cwm_maturity_for_version() {
+    local version="$1"
+
+    case "$version" in
+        *-alpha*) echo "alpha" ;;
+        *-beta*)  echo "beta" ;;
+        *-rc*)    echo "rc" ;;
+        *)        echo "stable" ;;
+    esac
+}
+
+# Read the version from a Joomla manifest XML.
+#
+# The first <version> element wins — a package manifest lists its member
+# extensions' manifests after its own header, and only the header version
+# is the package's.
+#
+# Arguments:
+#   $1  path to a manifest XML file
+#
+# Outputs:
+#   The version on stdout; nothing when the file is missing or carries no
+#   <version> element.
+#
+# Returns:
+#   0 found, 1 not found.
+cwm_version_from_manifest() {
+    local manifest="$1" version=""
+
+    if [ -f "$manifest" ]; then
+        version=$(grep -oE '<version>[^<]+</version>' "$manifest" | head -1 | sed -E 's|</?version>||g')
+    fi
+
+    if [ -z "$version" ]; then
+        return 1
+    fi
+
+    printf '%s\n' "$version"
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -34,6 +34,10 @@ TOOLS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # shellcheck source=lib/artifacts.sh
 source "${SCRIPT_DIR}/lib/artifacts.sh"
+# shellcheck source=lib/version.sh
+source "${SCRIPT_DIR}/lib/version.sh"
+# shellcheck source=lib/notes.sh
+source "${SCRIPT_DIR}/lib/notes.sh"
 PROJECT_ROOT="$(pwd)"
 
 CONFIG_FILE="${PROJECT_ROOT}/cwm-build.config.json"
@@ -111,31 +115,20 @@ echo ""
 if [ -n "${1:-}" ]; then
     VERSION="$1"
 else
-    if [ -n "$PKG_MANIFEST" ] && [ -f "$PKG_MANIFEST" ]; then
-        CURRENT=$(grep -oE '<version>[^<]+</version>' "$PKG_MANIFEST" | head -1 | sed -E 's|</?version>||g')
+    if [ -n "$PKG_MANIFEST" ]; then
+        CURRENT=$(cwm_version_from_manifest "$PKG_MANIFEST" || true)
         echo "Current package version: ${CURRENT:-unknown}"
     fi
     printf "Enter new version (e.g., 1.2.3): "
     read -r VERSION
 fi
 
-if [ -z "$VERSION" ]; then
-    echo "Error: No version provided."
-    exit 1
-fi
+# Validation, tag and pre-release derivation live in lib/version.sh so
+# they can be tested — see #52.
+cwm_validate_release_version "$VERSION" || exit 1
 
-if [[ "$VERSION" == *-dev* ]]; then
-    echo "Error: Development versions cannot be released. Use -alpha, -beta, or -rc for testing."
-    exit 1
-fi
-
-TAG="v${VERSION}"
-
-# Pre-release detection
-PRERELEASE_FLAG=""
-if [[ "$VERSION" == *-* ]]; then
-    PRERELEASE_FLAG="--prerelease"
-fi
+TAG=$(cwm_tag_for_version "$VERSION")
+PRERELEASE_FLAG=$(cwm_prerelease_flag "$VERSION")
 
 echo ""
 echo "=== ${PKG_NAME} Release ${VERSION} ==="
@@ -236,22 +229,16 @@ fi
 # nothing is lost. Configure `release.notesFile` with a {version} placeholder,
 # e.g. "build/release-notes-{version}.md". Absent file, absent config, or a
 # release nobody wrote notes for: unchanged behaviour.
-NOTES_FILE=""
+#
+# Resolution and assembly live in lib/notes.sh so they can be tested — see #52.
 NOTES_FILE_PATTERN=$(read_config "release.notesFile")
-if [ -n "$NOTES_FILE_PATTERN" ]; then
-    CANDIDATE="${NOTES_FILE_PATTERN//\{version\}/$VERSION}"
-    if [ -f "$CANDIDATE" ]; then
-        NOTES_FILE="$CANDIDATE"
-        echo "  Using hand-written release notes: ${NOTES_FILE}"
-        NOTES="$(cat "$NOTES_FILE")
-
-## Changes
-
-${NOTES}"
-    else
-        echo "  No hand-written notes at ${CANDIDATE}; using generated notes."
-    fi
+NOTES_FILE=$(cwm_resolve_notes_file "$NOTES_FILE_PATTERN" "$VERSION" || true)
+if [ -n "$NOTES_FILE" ]; then
+    echo "  Using hand-written release notes: ${NOTES_FILE}"
+elif [ -n "$NOTES_FILE_PATTERN" ]; then
+    echo "  No hand-written notes at ${NOTES_FILE_PATTERN//\{version\}/$VERSION}; using generated notes."
 fi
+NOTES=$(cwm_assemble_release_notes "$NOTES_FILE" "$NOTES")
 
 GH_REPO_ARG=""
 if [ -n "$GH_OWNER" ] && [ -n "$GH_REPO" ]; then

--- a/tests/shell/ars.test.sh
+++ b/tests/shell/ars.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/lib/ars.sh.
+#
+# The lookups are fed fixture JSON shaped like real ARS v7 responses:
+# data[].attributes with id, version, url. A miss on either lookup makes
+# the caller create a duplicate release or item (#37), which is why the
+# misses tested here matter as much as the hits.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+# shellcheck source=../../scripts/lib/ars.sh
+source "${SCRIPT_DIR}/../../scripts/lib/ars.sh"
+
+# --- Alias derivation --------------------------------------------------------
+assert_equals "proclaim" "$(cwm_ars_alias_prefix pkg_proclaim "")" "pkg_ prefix is stripped"
+assert_equals "cwmscripture" "$(cwm_ars_alias_prefix lib_cwmscripture "")" "lib_ prefix is stripped"
+assert_equals "scripture" "$(cwm_ars_alias_prefix pkg_cwmscripturelinks scripture)" \
+    "an explicit ars.aliasPrefix wins"
+assert_equals "custom" "$(cwm_ars_alias_prefix custom "")" "an unprefixed name passes through"
+
+assert_equals "proclaim-10-3-6" "$(cwm_ars_release_alias proclaim 10.3.6)" \
+    "dots become dashes: the alias is a URL slug"
+assert_equals "proclaim-10-4-0-beta1" "$(cwm_ars_release_alias proclaim 10.4.0-beta1)" \
+    "a pre-release suffix survives the slug"
+
+# --- Release lookup ----------------------------------------------------------
+RELEASES='{
+  "data": [
+    {"type": "releases", "id": "41", "attributes": {"id": 41, "version": "10.3.10"}},
+    {"type": "releases", "id": "42", "attributes": {"id": 42, "version": "10.3.1"}}
+  ]
+}'
+
+# The `search` parameter substring-matches, so a query for 10.3.1 also
+# returns 10.3.10 — the exact-match here is what keeps the create-or-update
+# decision honest.
+got="$(printf '%s' "$RELEASES" | cwm_ars_find_release_id 10.3.1)"
+assert_equals "42" "$got" "matches the exact version, not the 10.3.10 substring cousin"
+
+got="$(printf '%s' "$RELEASES" | cwm_ars_find_release_id 10.3.10)"
+assert_equals "41" "$got" "finds 10.3.10 as itself"
+
+got="$(printf '%s' "$RELEASES" | cwm_ars_find_release_id 10.3.2)"
+assert_equals "" "$got" "an absent version yields nothing (caller creates)"
+
+got="$(printf '%s' '{"data": []}' | cwm_ars_find_release_id 10.3.1)"
+assert_equals "" "$got" "an empty data array yields nothing"
+
+# Malformed JSON must yield nothing and exit 0: the caller runs under
+# set -e, and "cannot parse" must read as "not found → create", never as
+# an update PATCHed at a guessed id.
+got="$(printf '%s' '<html>Fatal error' | cwm_ars_find_release_id 10.3.1)"
+rc=$?
+assert_equals "" "$got" "malformed JSON yields nothing"
+assert_equals "0" "$rc" "malformed JSON does not abort the caller"
+
+# --- Item lookup -------------------------------------------------------------
+ITEMS='{
+  "data": [
+    {"type": "items", "id": "7", "attributes": {"id": 7,
+      "url": "https://github.com/o/r/releases/download/v10.3.5/pkg_proclaim-10.3.5.zip"}},
+    {"type": "items", "id": "8", "attributes": {"id": 8,
+      "url": "https://github.com/o/r/releases/download/v10.3.6/pkg_proclaim-10.3.6.zip"}}
+  ]
+}'
+
+got="$(printf '%s' "$ITEMS" | cwm_ars_find_item_id pkg_proclaim-10.3.6.zip)"
+assert_equals "8" "$got" "finds the item whose URL basename is the zip"
+
+got="$(printf '%s' "$ITEMS" | cwm_ars_find_item_id pkg_proclaim-10.3.7.zip)"
+assert_equals "" "$got" "an absent zip yields nothing (caller creates)"
+
+# The match is on the exact basename: a suffix match would claim
+# other-pkg_proclaim-10.3.6.zip for pkg_proclaim-10.3.6.zip and update
+# the wrong item.
+NEAR_MISS='{"data": [{"type": "items", "id": "9", "attributes": {"id": 9,
+  "url": "https://example.org/dl/other-pkg_proclaim-10.3.6.zip"}}]}'
+got="$(printf '%s' "$NEAR_MISS" | cwm_ars_find_item_id pkg_proclaim-10.3.6.zip)"
+assert_equals "" "$got" "a basename that merely ends with the zip name does not match"
+
+# An item without a url (type "file" items store a filename instead) is
+# skipped, not a crash.
+NO_URL='{"data": [{"type": "items", "id": "10", "attributes": {"id": 10}}]}'
+got="$(printf '%s' "$NO_URL" | cwm_ars_find_item_id pkg_proclaim-10.3.6.zip)"
+assert_equals "" "$got" "an item without a url is skipped"
+
+got="$(printf '%s' 'not json' | cwm_ars_find_item_id pkg_proclaim-10.3.6.zip)"
+assert_equals "" "$got" "malformed JSON yields nothing"
+
+finish

--- a/tests/shell/artifacts.test.sh
+++ b/tests/shell/artifacts.test.sh
@@ -2,31 +2,13 @@
 #
 # Tests for scripts/lib/artifacts.sh.
 #
-# Plain bash rather than bats, so the suite runs anywhere `composer test` does
-# without adding a dependency. The assertions needed here are simple enough
-# that a runner is a few lines; if shell coverage grows much past this, bats
-# earns its place (issue #52).
-
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
 # shellcheck source=../../scripts/lib/artifacts.sh
 source "${SCRIPT_DIR}/../../scripts/lib/artifacts.sh"
-
-PASS=0
-FAIL=0
-
-# assert_equals <expected> <actual> <description>
-assert_equals() {
-    if [ "$1" = "$2" ]; then
-        PASS=$((PASS + 1))
-    else
-        FAIL=$((FAIL + 1))
-        echo "  FAIL: $3"
-        echo "        expected: $1"
-        echo "        actual:   $2"
-    fi
-}
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
@@ -108,5 +90,4 @@ fixture pkg_proclaim-10.3.2.zip pkg_proclaim-10.3.6.zip
 out="$(cwm_select_artifact_for_version 10.3.6 "$GLOB" 2>/dev/null)"
 assert_equals "1" "$(printf '%s' "$out" | grep -c .)" "stdout carries only the path"
 
-echo "  artifacts.test.sh: ${PASS} passed, ${FAIL} failed"
-[ "$FAIL" -eq 0 ]
+finish

--- a/tests/shell/bullets.test.sh
+++ b/tests/shell/bullets.test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/lib/bullets.sh.
+#
+# The bullets file is hand-written moments before a release, so the
+# parser's job is to be forgiving about markers and whitespace while
+# never emitting broken HTML into a published article.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+# shellcheck source=../../scripts/lib/bullets.sh
+source "${SCRIPT_DIR}/../../scripts/lib/bullets.sh"
+
+# --- Escaping ----------------------------------------------------------------
+assert_equals '&amp; &lt; &gt;' "$(printf '& < >' | cwm_html_escape)" \
+    "ampersand, less-than, greater-than are escaped"
+assert_equals '&amp;lt;' "$(printf '&lt;' | cwm_html_escape)" \
+    "a pre-existing entity is escaped, not passed through (ampersand first)"
+
+# --- Basic bullets -----------------------------------------------------------
+got="$(printf 'Visual layout editor\n' | cwm_bullets_to_li)"
+assert_equals '<li>Visual layout editor</li>' "$got" "a plain line becomes an <li>"
+
+got="$(printf -- '- Dashed bullet\n* Starred bullet\n' | cwm_bullets_to_li)"
+assert_equals '<li>Dashed bullet</li>
+<li>Starred bullet</li>' "$got" "leading - and * markers are trimmed"
+
+got="$(printf 'First\n\n   \nSecond\n' | cwm_bullets_to_li)"
+assert_equals '<li>First</li>
+<li>Second</li>' "$got" "blank and whitespace-only lines are skipped"
+
+got="$(printf '   padded   \n' | cwm_bullets_to_li)"
+assert_equals '<li>padded</li>' "$got" "surrounding whitespace is trimmed"
+
+# --- Inline markdown ---------------------------------------------------------
+got="$(printf '**Media chapters** and copying\n' | cwm_bullets_to_li)"
+assert_equals '<li><strong>Media chapters</strong> and copying</li>' "$got" \
+    "**bold** renders as <strong>"
+
+got="$(printf 'A & B improvements\n' | cwm_bullets_to_li)"
+assert_equals '<li>A &amp; B improvements</li>' "$got" "text content is HTML-escaped"
+
+# The documented <url> form. Before the extraction this never worked: the
+# escape ran first, the literal-<…> rule could no longer match, and the
+# bare-URL rule dragged the trailing &gt; into the href.
+got="$(printf 'See <https://example.com/docs> for details\n' | cwm_bullets_to_li)"
+assert_equals '<li>See <a href="https://example.com/docs">https://example.com/docs</a> for details</li>' \
+    "$got" "an angle-bracket link renders as an anchor, without the trailing &gt;"
+
+# A query string's & arrives escaped; it belongs inside the URL, while the
+# closing &gt; does not.
+got="$(printf '<https://example.com/?a=1&b=2>\n' | cwm_bullets_to_li)"
+assert_equals '<li><a href="https://example.com/?a=1&amp;b=2">https://example.com/?a=1&amp;b=2</a></li>' \
+    "$got" "an escaped query-string ampersand stays in the URL"
+
+got="$(printf 'Docs at https://example.com/wiki now\n' | cwm_bullets_to_li)"
+assert_equals '<li>Docs at <a href="https://example.com/wiki">https://example.com/wiki</a> now</li>' \
+    "$got" "a bare URL renders as an anchor"
+
+# Two angle links on one line must not merge into a single greedy match.
+got="$(printf '<https://a.example> and <https://b.example>\n' | cwm_bullets_to_li)"
+assert_equals '<li><a href="https://a.example">https://a.example</a> and <a href="https://b.example">https://b.example</a></li>' \
+    "$got" "two angle links on one line stay separate"
+
+# --- The mixed realistic case ------------------------------------------------
+got="$(printf -- '- **YouTube OAuth** integration\n- See <https://example.com/notes>\n' | cwm_bullets_to_li)"
+assert_equals '<li><strong>YouTube OAuth</strong> integration</li>
+<li>See <a href="https://example.com/notes">https://example.com/notes</a></li>' \
+    "$got" "markers, bold and links compose"
+
+finish

--- a/tests/shell/helpers.sh
+++ b/tests/shell/helpers.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Shared assertions for tests/shell. Sourced by the *.test.sh files; not a
+# test itself, which is why the name doesn't match the runner's glob.
+#
+# Plain bash rather than bats, so the suite runs anywhere `composer test`
+# does without adding a dependency. If shell coverage grows much past a
+# handful of files, bats earns its place (issue #52).
+
+PASS=0
+FAIL=0
+
+# assert_equals <expected> <actual> <description>
+assert_equals() {
+    if [ "$1" = "$2" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $3"
+        echo "        expected: $1"
+        echo "        actual:   $2"
+    fi
+}
+
+# assert_contains <haystack> <needle> <description>
+assert_contains() {
+    case "$1" in
+        *"$2"*) PASS=$((PASS + 1)) ;;
+        *)
+            FAIL=$((FAIL + 1))
+            echo "  FAIL: $3"
+            echo "        expected to contain: $2"
+            echo "        actual:              $1"
+            ;;
+    esac
+}
+
+# finish — print the tally and exit non-zero if anything failed.
+finish() {
+    echo "  $(basename "$0"): ${PASS} passed, ${FAIL} failed"
+    [ "$FAIL" -eq 0 ]
+}

--- a/tests/shell/notes.test.sh
+++ b/tests/shell/notes.test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/lib/notes.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+# shellcheck source=../../scripts/lib/notes.sh
+source "${SCRIPT_DIR}/../../scripts/lib/notes.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- Resolving the notes file ------------------------------------------------
+cwm_resolve_notes_file "" 10.3.6 >/dev/null
+assert_equals "1" "$?" "an unconfigured pattern returns 1"
+
+printf '## Highlights\n' > "$WORK/release-notes-10.3.6.md"
+
+got="$(cwm_resolve_notes_file "$WORK/release-notes-{version}.md" 10.3.6)"
+assert_equals "$WORK/release-notes-10.3.6.md" "$got" "{version} is substituted and the file found"
+
+cwm_resolve_notes_file "$WORK/release-notes-{version}.md" 10.3.7 >/dev/null
+assert_equals "1" "$?" "a version nobody wrote notes for returns 1"
+
+# A pattern without a placeholder is legal — a project with one evergreen
+# notes file — and resolves to itself.
+got="$(cwm_resolve_notes_file "$WORK/release-notes-10.3.6.md" 10.3.6)"
+assert_equals "$WORK/release-notes-10.3.6.md" "$got" "a literal path resolves to itself"
+
+# --- Assembling the body -----------------------------------------------------
+GENERATED='## What'\''s Changed
+* fix(api): a PR title by @someone in #99'
+
+got="$(cwm_assemble_release_notes "" "$GENERATED")"
+assert_equals "$GENERATED" "$got" "no notes file: the generated notes pass through"
+
+got="$(cwm_assemble_release_notes "$WORK/absent.md" "$GENERATED")"
+assert_equals "$GENERATED" "$got" "a vanished notes file degrades to the generated notes"
+
+cat > "$WORK/notes.md" <<'MD'
+This release repairs podcast feeds.
+MD
+
+got="$(cwm_assemble_release_notes "$WORK/notes.md" "$GENERATED")"
+expected='This release repairs podcast feeds.
+
+## Changes
+
+## What'\''s Changed
+* fix(api): a PR title by @someone in #99'
+assert_equals "$expected" "$got" "hand-written notes lead; the generated list is kept beneath ## Changes"
+
+# The hand-written notes must come first: the ARS download page shows the
+# top of the notes, and the PR-title list is written for us, not for the
+# administrator deciding whether to update.
+case "$got" in
+    "This release repairs podcast feeds."*) PASS=$((PASS + 1)) ;;
+    *) FAIL=$((FAIL + 1)); echo "  FAIL: the hand-written notes should open the body" ;;
+esac
+
+finish

--- a/tests/shell/version.test.sh
+++ b/tests/shell/version.test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/lib/version.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+# shellcheck source=../../scripts/lib/version.sh
+source "${SCRIPT_DIR}/../../scripts/lib/version.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- Validation --------------------------------------------------------------
+cwm_validate_release_version "10.3.6" 2>/dev/null
+assert_equals "0" "$?" "a plain semantic version is releasable"
+
+cwm_validate_release_version "10.4.0-beta1" 2>/dev/null
+assert_equals "0" "$?" "a beta is releasable (as a pre-release)"
+
+cwm_validate_release_version "" 2>/dev/null
+assert_equals "1" "$?" "an empty version returns 1"
+
+# -dev is the working state between releases; it must never ship. This is
+# a distinct code so a caller can tell "forgot the argument" from "tried
+# to release the development version".
+cwm_validate_release_version "10.4.0-dev" 2>/dev/null
+assert_equals "2" "$?" "a -dev version returns 2"
+
+err="$(cwm_validate_release_version "10.4.0-dev" 2>&1)"
+assert_contains "$err" "-alpha, -beta, or -rc" "the -dev error names the valid channels"
+
+# --- Tag and pre-release derivation ------------------------------------------
+assert_equals "v10.3.6" "$(cwm_tag_for_version 10.3.6)" "tag is the v-prefixed version"
+
+cwm_is_prerelease "10.3.6"
+assert_equals "1" "$?" "a stable version is not a pre-release"
+
+cwm_is_prerelease "10.4.0-rc1"
+assert_equals "0" "$?" "a hyphenated suffix marks a pre-release"
+
+assert_equals "--prerelease" "$(cwm_prerelease_flag 10.4.0-beta1)" "beta gets the gh --prerelease flag"
+assert_equals "" "$(cwm_prerelease_flag 10.3.6)" "stable gets no flag"
+
+# --- ARS maturity ------------------------------------------------------------
+assert_equals "alpha" "$(cwm_maturity_for_version 11.0.0-alpha2)" "alpha maturity"
+assert_equals "beta" "$(cwm_maturity_for_version 10.4.0-beta1)" "beta maturity"
+assert_equals "rc" "$(cwm_maturity_for_version 10.4.0-rc1)" "rc maturity"
+assert_equals "stable" "$(cwm_maturity_for_version 10.3.6)" "no suffix is stable"
+
+# --- Version from a manifest -------------------------------------------------
+# A package manifest lists member extensions after its own header; only
+# the first <version> is the package's.
+cat > "$WORK/pkg.xml" <<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="package" method="upgrade">
+    <name>pkg_proclaim</name>
+    <version>10.3.6</version>
+    <files>
+        <file type="component" id="com_proclaim">com_proclaim.zip</file>
+    </files>
+    <description>A member manifest fragment carrying <version>9.9.9</version> must not win.</description>
+</extension>
+XML
+assert_equals "10.3.6" "$(cwm_version_from_manifest "$WORK/pkg.xml")" \
+    "the first <version> element wins"
+
+cwm_version_from_manifest "$WORK/does-not-exist.xml" >/dev/null
+assert_equals "1" "$?" "a missing manifest returns 1"
+
+printf '<extension><name>x</name></extension>\n' > "$WORK/noversion.xml"
+cwm_version_from_manifest "$WORK/noversion.xml" >/dev/null
+assert_equals "1" "$?" "a manifest without a <version> element returns 1"
+
+finish


### PR DESCRIPTION
Continues #52 — the three remaining items from the progress comment: `ars-publish.sh` lookups and notes assembly, `release.sh` version/tag derivation, `cwm-article.sh` bullets parsing.

## What moved where

| Lib | From | Covers |
|---|---|---|
| `scripts/lib/version.sh` | release.sh, ars-publish.sh, cwm-article.sh | version validation (`-dev` refusal), tag + `--prerelease` derivation, ARS maturity, manifest `<version>` extraction (was three separate greps) |
| `scripts/lib/notes.sh` | release.sh | notes-file resolution (`{version}` placeholder), body assembly (hand-written leads, generated list under `## Changes`) |
| `scripts/lib/ars.sh` | ars-publish.sh | alias-prefix stripping, URL-slug alias, and the two create-or-update lookups |
| `scripts/lib/bullets.sh` | cwm-article.sh | HTML escaping, inline markdown, `<li>` assembly |

Each has a `tests/shell/*.test.sh` suite (66 assertions total); CI's existing runner and shellcheck steps pick them up unchanged. `composer.json` gains `test:shell`, wired into `composer test` — which the artifacts.test.sh header already claimed ran the suite.

## Behaviour tightened or fixed along the way

- **ARS item lookup matches the URL basename, not `endswith`** — `other-pkg_x-1.0.zip` can no longer be claimed for `pkg_x-1.0.zip`; the same near-miss shape lib/artifacts.sh refuses (#51).
- **Lookup inputs are argv, not interpolated program text** — the version / zip name used to be spliced into the inline python source.
- **Malformed JSON from either lookup is "not found", loudly testable** — the caller's create branch is the safe reading; a PATCH at a guessed id is not.
- **The documented `<https://…>` bullet form now works.** It never did: escaping ran before the literal `<…>` rule could match, so the bare-URL rule dragged the trailing `&gt;` into the href. The rule now matches the escaped form, keeps `&amp;` inside query strings, and two links on one line stay separate. Verified end-to-end with a `DRY_RUN=1 cwm-article` preview.

Remaining for #52 after this: nothing from the named list — follow-ups would be new scope (e.g. the curl/create-update flow itself, which needs a fake-server harness rather than pure functions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBsju3MSzptws5njS14NaR