### PR TITLE
test(scripts): lift the remaining script logic into src/, and fix the role-dropping defect it hid

### DIFF
--- a/scripts/install-zip.php
+++ b/scripts/install-zip.php
@@ -20,10 +20,14 @@ declare(strict_types=1);
  * install scriptfile, manifest declarations, schema updates).
  */
 
+require_once __DIR__ . '/../src/Build/DistZipResolver.php';
+require_once __DIR__ . '/../src/Cli/Flags.php';
 require_once __DIR__ . '/../src/Dev/InstallConfig.php';
 require_once __DIR__ . '/../src/Dev/PropertiesReader.php';
 require_once __DIR__ . '/../src/Dev/ExtensionInstaller.php';
 
+use CWM\BuildTools\Build\DistZipResolver;
+use CWM\BuildTools\Cli\Flags;
 use CWM\BuildTools\Dev\ExtensionInstaller;
 use CWM\BuildTools\Dev\InstallConfig;
 use CWM\BuildTools\Dev\PropertiesReader;
@@ -75,8 +79,8 @@ HELP;
 }
 
 $projectRoot = getcwd() ?: '.';
-$verbose     = in_array('-v', $argv, true) || in_array('--verbose', $argv, true);
-$explicitZip = extractFlagValue($argv, '--zip');
+$verbose     = Flags::has($argv, ['-v', '--verbose']);
+$explicitZip = Flags::value($argv, '--zip');
 
 $config = loadConfig($projectRoot);
 $reader = new PropertiesReader($projectRoot . '/build.properties');
@@ -96,11 +100,16 @@ if ($testInstalls === []) {
     exit(1);
 }
 
-$zipPath = $explicitZip !== null
-    ? resolveExplicitZip($projectRoot, $explicitZip)
-    : resolveZipFromOutputGlob($projectRoot, $config);
+// Resolution logic lives in Build\DistZipResolver so it can be tested — #32.
+$resolver = new DistZipResolver();
 
-if ($zipPath === null) {
+try {
+    $zipPath = $explicitZip !== null
+        ? $resolver->resolveExplicit($projectRoot, $explicitZip)
+        : $resolver->resolveFromGlob($projectRoot, (string) ($config['build']['outputGlob'] ?? ''));
+} catch (\RuntimeException $e) {
+    fwrite(\STDERR, $e->getMessage() . "\n");
+
     exit(1);
 }
 
@@ -178,70 +187,5 @@ function loadConfig(string $projectRoot): array
     return $config;
 }
 
-/**
- * Find the value of `--name value` or `--name=value` in $argv.
- *
- * @param  list<string>  $argv
- */
-function extractFlagValue(array $argv, string $flag): ?string
-{
-    foreach ($argv as $i => $arg) {
-        if ($arg === $flag) {
-            return $argv[$i + 1] ?? null;
-        }
-
-        if (str_starts_with($arg, $flag . '=')) {
-            return substr($arg, strlen($flag) + 1);
-        }
-    }
-
-    return null;
-}
-
-function resolveExplicitZip(string $projectRoot, string $rawPath): ?string
-{
-    $candidate = $rawPath[0] === '/'
-        ? $rawPath
-        : $projectRoot . '/' . ltrim($rawPath, '/');
-
-    $resolved = realpath($candidate);
-
-    if ($resolved === false || !is_file($resolved)) {
-        fwrite(\STDERR, "--zip path not found: {$candidate}\n");
-
-        return null;
-    }
-
-    return $resolved;
-}
-
-/**
- * @param  array<string, mixed>  $config
- */
-function resolveZipFromOutputGlob(string $projectRoot, array $config): ?string
-{
-    $glob = (string) ($config['build']['outputGlob'] ?? '');
-
-    if ($glob === '') {
-        fwrite(\STDERR, "build.outputGlob is not set in cwm-build.config.json — cannot locate the dist zip.\n");
-        fwrite(\STDERR, "Either set it (e.g. \"build/dist/lib_x-*.zip\") or pass --zip explicitly.\n");
-
-        return null;
-    }
-
-    $pattern = $projectRoot . '/' . ltrim($glob, '/');
-    $matches = glob($pattern) ?: [];
-
-    if ($matches === []) {
-        fwrite(\STDERR, "No zip matched build.outputGlob '{$glob}'.\n");
-        fwrite(\STDERR, "Run 'composer cwm-build' first, or pass --zip <path>.\n");
-
-        return null;
-    }
-
-    // Pick the most recently modified zip — handles the common case where
-    // multiple versions sit in build/dist/ during iterative testing.
-    usort($matches, static fn (string $a, string $b): int => filemtime($b) <=> filemtime($a));
-
-    return $matches[0];
-}
+// (Zip resolution and flag parsing extracted to Build\DistZipResolver and
+// Cli\Flags — see #32.)

--- a/scripts/setup.php
+++ b/scripts/setup.php
@@ -16,11 +16,17 @@ declare(strict_types=1);
  *   composer setup -- --help
  */
 
+require_once __DIR__ . '/../src/Config/ComposerPathRepoSync.php';
 require_once __DIR__ . '/../src/Dev/InstallConfig.php';
+require_once __DIR__ . '/../src/Dev/InstallIntake.php';
 require_once __DIR__ . '/../src/Dev/PropertiesReader.php';
+require_once __DIR__ . '/../src/Dev/SiblingPathGuesser.php';
 
+use CWM\BuildTools\Config\ComposerPathRepoSync;
 use CWM\BuildTools\Dev\InstallConfig;
+use CWM\BuildTools\Dev\InstallIntake;
 use CWM\BuildTools\Dev\PropertiesReader;
+use CWM\BuildTools\Dev\SiblingPathGuesser;
 
 $projectRoot = getcwd();
 
