### PR TITLE
fix(ars): refuse to publish without ars.environments

### DIFF
--- a/scripts/ars-publish.sh
+++ b/scripts/ars-publish.sh
@@ -8,8 +8,12 @@
 #   categoryId      Numeric ARS category id for releases of this extension
 #   updateStreamId  Numeric ARS update-stream id; the changelog URL is also
 #                   patched on this stream when changelogUrl is set
+#   environments    Non-empty JSON array of ARS environment ids (Joomla / PHP
+#                   versions). Required: publishing an item with no
+#                   environments makes ARS emit update XML with wrong
+#                   php_minimum / targetplatform values that block updates
+#                   on every real site.
 # Optional ars.* fields:
-#   environments     JSON array of ARS environment ids (Joomla / PHP versions)
 #   tokenItem        1Password item label (default: "CWM ARS API Token")
 #   tokenVault       1Password vault (default: "CWM")
 #   zipPrefix        Override the artifact prefix when scanning local builds.
@@ -117,6 +121,15 @@ GH_REPO=$(read_config "github.repo")
 
 if [ -z "$SITE_URL" ] || [ -z "$ARS_CATEGORY_ID" ] || [ -z "$ARS_UPDATE_STREAM_ID" ]; then
     echo "Error: ars.endpoint, ars.categoryId, ars.updateStreamId are required in cwm-build.config.json"
+    exit 1
+fi
+
+# ars.environments must be a non-empty array: an item published without
+# environments makes ARS emit update XML with bogus php_minimum /
+# targetplatform requirements that block the update on every real site.
+if ! cwm_ars_validate_environments "$ARS_ENVIRONMENTS"; then
+    echo "Error: ars.environments must be a non-empty JSON array of ARS environment ids in cwm-build.config.json (got: ${ARS_ENVIRONMENTS})."
+    echo "       Copy the ids from a known-good existing item: GET {endpoint}/api/index.php/v1/ars/items and read its \"environments\" attribute."
     exit 1
 fi
 

--- a/scripts/lib/ars.sh
+++ b/scripts/lib/ars.sh
@@ -116,3 +116,31 @@ for i in d.get('data', []):
         break
 " "$1" 2>/dev/null || true
 }
+
+# Validate the configured ars.environments value.
+#
+# An item published with no environments makes ARS emit update XML with
+# bogus php_minimum / targetplatform requirements that block the update
+# on every real site (Proclaim 10.3.4-10.4.0 shipped invisible to
+# Joomla 5 and "requires PHP 8.5" this way). The publish must refuse to
+# run rather than ship that.
+#
+# Arguments:
+#   $1  the ars.environments config value as JSON (read_config_json
+#       output: a JSON array, or the literal string "null" when unset)
+#
+# Returns:
+#   0 when the value is a non-empty JSON array of ids, 1 otherwise.
+cwm_ars_validate_environments() {
+    python3 -c "
+import json, sys
+
+try:
+    v = json.loads(sys.argv[1])
+except (ValueError, IndexError):
+    sys.exit(1)
+ok = isinstance(v, list) and len(v) > 0 \
+    and all(isinstance(e, (str, int)) and str(e).strip().isdigit() for e in v)
+sys.exit(0 if ok else 1)
+" "$1" 2>/dev/null
+}

--- a/tests/shell/ars.test.sh
+++ b/tests/shell/ars.test.sh
@@ -91,4 +91,23 @@ assert_equals "" "$got" "an item without a url is skipped"
 got="$(printf '%s' 'not json' | cwm_ars_find_item_id pkg_proclaim-10.3.6.zip)"
 assert_equals "" "$got" "malformed JSON yields nothing"
 
+# --- Environments validation -------------------------------------------------
+# Publishing an item with NO environments makes ARS emit update XML with
+# bogus php_minimum / targetplatform values that block the update on every
+# real site (Proclaim 10.3.4-10.4.0). The publish must refuse instead.
+
+check_envs() {
+    if cwm_ars_validate_environments "$1"; then echo ok; else echo fail; fi
+}
+
+assert_equals "ok" "$(check_envs '["45","46","48","49","50"]')" "a string-id array is valid"
+assert_equals "ok" "$(check_envs '[45, 46]')" "a numeric-id array is valid"
+assert_equals "fail" "$(check_envs 'null')" "an unset key (json null) is refused"
+assert_equals "fail" "$(check_envs '[]')" "an empty array is refused"
+assert_equals "fail" "$(check_envs '')" "an empty string is refused"
+assert_equals "fail" "$(check_envs '"45"')" "a bare string is refused: must be an array"
+assert_equals "fail" "$(check_envs '{"45": true}')" "an object is refused"
+assert_equals "fail" "$(check_envs '["45", ""]')" "a blank id inside the array is refused"
+assert_equals "fail" "$(check_envs 'not json')" "malformed JSON is refused"
+
 finish


### PR DESCRIPTION
Closes #58.

`read_config_json "ars.environments"` yields the literal `null` when the key is absent, and the item payload shipped it verbatim — ARS then emits update XML requiring PHP 8.5 / Joomla 6.1+, which blocked or hid Proclaim 10.3.4–10.4.0 on every real site.

- `ars.environments` documented as **required** (non-empty JSON array of environment ids)
- `cwm_ars_validate_environments` added to `scripts/lib/ars.sh`; the publish exits with a pointer to a known-good item's `environments` attribute before any API call
- 9 new cases in `tests/shell/ars.test.sh` (valid string/numeric arrays; refused: null, `[]`, empty string, bare string, object, blank id, malformed JSON)

All shell suites green: ars 26, artifacts 11, bullets 13, notes 8, version 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBsju3MSzptws5njS14NaR