@@ -38,6 +44,9 @@ WHAT IT DOES
   Walks you through one or more Joomla install paths (J5, J6, future J7)
   and captures, per install:
     - filesystem path
+    - role: `dev` (cwm-link symlinks the working tree here) or `test`
+      (cwm-install-zip deploys the built artifact here; reset/teardown
+      tooling may wipe it — never point it at a working install)
     - dev URL (informational; not required)
     - target Joomla version (used by cwm-joomla-install)
     - DB credentials, admin credentials (reserved; cwm-verify reads
@@ -106,25 +115,26 @@ $defaultIds = $existingList !== []
     : ['j5', 'j6'];
 $index      = 0;
 
+// Every judgement about the answers lives in InstallIntake so it can be
+// tested (#32) — including preserving an install's existing role, which
+// this loop used to drop on every re-run.
+$intake = new InstallIntake();
+
 while (true) {
     $defaultId = $defaultIds[$index] ?? '';
-    $id        = ask("Install id #" . ($index + 1) . " (e.g. j5, j6, j7)", $defaultId === '' ? null : $defaultId);
+    $rawId     = ask("Install id #" . ($index + 1) . " (e.g. j5, j6, j7)", $defaultId === '' ? null : $defaultId);
 
-    if ($id === null || $id === '') {
+    if ($rawId === null || $rawId === '') {
         break;
     }
 
-    if (!preg_match('/^[a-z0-9][a-z0-9_-]*$/i', $id)) {
+    $id = $intake->normaliseId($rawId);
+
+    if ($id === null) {
         echo "  Invalid id — use letters, digits, dash or underscore.\n";
 
         continue;
     }
-
-    // Section names in build.properties are lowercase by convention; the
-    // legacy Proclaim mapping (j5dev → j5) and the example template both
-    // assume lowercase. Normalise here so a user typing "J5" still ends
-    // up matching what LinkResolver and ExtensionVerifier expect.
-    $id = strtolower($id);
 
     $existing = $existingById[$id] ?? null;
 
@@ -140,6 +150,14 @@ while (true) {
         echo "  WARNING: '{$path}' does not exist yet. You can run 'composer joomla-install' later to populate it.\n";
     }
 
+    $rawRole = ask("  Role (dev = symlink target, test = zip-install target)", $existing?->role ?? InstallConfig::ROLE_DEV);
+    $role    = $intake->normaliseRole((string) $rawRole);
+
+    if ($role === null) {
+        echo "  Unrecognised role '{$rawRole}' — keeping '" . ($existing?->role ?? InstallConfig::ROLE_DEV) . "'.\n";
+        $role = null; // let assemble() fall back to existing/dev
+    }
+
     $url     = ask("  Dev URL (optional)", $existing?->url ?? "https://{$id}-dev.local");
     $version = ask("  Default Joomla version", $existing?->version ?? '5.4.2');
 
@@ -152,23 +170,19 @@ while (true) {
     $adminPass  = ask("  Admin password", $existing?->adminPass() ?? 'admin');
     $adminEmail = ask("  Admin email", $existing?->adminEmail() ?? 'admin@example.com');
 
-    $installs[] = new InstallConfig(
-        id:      $id,
-        path:    $path,
-        url:     $url ?: null,
-        version: $version ?: null,
-        db:      [
-            'host' => $dbHost ?: 'localhost',
-            'user' => $dbUser ?? '',
-            'pass' => $dbPass ?? '',
-            'name' => $dbName ?? '',
-        ],
-        admin:   [
-            'user'  => $adminUser ?: 'admin',
-            'pass'  => $adminPass ?: 'admin',
-            'email' => $adminEmail ?: 'admin@example.com',
-        ],
-    );
+    $installs[] = $intake->assemble($id, [
+        'path'       => $path,
+        'url'        => $url,
+        'version'    => $version,
+        'role'       => $role,
+        'dbHost'     => $dbHost,
+        'dbUser'     => $dbUser,
+        'dbPass'     => $dbPass,
+        'dbName'     => $dbName,
+        'adminUser'  => $adminUser,
+        'adminPass'  => $adminPass,
+        'adminEmail' => $adminEmail,
+    ], $existing);
 
     $index++;
     echo "\n";
@@ -251,7 +265,7 @@ function configureCwmSiblings(string $projectRoot, PropertiesReader $reader): vo
 
         $existing = $existingPaths[$package] ?? null;
         $default  = $existing
-            ?? detectSiblingDefault($projectRoot, $package)
+            ?? (new SiblingPathGuesser())->guess(dirname($projectRoot), $package)
             ?? '';
 
         if ($default !== '' && is_dir($default)) {
@@ -306,44 +320,11 @@ function configureCwmSiblings(string $projectRoot, PropertiesReader $reader): vo
 }
 
 /**
- * Best-effort guess at where a CWM sibling lives if the developer hasn't
- * configured it. Looks under the project root's parent dir for a matching
- * directory name (matches the common ~/GitHub/<repo> sibling layout).
- */
-function detectSiblingDefault(string $projectRoot, string $packageName): ?string
-{
-    // composer name format: "vendor/name" — usually "name" is the directory.
-    $base = basename($packageName);
-
-    // Common CWM/Joomla naming: lib_cwmscripture (with underscores). The
-    // composer name might be "joomla-bible-study/lib-cwmscripture" (dashes).
-    // Try a few normalised candidates.
-    $candidates = array_unique([
-        $base,
-        str_replace('-', '_', $base),
-        str_replace('_', '-', $base),
-        strtolower($base),
-    ]);
-
-    $parent = dirname($projectRoot);
-
-    foreach ($candidates as $name) {
-        $candidate = $parent . '/' . $name;
-
-        if (is_dir($candidate)) {
-            return $candidate;
-        }
-    }
-
-    return null;
-}
-
-/**
  * Sync composer.json's `repositories[]` block so each $resolved[$package]
  * has a matching path-repo entry with the developer's absolute path.
  *
- * Adds entries for newly-configured siblings; rewrites URLs on existing
- * entries. Other repository entries (VCS, registry, etc.) are preserved.
+ * The mutation itself lives in Config\ComposerPathRepoSync so it can be
+ * tested (#32) — this wrapper owns only the file I/O.
  *
  * @param  array<string, string> $resolved Map of package name -> absolute path.
  */
@@ -371,68 +352,16 @@ function syncComposerPathRepos(string $projectRoot, array $resolved): void
         return;
     }
 
-    $data['repositories'] = $data['repositories'] ?? [];
+    $result = (new ComposerPathRepoSync())->sync($data, $resolved);
 
-    if (!is_array($data['repositories'])) {
-        return;
-    }
-
-    // Index existing path repos by current URL's basename so we can match
-    // each $resolved package back to its existing entry (if any).
-    $existingByBase = [];
-
-    foreach ($data['repositories'] as $i => $entry) {
-        if (is_array($entry) && ($entry['type'] ?? null) === 'path') {
-            $url                  = (string) ($entry['url'] ?? '');
-            $existingByBase[basename($url)] = $i;
-        }
-    }
-
-    $changed = false;
-
-    foreach ($resolved as $package => $absolutePath) {
-        $base = basename($package);
-        // Match either the composer name basename or the underscore variant.
-        $candidates = array_unique([
-            $base,
-            str_replace('-', '_', $base),
-            str_replace('_', '-', $base),
-        ]);
-
-        $existingIndex = null;
-
-        foreach ($candidates as $candidate) {
-            if (isset($existingByBase[$candidate])) {
-                $existingIndex = $existingByBase[$candidate];
-                break;
-            }
-        }
-
-        if ($existingIndex !== null) {
-            if (($data['repositories'][$existingIndex]['url'] ?? null) !== $absolutePath) {
-                $data['repositories'][$existingIndex]['url'] = $absolutePath;
-                $changed = true;
-            }
-
-            continue;
-        }
-
-        $data['repositories'][] = [
-            'type'    => 'path',
-            'url'     => $absolutePath,
-            'options' => ['symlink' => true],
-        ];
-        $changed = true;
-    }
-
-    if (!$changed) {
+    if (!$result['changed']) {
         echo "  composer.json path repos already in sync.\n";
 
         return;
     }
 
     $trailing  = substr($raw, -1) === "\n" ? "\n" : '';
-    $rewritten = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . $trailing;
+    $rewritten = json_encode($result['data'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . $trailing;
 
     if ($rewritten === false || file_put_contents($composerPath, $rewritten) === false) {
         fwrite(\STDERR, "  WARNING: could not rewrite composer.json — sync repositories[] by hand.\n");

--- a/scripts/verify.php
+++ b/scripts/verify.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  *   composer cwm-verify -- -v                # also list OK rows
  */
 
+require_once __DIR__ . '/../src/Cli/Flags.php';
 require_once __DIR__ . '/../src/Config/CwmPackage.php';
 require_once __DIR__ . '/../src/Config/InstalledPackageReader.php';
 require_once __DIR__ . '/../src/Dev/InstallConfig.php';
@@ -25,6 +26,7 @@ require_once __DIR__ . '/../src/Dev/Linker.php';
 require_once __DIR__ . '/../src/Dev/LinkResolver.php';
 require_once __DIR__ . '/../src/Dev/DevTargetVerifier.php';
 
+use CWM\BuildTools\Cli\Flags;
 use CWM\BuildTools\Config\InstalledPackageReader;
 use CWM\BuildTools\Dev\DevTargetVerifier;
 use CWM\BuildTools\Dev\ExtensionVerifier;
@@ -96,9 +98,9 @@ HELP;
     exit(0);
 }
 
-$verbose   = in_array('-v', $argv, true) || in_array('--verbose', $argv, true);
+$verbose   = Flags::has($argv, ['-v', '--verbose']);
 $reconcile = in_array('--fix', $argv, true);
-$target    = extractFlagValue($argv, '--target');
+$target    = Flags::value($argv, '--target');
 
 if ($target !== null && !in_array($target, [InstallConfig::ROLE_DEV, InstallConfig::ROLE_TEST], true)) {
     fwrite(\STDERR, "--target must be one of: dev, test\n");
@@ -192,20 +194,4 @@ function loadConfig(string $projectRoot): array
     return $config;
 }
 
-/**
- * @param  list<string> $argv
- */
-function extractFlagValue(array $argv, string $flag): ?string
-{
-    foreach ($argv as $i => $arg) {
-        if ($arg === $flag) {
-            return $argv[$i + 1] ?? null;
-        }
-
-        if (str_starts_with($arg, $flag . '=')) {
-            return substr($arg, strlen($flag) + 1);
-        }
-    }
-
-    return null;
-}
+// (Flag parsing extracted to Cli\Flags — see #32.)

--- a/src/Build/DistZipResolver.php
+++ b/src/Build/DistZipResolver.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Build;
+
+/**
+ * Resolve which dist zip `cwm-install-zip` deploys.
+ *
+ * Extracted from scripts/install-zip.php so the selection can be tested
+ * (#32). Two paths: an explicit --zip argument, or the newest match of
+ * `build.outputGlob`.
+ *
+ * Deliberate contrast with the release pipeline: lib/artifacts.sh selects
+ * by VERSION and refuses ambiguity, because a release publishes to the
+ * world. This resolver selects by MODIFICATION TIME, because its job is
+ * iterative local testing — "install the zip I just built" — where several
+ * versions legitimately sit in build/dist/ and the newest is almost always
+ * the one meant. A caller that must be exact (the release harness) passes
+ * --zip explicitly.
+ */
+final class DistZipResolver
+{
+    /**
+     * Resolve an explicit --zip argument against the project root.
+     *
+     * @throws \RuntimeException when the path does not exist.
+     */
+    public function resolveExplicit(string $projectRoot, string $rawPath): string
+    {
+        $candidate = str_starts_with($rawPath, '/')
+            ? $rawPath
+            : $projectRoot . '/' . ltrim($rawPath, '/');
+
+        $resolved = realpath($candidate);
+
+        if ($resolved === false || !is_file($resolved)) {
+            throw new \RuntimeException("--zip path not found: {$candidate}");
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Resolve the newest zip matching `build.outputGlob`.
+     *
+     * @throws \RuntimeException when the glob is unset or matches nothing,
+     *                           with a message that says what to do next.
+     */
+    public function resolveFromGlob(string $projectRoot, string $glob): string
+    {
+        if ($glob === '') {
+            throw new \RuntimeException(
+                "build.outputGlob is not set in cwm-build.config.json — cannot locate the dist zip.\n"
+                . 'Either set it (e.g. "build/dist/lib_x-*.zip") or pass --zip explicitly.'
+            );
+        }
+
+        $pattern = $projectRoot . '/' . ltrim($glob, '/');
+        $matches = glob($pattern) ?: [];
+
+        if ($matches === []) {
+            throw new \RuntimeException(
+                "No zip matched build.outputGlob '{$glob}'.\n"
+                . "Run 'composer cwm-build' first, or pass --zip <path>."
+            );
+        }
+
+        // Newest modification time wins — see the class docblock for why
+        // this is mtime and not version.
+        usort($matches, static fn (string $a, string $b): int => filemtime($b) <=> filemtime($a));
+
+        return $matches[0];
+    }
+}

--- a/src/Cli/Flags.php
+++ b/src/Cli/Flags.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Cli;
+
+/**
+ * Command-line flag extraction shared by the scripts/ entry points.
+ *
+ * Three scripts carried their own copy of this loop (#32); a bug in one
+ * copy would have been invisible to the others' behaviour and to CI.
+ */
+final class Flags
+{
+    /**
+     * The value of `--name value` or `--name=value` in $argv, or null when
+     * the flag is absent (or present with no value).
+     *
+     * @param  list<string>  $argv
+     */
+    public static function value(array $argv, string $flag): ?string
+    {
+        foreach ($argv as $i => $arg) {
+            if ($arg === $flag) {
+                return $argv[$i + 1] ?? null;
+            }
+
+            if (str_starts_with($arg, $flag . '=')) {
+                return substr($arg, strlen($flag) + 1);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether any of the given switches is present.
+     *
+     * @param  list<string>  $argv
+     * @param  list<string>  $switches  e.g. ['-v', '--verbose']
+     */
+    public static function has(array $argv, array $switches): bool
+    {
+        foreach ($switches as $switch) {
+            if (in_array($switch, $argv, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Config/ComposerPathRepoSync.php
+++ b/src/Config/ComposerPathRepoSync.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Config;
+
+/**
+ * Synchronise composer.json's `repositories[]` with the developer's CWM
+ * sibling paths, extracted from scripts/setup.php so the mutation can be
+ * tested (#32).
+ *
+ * This is the highest-consequence code cwm-setup runs: it rewrites a
+ * consuming project's composer.json. The class works on the decoded
+ * array and reports whether anything changed; reading, encoding and
+ * writing the file stay with the caller.
+ *
+ * Matching is by basename of the existing path-repo URL against the
+ * package name's basename (dash and underscore variants), because the
+ * composer name ("cwm/lib-cwmscripture") and the checkout directory
+ * ("lib_cwmscripture") routinely disagree about separators. Entries of
+ * other types (vcs, composer, …) are never touched.
+ */
+final class ComposerPathRepoSync
+{
+    /**
+     * @param  array<string, mixed>   $composerData  Decoded composer.json.
+     * @param  array<string, string>  $resolved      Package name → absolute path.
+     *
+     * @return array{data: array<string, mixed>, changed: bool}
+     */
+    public function sync(array $composerData, array $resolved): array
+    {
+        $composerData['repositories'] = $composerData['repositories'] ?? [];
+
+        if (!is_array($composerData['repositories'])) {
+            // Somebody made repositories an object/string we don't
+            // understand — leave it alone rather than guess.
+            return ['data' => $composerData, 'changed' => false];
+        }
+
+        $existingByBase = [];
+
+        foreach ($composerData['repositories'] as $i => $entry) {
+            if (is_array($entry) && ($entry['type'] ?? null) === 'path') {
+                $existingByBase[basename((string) ($entry['url'] ?? ''))] = $i;
+            }
+        }
+
+        $changed = false;
+
+        foreach ($resolved as $package => $absolutePath) {
+            $base = basename($package);
+
+            $candidates = array_unique([
+                $base,
+                str_replace('-', '_', $base),
+                str_replace('_', '-', $base),
+            ]);
+
+            $existingIndex = null;
+
+            foreach ($candidates as $candidate) {
+                if (isset($existingByBase[$candidate])) {
+                    $existingIndex = $existingByBase[$candidate];
+                    break;
+                }
+            }
+
+            if ($existingIndex !== null) {
+                if (($composerData['repositories'][$existingIndex]['url'] ?? null) !== $absolutePath) {
+                    $composerData['repositories'][$existingIndex]['url'] = $absolutePath;
+                    $changed = true;
+                }
+
+                continue;
+            }
+
+            $composerData['repositories'][] = [
+                'type'    => 'path',
+                'url'     => $absolutePath,
+                'options' => ['symlink' => true],
+            ];
+            $changed = true;
+        }
+
+        return ['data' => $composerData, 'changed' => $changed];
+    }
+}

--- a/src/Dev/InstallIntake.php
+++ b/src/Dev/InstallIntake.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Dev;
+
+/**
+ * The decisions inside cwm-setup's install prompt loop, extracted from
+ * scripts/setup.php so they can be tested (#32). The script keeps the
+ * prompts and echoes; every judgement about the answers lives here.
+ *
+ * The extraction also fixed a real defect: the loop rebuilt each
+ * InstallConfig without passing `role`, so re-running `composer setup` on
+ * a project with a `role = test` install silently flipped it back to
+ * `dev`. A dev-role site is what `cwm-link` symlinks — and a symlinked
+ * "test" site is the precondition for the teardown-deletes-the-repo
+ * incident role separation exists to prevent. assemble() preserves the
+ * existing role unless an explicit answer changes it.
+ */
+final class InstallIntake
+{
+    /**
+     * Validate and normalise an install id as typed.
+     *
+     * Section names in build.properties are lowercase by convention; the
+     * legacy Proclaim mapping (j5dev → j5) and the example template both
+     * assume lowercase. Normalising here means a user typing "J5" still
+     * ends up matching what LinkResolver and ExtensionVerifier expect.
+     *
+     * @return string|null  The normalised id, or null when invalid.
+     */
+    public function normaliseId(string $id): ?string
+    {
+        if (!preg_match('/^[a-z0-9][a-z0-9_-]*$/i', $id)) {
+            return null;
+        }
+
+        return strtolower($id);
+    }
+
+    /**
+     * Validate a role answer.
+     *
+     * @return string|null  'dev' or 'test', or null when unrecognised.
+     */
+    public function normaliseRole(string $role): ?string
+    {
+        $role = strtolower(trim($role));
+
+        return in_array($role, [InstallConfig::ROLE_DEV, InstallConfig::ROLE_TEST], true) ? $role : null;
+    }
+
+    /**
+     * Build the InstallConfig for one prompted install.
+     *
+     * @param  string  $id  Already through normaliseId().
+     * @param  array{
+     *     path: string,
+     *     url?: string|null,
+     *     version?: string|null,
+     *     role?: string|null,
+     *     dbHost?: string|null,
+     *     dbUser?: string|null,
+     *     dbPass?: string|null,
+     *     dbName?: string|null,
+     *     adminUser?: string|null,
+     *     adminPass?: string|null,
+     *     adminEmail?: string|null,
+     * }  $answers  Trimmed prompt answers; null/'' means "no answer".
+     * @param  InstallConfig|null  $existing  The install as currently
+     *                                        configured, when re-running.
+     */
+    public function assemble(string $id, array $answers, ?InstallConfig $existing = null): InstallConfig
+    {
+        // Role precedence: an explicit answer, else whatever the install
+        // already was, else dev. Losing the existing role is never right —
+        // see the class docblock.
+        $role = $answers['role'] ?? null;
+
+        if ($role === null || $role === '') {
+            $role = $existing?->role ?? InstallConfig::ROLE_DEV;
+        }
+
+        return new InstallConfig(
+            id:      $id,
+            path:    $answers['path'],
+            url:     ($answers['url'] ?? '') !== '' ? $answers['url'] : null,
+            version: ($answers['version'] ?? '') !== '' ? $answers['version'] : null,
+            db:      [
+                'host' => ($answers['dbHost'] ?? '') !== '' ? $answers['dbHost'] : 'localhost',
+                'user' => $answers['dbUser'] ?? '',
+                'pass' => $answers['dbPass'] ?? '',
+                'name' => $answers['dbName'] ?? '',
+            ],
+            admin:   [
+                'user'  => ($answers['adminUser'] ?? '') !== '' ? $answers['adminUser'] : 'admin',
+                'pass'  => ($answers['adminPass'] ?? '') !== '' ? $answers['adminPass'] : 'admin',
+                'email' => ($answers['adminEmail'] ?? '') !== '' ? $answers['adminEmail'] : 'admin@example.com',
+            ],
+            role:    $role,
+        );
+    }
+}

--- a/src/Dev/SiblingPathGuesser.php
+++ b/src/Dev/SiblingPathGuesser.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Dev;
+
+/**
+ * Best-effort guess at where a CWM sibling checkout lives, extracted from
+ * scripts/setup.php so the candidate logic can be tested (#32).
+ *
+ * Matches the common ~/GitHub/<repo> layout: siblings sit next to the
+ * project under one parent directory. The composer package name's basename
+ * usually matches the directory, but CWM/Joomla naming mixes dashes and
+ * underscores (composer "lib-cwmscripture", directory "lib_cwmscripture"),
+ * so both variants are tried.
+ */
+final class SiblingPathGuesser
+{
+    /**
+     * @param  string  $parentDir    Directory the siblings would live in
+     *                               (normally dirname(projectRoot)).
+     * @param  string  $packageName  Composer name, e.g. "cwm/lib-cwmscripture".
+     *
+     * @return string|null  An existing directory, or null when no candidate
+     *                      is on disk.
+     */
+    public function guess(string $parentDir, string $packageName): ?string
+    {
+        $base = basename($packageName);
+
+        $candidates = array_unique([
+            $base,
+            str_replace('-', '_', $base),
+            str_replace('_', '-', $base),
+            strtolower($base),
+        ]);
+
+        foreach ($candidates as $name) {
+            $candidate = $parentDir . '/' . $name;
+
+            if (is_dir($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Build/DistZipResolverTest.php
+++ b/tests/Build/DistZipResolverTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Build;
+
+use CWM\BuildTools\Build\DistZipResolver;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class DistZipResolverTest extends TestCase
+{
+    private DistZipResolver $resolver;
+
+    private string $tmp;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new DistZipResolver();
+        $this->tmp      = sys_get_temp_dir() . '/cwm-distzip-' . bin2hex(random_bytes(6));
+        mkdir($this->tmp . '/build/dist', 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->tmp . '/build/dist/*') ?: [] as $f) {
+            @unlink($f);
+        }
+        @rmdir($this->tmp . '/build/dist');
+        @rmdir($this->tmp . '/build');
+        @rmdir($this->tmp);
+    }
+
+    private function zip(string $name, int $mtime): string
+    {
+        $path = $this->tmp . '/build/dist/' . $name;
+        touch($path, $mtime);
+
+        return $path;
+    }
+
+    #[Test]
+    public function theNewestZipWinsRegardlessOfName(): void
+    {
+        // Lexically 10.3.10 sorts before 10.3.2; mtime is the contract here
+        // (this resolver serves iterative local testing, where "the zip I
+        // just built" is the one meant — the release pipeline selects by
+        // version instead, in lib/artifacts.sh).
+        $this->zip('pkg_x-10.3.2.zip', time() - 100);
+        $newest = $this->zip('pkg_x-10.3.10.zip', time());
+
+        $this->assertSame(
+            $newest,
+            $this->resolver->resolveFromGlob($this->tmp, 'build/dist/pkg_x-*.zip')
+        );
+    }
+
+    #[Test]
+    public function anEmptyGlobConfigurationIsAnActionableError(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/outputGlob is not set/');
+
+        $this->resolver->resolveFromGlob($this->tmp, '');
+    }
+
+    #[Test]
+    public function noMatchesTellsTheUserToBuildFirst(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/cwm-build/');
+
+        $this->resolver->resolveFromGlob($this->tmp, 'build/dist/pkg_x-*.zip');
+    }
+
+    #[Test]
+    public function anExplicitRelativeZipResolvesAgainstTheProjectRoot(): void
+    {
+        $zip = $this->zip('pkg_x-1.0.0.zip', time());
+
+        $this->assertSame(
+            realpath($zip),
+            $this->resolver->resolveExplicit($this->tmp, 'build/dist/pkg_x-1.0.0.zip')
+        );
+    }
+
+    #[Test]
+    public function anExplicitAbsoluteZipIsUsedAsIs(): void
+    {
+        $zip = $this->zip('pkg_x-1.0.0.zip', time());
+
+        $this->assertSame(realpath($zip), $this->resolver->resolveExplicit('/somewhere/else', $zip));
+    }
+
+    #[Test]
+    public function aMissingExplicitZipIsAnError(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/--zip path not found/');
+
+        $this->resolver->resolveExplicit($this->tmp, 'build/dist/absent.zip');
+    }
+}

--- a/tests/Cli/FlagsTest.php
+++ b/tests/Cli/FlagsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Cli;
+
+use CWM\BuildTools\Cli\Flags;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class FlagsTest extends TestCase
+{
+    #[Test]
+    public function spaceSeparatedValuesAreFound(): void
+    {
+        $this->assertSame('test', Flags::value(['script', '--target', 'test'], '--target'));
+    }
+
+    #[Test]
+    public function equalsSeparatedValuesAreFound(): void
+    {
+        $this->assertSame('test', Flags::value(['script', '--target=test'], '--target'));
+    }
+
+    #[Test]
+    public function anAbsentFlagIsNull(): void
+    {
+        $this->assertNull(Flags::value(['script', '-v'], '--target'));
+    }
+
+    #[Test]
+    public function aFlagWithNoValueIsNull(): void
+    {
+        $this->assertNull(Flags::value(['script', '--target'], '--target'));
+    }
+
+    #[Test]
+    public function aPrefixDoesNotMatchALongerFlag(): void
+    {
+        // --targeted=x must not satisfy --target.
+        $this->assertNull(Flags::value(['script', '--targeted=x'], '--target'));
+    }
+
+    #[Test]
+    public function switchesMatchAnyAlias(): void
+    {
+        $this->assertTrue(Flags::has(['script', '-v'], ['-v', '--verbose']));
+        $this->assertTrue(Flags::has(['script', '--verbose'], ['-v', '--verbose']));
+        $this->assertFalse(Flags::has(['script', '--version'], ['-v', '--verbose']));
+    }
+}

--- a/tests/Config/ComposerPathRepoSyncTest.php
+++ b/tests/Config/ComposerPathRepoSyncTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Config;
+
+use CWM\BuildTools\Config\ComposerPathRepoSync;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This class rewrites a consuming project's composer.json — the highest-
+ * consequence thing cwm-setup does — so the matching rules and the
+ * leave-everything-else-alone guarantee are pinned here.
+ */
+class ComposerPathRepoSyncTest extends TestCase
+{
+    private ComposerPathRepoSync $sync;
+
+    protected function setUp(): void
+    {
+        $this->sync = new ComposerPathRepoSync();
+    }
+
+    #[Test]
+    public function aNewSiblingGetsAPathRepoWithSymlinkOption(): void
+    {
+        $result = $this->sync->sync(
+            ['name' => 'cwm/consumer'],
+            ['cwm/lib-cwmscripture' => '/Users/dev/GitHub/lib_cwmscripture']
+        );
+
+        $this->assertTrue($result['changed']);
+        $this->assertSame(
+            [
+                'type'    => 'path',
+                'url'     => '/Users/dev/GitHub/lib_cwmscripture',
+                'options' => ['symlink' => true],
+            ],
+            $result['data']['repositories'][0]
+        );
+    }
+
+    #[Test]
+    public function anExistingEntryIsMatchedAcrossDashUnderscoreVariants(): void
+    {
+        // Composer name uses dashes; the checkout (and the existing repo
+        // URL) use underscores. The entry must be updated, not duplicated.
+        $data = [
+            'repositories' => [
+                ['type' => 'path', 'url' => '../lib_cwmscripture', 'options' => ['symlink' => true]],
+            ],
+        ];
+
+        $result = $this->sync->sync($data, ['cwm/lib-cwmscripture' => '/abs/lib_cwmscripture']);
+
+        $this->assertTrue($result['changed']);
+        $this->assertCount(1, $result['data']['repositories']);
+        $this->assertSame('/abs/lib_cwmscripture', $result['data']['repositories'][0]['url']);
+    }
+
+    #[Test]
+    public function anAlreadyCorrectEntryReportsNoChange(): void
+    {
+        $data = [
+            'repositories' => [
+                ['type' => 'path', 'url' => '/abs/lib_cwmscripture', 'options' => ['symlink' => true]],
+            ],
+        ];
+
+        $result = $this->sync->sync($data, ['cwm/lib-cwmscripture' => '/abs/lib_cwmscripture']);
+
+        $this->assertFalse($result['changed'], 'A byte-identical rewrite would churn composer.json for nothing');
+    }
+
+    #[Test]
+    public function nonPathRepositoriesAreNeverTouched(): void
+    {
+        $vcs = ['type' => 'vcs', 'url' => 'https://github.com/Joomla-Bible-Study/cwm-build-tools.git'];
+
+        $data = ['repositories' => [$vcs]];
+
+        $result = $this->sync->sync($data, ['cwm/lib-cwmscripture' => '/abs/lib_cwmscripture']);
+
+        $this->assertSame($vcs, $result['data']['repositories'][0], 'The VCS entry must survive untouched');
+        $this->assertCount(2, $result['data']['repositories']);
+    }
+
+    #[Test]
+    public function aMissingRepositoriesBlockIsCreated(): void
+    {
+        $result = $this->sync->sync([], ['cwm/x' => '/abs/x']);
+
+        $this->assertTrue($result['changed']);
+        $this->assertCount(1, $result['data']['repositories']);
+    }
+
+    #[Test]
+    public function anUnrecognisableRepositoriesValueIsLeftAlone(): void
+    {
+        // repositories as a non-array is somebody's deliberate exotic setup;
+        // guessing at it risks destroying what we do not understand.
+        $result = $this->sync->sync(['repositories' => 'https://packages.example.com'], ['cwm/x' => '/abs/x']);
+
+        $this->assertFalse($result['changed']);
+        $this->assertSame('https://packages.example.com', $result['data']['repositories']);
+    }
+
+    #[Test]
+    public function multipleSiblingsResolveIndependently(): void
+    {
+        $data = [
+            'repositories' => [
+                ['type' => 'path', 'url' => '../lib_cwmscripture'],
+                ['type' => 'vcs', 'url' => 'https://example.com/repo.git'],
+            ],
+        ];
+
+        $result = $this->sync->sync($data, [
+            'cwm/lib-cwmscripture'   => '/abs/lib_cwmscripture',
+            'cwm/cwmscripturelinks'  => '/abs/CWMScriptureLinks',
+        ]);
+
+        $this->assertTrue($result['changed']);
+        $this->assertCount(3, $result['data']['repositories']);
+        $this->assertSame('/abs/lib_cwmscripture', $result['data']['repositories'][0]['url']);
+        $this->assertSame('/abs/CWMScriptureLinks', $result['data']['repositories'][2]['url']);
+    }
+}

--- a/tests/Dev/InstallIntakeTest.php
+++ b/tests/Dev/InstallIntakeTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Dev;
+
+use CWM\BuildTools\Dev\InstallConfig;
+use CWM\BuildTools\Dev\InstallIntake;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The role-preservation tests pin the defect this extraction fixed:
+ * scripts/setup.php rebuilt each InstallConfig without `role`, so
+ * re-running `composer setup` silently flipped a `role = test` install
+ * back to `dev` — and a dev-role site is what `cwm-link` symlinks, which
+ * is the precondition for the teardown-deletes-the-repo incident role
+ * separation exists to prevent.
+ */
+class InstallIntakeTest extends TestCase
+{
+    private InstallIntake $intake;
+
+    protected function setUp(): void
+    {
+        $this->intake = new InstallIntake();
+    }
+
+    #[Test]
+    public function reRunningSetupPreservesATestRole(): void
+    {
+        $existing = new InstallConfig(
+            id: 'j6-test',
+            path: '/sites/j6-test',
+            role: InstallConfig::ROLE_TEST,
+        );
+
+        // The user pressed Enter through every prompt — no explicit answers.
+        $rebuilt = $this->intake->assemble('j6-test', ['path' => '/sites/j6-test'], $existing);
+
+        $this->assertSame(
+            InstallConfig::ROLE_TEST,
+            $rebuilt->role,
+            'Re-running setup must never quietly demote a test install to dev'
+        );
+    }
+
+    #[Test]
+    public function anExplicitRoleAnswerOverridesTheExistingRole(): void
+    {
+        $existing = new InstallConfig(id: 'j6', path: '/sites/j6', role: InstallConfig::ROLE_TEST);
+
+        $rebuilt = $this->intake->assemble(
+            'j6',
+            ['path' => '/sites/j6', 'role' => InstallConfig::ROLE_DEV],
+            $existing
+        );
+
+        $this->assertSame(InstallConfig::ROLE_DEV, $rebuilt->role);
+    }
+
+    #[Test]
+    public function aNewInstallDefaultsToDev(): void
+    {
+        $config = $this->intake->assemble('j7', ['path' => '/sites/j7']);
+
+        $this->assertSame(InstallConfig::ROLE_DEV, $config->role);
+    }
+
+    #[Test]
+    public function idsAreNormalisedToLowercase(): void
+    {
+        // Section names in build.properties are lowercase by convention;
+        // LinkResolver and ExtensionVerifier match against the lowercase id.
+        $this->assertSame('j5', $this->intake->normaliseId('J5'));
+    }
+
+    #[Test]
+    public function idsWithInvalidCharactersAreRejected(): void
+    {
+        $this->assertNull($this->intake->normaliseId('j5 dev'));
+        $this->assertNull($this->intake->normaliseId('-j5'));
+        $this->assertNull($this->intake->normaliseId(''));
+    }
+
+    #[Test]
+    public function dashAndUnderscoreIdsAreAccepted(): void
+    {
+        $this->assertSame('j6-test', $this->intake->normaliseId('j6-test'));
+        $this->assertSame('j6_alt', $this->intake->normaliseId('j6_alt'));
+    }
+
+    #[Test]
+    public function rolesAreValidatedAndNormalised(): void
+    {
+        $this->assertSame('dev', $this->intake->normaliseRole(' DEV '));
+        $this->assertSame('test', $this->intake->normaliseRole('test'));
+        $this->assertNull($this->intake->normaliseRole('production'));
+        $this->assertNull($this->intake->normaliseRole(''));
+    }
+
+    #[Test]
+    public function blankAnswersFallBackToTheDocumentedDefaults(): void
+    {
+        $config = $this->intake->assemble('j5', ['path' => '/sites/j5']);
+
+        $this->assertNull($config->url);
+        $this->assertSame('localhost', $config->dbHost());
+        $this->assertSame('admin', $config->adminUser());
+        $this->assertSame('admin@example.com', $config->adminEmail());
+    }
+
+    #[Test]
+    public function givenAnswersWinOverDefaults(): void
+    {
+        $config = $this->intake->assemble('j5', [
+            'path'      => '/sites/j5',
+            'url'       => 'https://j5.local',
+            'dbHost'    => 'db:3307',
+            'adminUser' => 'root-admin',
+        ]);
+
+        $this->assertSame('https://j5.local', $config->url);
+        $this->assertSame('db:3307', $config->dbHost());
+        $this->assertSame('root-admin', $config->adminUser());
+    }
+}

--- a/tests/Dev/SiblingPathGuesserTest.php
+++ b/tests/Dev/SiblingPathGuesserTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Dev;
+
+use CWM\BuildTools\Dev\SiblingPathGuesser;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class SiblingPathGuesserTest extends TestCase
+{
+    private SiblingPathGuesser $guesser;
+
+    private string $tmp;
+
+    protected function setUp(): void
+    {
+        $this->guesser = new SiblingPathGuesser();
+        $this->tmp     = sys_get_temp_dir() . '/cwm-sibling-' . bin2hex(random_bytes(6));
+        mkdir($this->tmp, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->tmp . '/*') ?: [] as $d) {
+            @rmdir($d);
+        }
+        @rmdir($this->tmp);
+    }
+
+    #[Test]
+    public function aDashedComposerNameFindsAnUnderscoredCheckout(): void
+    {
+        // The CWM norm: composer "cwm/lib-cwmscripture", directory
+        // "lib_cwmscripture".
+        mkdir($this->tmp . '/lib_cwmscripture');
+
+        $this->assertSame(
+            $this->tmp . '/lib_cwmscripture',
+            $this->guesser->guess($this->tmp, 'cwm/lib-cwmscripture')
+        );
+    }
+
+    #[Test]
+    public function anExactBasenameMatchWins(): void
+    {
+        mkdir($this->tmp . '/CWMScriptureLinks');
+
+        $this->assertSame(
+            $this->tmp . '/CWMScriptureLinks',
+            $this->guesser->guess($this->tmp, 'cwm/CWMScriptureLinks')
+        );
+    }
+
+    #[Test]
+    public function noCandidateOnDiskMeansNull(): void
+    {
+        $this->assertNull($this->guesser->guess($this->tmp, 'cwm/absent-package'));
+    }
+}


### PR DESCRIPTION
Finishes the `scripts/*.php` list from #32 (shell coverage landed via #52 / #56).

## Extracted, each with a test suite

| Class | From | Pins |
|---|---|---|
| `Build\DistZipResolver` | install-zip.php | explicit `--zip` resolution; newest-**mtime** glob pick, with the deliberate contrast to `lib/artifacts.sh` documented (local testing wants "the zip I just built"; a release selects by **version** and refuses ambiguity) |
| `Cli\Flags` | install-zip.php + verify.php | the `--flag value` / `--flag=value` loop both scripts carried private copies of; prefix non-match pinned |
| `Dev\InstallIntake` | setup.php | id validation + lowercase normalisation, role validation, defaults, `InstallConfig` assembly |
| `Dev\SiblingPathGuesser` | setup.php | dash/underscore candidate set against the sibling layout |
| `Config\ComposerPathRepoSync` | setup.php | the `repositories[]` mutation — the highest-consequence thing cwm-setup does. Match across dash/underscore variants, update-not-duplicate, **non-path entries never touched**, no-op reports unchanged |

`setup.php`, `install-zip.php` and `verify.php` become thin wrappers. `build.php` and `package.php` already were — their logic lives in `PackageBuilder`/`Packager`, tested previously.

## The defect the extraction surfaced (the whole point of #32)

The setup prompt loop rebuilt each `InstallConfig` **without `role`**, so re-running `composer setup` silently demoted a `role = test` install to `dev`. A dev-role site is what `cwm-link` symlinks — the exact precondition for the teardown-deletes-the-repo incident that role separation exists to prevent (the v1.6.1 bug's mirror image, from the other direction).

Fixed and pinned: `assemble()` preserves the existing role, the wizard now prompts for role explicitly (new installs still default to `dev`), and the regression test is named for the incident: `reRunningSetupPreservesATestRole`.

## Verified

- 337 PHP tests (was 306), python + shell suites unchanged
- `php -l` on the three rewired scripts; `--help` smoke on each; setup still refuses to run without `cwm-build.config.json`

With this, every item on #32's affected list is either extracted-and-tested or already a thin wrapper over tested classes — closes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBsju3MSzptws5njS14NaR