### PR TITLE
feat(build): fail the build when media output has no source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`build.verifyMediaSources` — fail the build on output that outlived its
+  source.** `verifyAssets` catches an asset the manifest references that the
+  build never produced; this catches the inverse, a file in `media/` no source
+  can reproduce. Configured as `{ source, output }` directory pairs, opt-in per
+  project.
+
+  lib_cwmscripture shipped `media/lib_cwmscripture/js/translations-manager.min.js`
+  (plus its `.gz` and `.map`) in every release for months after the source was
+  renamed to `bible-translations.es6.js`. Minified output is gitignored, so no
+  checkout, branch switch or pull ever removed it, and the packager ships whatever
+  is in `media/`. The published v1.1.6 zip contained 90 files where a fresh build
+  of the same tag produced 87.
+
+  Nothing referenced the stale files, so there was no error to notice — it
+  surfaced only by comparing the published asset against a build from another
+  checkout. The real damage is that the release artifact stops being a function of
+  the source and becomes a function of the source *plus that machine's build
+  history*: two developers on the same tag produce different packages, and the
+  library inside `pkg_proclaim` differed from the published library of the same
+  version. Re-publishing a corrected artifact then invalidates the checksums the
+  update server recorded at publish time.
+
+  Matching handles every derived form (`.min`, `.map`, `.gz`, `.es6`/`.esm`
+  sources), ignores non-build files such as `joomla.asset.json` and `index.html`,
+  and checks only the top level of each output dir — subdirectories are usually
+  copied third-party payloads whose layout has no relationship to `media_source`.
+
 ## [1.11.0] - 2026-07-29
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,51 @@ Consumed by `cwm-build` / `cwm-package`.
 | `vendorPrune` | Strip composer metadata/docs from `vendor/` subtrees. |
 | `preBuild` | `{ mode: "ensure-minified", dirs[] }` or `{ mode: "run", command }` (e.g. `npm run build`). Runs before zipping. |
 | `verifyAssets` | `true` to fail the build if a `joomla.asset.json`-referenced file is missing. See the [JS guide](javascript-and-joomladialog.md#72-buildverifyassets-fail-loudly-if-an-asset-didnt-build). |
+| `verifyMediaSources[]` | `{ source, output }` directory pairs. Fails the build when a file in `output` has no matching source in `source` — i.e. build output that outlived its source. See below. |
 | `versionPrompt` | `{ enabled, timeout }` for the interactive 3-way version prompt. |
+
+#### `verifyMediaSources` — catch build output that outlived its source
+
+`verifyAssets` catches an asset the manifest references that the build never
+produced. This catches the opposite: a file in `media/` that no source can
+reproduce.
+
+```json
+"verifyMediaSources": [
+    { "source": "build/media_source/js",  "output": "media/lib_cwmscripture/js" },
+    { "source": "build/media_source/css", "output": "media/lib_cwmscripture/css" }
+]
+```
+
+Why it exists: minified output is gitignored, so when a source file is renamed or
+deleted, its old output is not removed by any checkout, branch switch or pull. It
+just sits in `media/`, and the packager ships whatever is there. lib_cwmscripture
+shipped `translations-manager.min.js` (plus `.gz` and `.map`) in every release for
+months after the source became `bible-translations.es6.js` — the published v1.1.6
+zip had 90 files where a fresh build of the same tag had 87. Nothing referenced
+them, so there was no error to notice.
+
+The cost of that is not cosmetic: the release artifact stops being a function of
+the source and becomes a function of the source *plus that machine's build
+history*, so two developers on the same tag produce different packages. Fixing it
+after publication also invalidates the checksums the update server recorded at
+publish time.
+
+Matching rules:
+
+- `foo.min.js`, `foo.min.js.gz`, `foo.min.js.map` and `foo.js` all trace back to
+  `foo` — satisfied by `foo.es6.js`, `foo.esm.js` or `foo.js` in the source dir.
+- Files that are not `.js` / `.mjs` / `.css` (or a `.map` / `.gz` of one) are
+  ignored: `joomla.asset.json`, `index.html`, licence files.
+- Only the top level of each `output` dir is checked. Subdirectories are usually
+  copied third-party payloads whose layout has no relationship to `media_source`,
+  and flagging those would just teach people to switch the check off.
+- A pair whose `output` dir does not exist is skipped; a missing `source` dir is
+  an error, since that is a config typo.
+
+Opt-in per project: a tree that keeps hand-maintained files in the same directory
+as build output would fail, so point the pairs at the directories your build
+actually owns.
 
 ### The `security` block
 

--- a/src/Build/BuildConfig.php
+++ b/src/Build/BuildConfig.php
@@ -37,6 +37,7 @@ final class BuildConfig
      * @param list<string>                          $includeRootExtensions  When set with `includeRoots`, allows root-level files with these extensions through the include filter.
      * @param array{mode: string, dirs?: list<string>, command?: string}|null $preBuild Optional pre-build hook.
      * @param array{enabled: bool, timeout: int}|null $versionPrompt Optional 3-way version prompt (manifest / date-stamped / custom). Only fires when interactive AND no `--version` override is given.
+     * @param list<array{source: string, output: string}> $verifyMediaSources Source/output directory pairs; every built file in `output` must trace back to a source in `source`.
      */
     public function __construct(
         public readonly string $outputDir,
@@ -54,6 +55,7 @@ final class BuildConfig
         public readonly array $includeRootExtensions = [],
         public readonly ?array $versionPrompt = null,
         public readonly bool $verifyAssets = false,
+        public readonly array $verifyMediaSources = [],
     ) {
     }
 
@@ -172,7 +174,48 @@ final class BuildConfig
             includeRootExtensions: $includeRootExtensions,
             versionPrompt:         $versionPrompt,
             verifyAssets:          isset($cfg['verifyAssets']) ? (bool) $cfg['verifyAssets'] : false,
+            verifyMediaSources:    self::mediaSourcePairs($cfg),
         );
+    }
+
+    /**
+     * Validate `verifyMediaSources`: a list of {source, output} directory pairs.
+     *
+     * @param  array<string, mixed> $cfg
+     * @return list<array{source: string, output: string}>
+     */
+    private static function mediaSourcePairs(array $cfg): array
+    {
+        if (!isset($cfg['verifyMediaSources'])) {
+            return [];
+        }
+
+        if (!is_array($cfg['verifyMediaSources'])) {
+            throw new \InvalidArgumentException('build.verifyMediaSources must be an array of {source, output} objects');
+        }
+
+        $pairs = [];
+
+        foreach ($cfg['verifyMediaSources'] as $i => $pair) {
+            if (!is_array($pair) || !isset($pair['source'], $pair['output'])) {
+                throw new \InvalidArgumentException(
+                    "build.verifyMediaSources[$i] must be an object with `source` and `output`"
+                );
+            }
+
+            $source = (string) $pair['source'];
+            $output = (string) $pair['output'];
+
+            if (trim($source) === '' || trim($output) === '') {
+                throw new \InvalidArgumentException(
+                    "build.verifyMediaSources[$i] `source` and `output` must be non-empty"
+                );
+            }
+
+            $pairs[] = ['source' => $source, 'output' => $output];
+        }
+
+        return $pairs;
     }
 
     /**

--- a/src/Build/PackageBuilder.php
+++ b/src/Build/PackageBuilder.php
@@ -81,6 +81,10 @@ final class PackageBuilder
             $this->verifyAssetReferences();
         }
 
+        if ($this->config->verifyMediaSources !== []) {
+            $this->verifyMediaSourceParity();
+        }
+
         $outputDir = $this->resolve($this->config->outputDir);
 
         if (!is_dir($outputDir) && !mkdir($outputDir, 0o777, true) && !is_dir($outputDir)) {
@@ -328,6 +332,122 @@ final class PackageBuilder
             );
             exit(1);
         }
+    }
+
+    /**
+     * Fail when a built media file has no source to have been built from.
+     *
+     * `verifyAssets` catches the opposite problem — an asset the manifest
+     * references that the build never produced. This catches output that outlives
+     * its source, which is invisible for as long as nothing loads it.
+     *
+     * It has happened: lib_cwmscripture shipped
+     * `media/lib_cwmscripture/js/translations-manager.min.js` (plus `.gz` and
+     * `.map`) in every release for months after `translations-manager.es6.js` was
+     * replaced by `bible-translations.es6.js`. Minified output is gitignored, so no
+     * checkout, branch switch or pull ever removed it, and the packager ships
+     * whatever sits in `media/`. The published v1.1.6 asset had 90 files where a
+     * fresh build of the same tag had 87 — the release artifact was a function of
+     * the source *plus that machine's build history*.
+     *
+     * Nothing referenced those files, so there was no error to notice. Re-publishing
+     * a corrected artifact later is not free either: it invalidates the checksums
+     * the update server recorded at publish time.
+     *
+     * Only the top level of each output directory is checked. Subdirectories are
+     * usually third-party payloads (a copied vendor library) whose layout has no
+     * relationship to `media_source`, and flagging those would train people to
+     * disable the check.
+     *
+     * @throws \RuntimeException When an orphaned build artifact is found.
+     */
+    private function verifyMediaSourceParity(): void
+    {
+        $orphans = [];
+
+        foreach ($this->config->verifyMediaSources as $pair) {
+            $outputDir = $this->resolve($pair['output']);
+            $sourceDir = $this->resolve($pair['source']);
+
+            if (!is_dir($outputDir)) {
+                continue;
+            }
+
+            if (!is_dir($sourceDir)) {
+                throw new \RuntimeException(
+                    "build.verifyMediaSources: source directory not found: {$pair['source']}"
+                );
+            }
+
+            $sourceBases = [];
+
+            foreach ((array) scandir($sourceDir) as $entry) {
+                if (!is_file($sourceDir . '/' . $entry)) {
+                    continue;
+                }
+
+                $sourceBases[self::sourceBaseName($entry)] = true;
+            }
+
+            foreach ((array) scandir($outputDir) as $entry) {
+                if (!is_file($outputDir . '/' . $entry)) {
+                    continue;
+                }
+
+                $base = self::outputBaseName($entry);
+
+                // null = not a build product (joomla.asset.json, index.html, a
+                // licence file). Those are shipped as-is and have no source.
+                if ($base === null || isset($sourceBases[$base])) {
+                    continue;
+                }
+
+                $orphans[] = $pair['output'] . '/' . $entry;
+            }
+        }
+
+        if ($orphans === []) {
+            return;
+        }
+
+        throw new \RuntimeException(
+            "Media verification failed — built files with no corresponding source:\n  - "
+            . implode("\n  - ", $orphans)
+            . "\n\nTheir source was removed or renamed, but the build output survived because it is\n"
+            . "gitignored. Packaging them makes the release artifact depend on this machine's build\n"
+            . "history rather than on the source tree. Delete them (`git clean -Xfd <media dir>`)\n"
+            . "and rebuild, or add the source back if the removal was a mistake."
+        );
+    }
+
+    /**
+     * Base name of a source file: `foo.es6.js` -> `foo`, `foo.scss` -> `foo`.
+     */
+    private static function sourceBaseName(string $filename): string
+    {
+        $base = preg_replace('/\.[^.]+$/', '', $filename) ?? $filename;
+
+        // Strip the ES-module marker so foo.es6.js and foo.js agree on `foo`.
+        return preg_replace('/\.(es6|esm)$/i', '', $base) ?? $base;
+    }
+
+    /**
+     * Base name of a build product, or null when the file is not one.
+     *
+     * `foo.min.js.gz` / `foo.min.js.map` / `foo.min.js` / `foo.js` -> `foo`
+     */
+    private static function outputBaseName(string $filename): ?string
+    {
+        $name = preg_replace('/\.gz$/i', '', $filename) ?? $filename;
+        $name = preg_replace('/\.map$/i', '', $name) ?? $name;
+
+        if (!preg_match('/\.(js|mjs|css)$/i', $name)) {
+            return null;
+        }
+
+        $name = preg_replace('/\.[^.]+$/', '', $name) ?? $name;
+
+        return preg_replace('/\.min$/i', '', $name) ?? $name;
     }
 
     /**

--- a/tests/Build/PackageBuilderTest.php
+++ b/tests/Build/PackageBuilderTest.php
@@ -680,6 +680,173 @@ final class PackageBuilderTest extends TestCase
     /**
      * @return array<string, mixed>
      */
+    // ---------------------------------------------------------------------
+    // verifyMediaSources — build output that outlived its source
+    // ---------------------------------------------------------------------
+
+    /**
+     * The lib_cwmscripture case: translations-manager.es6.js was replaced by
+     * bible-translations.es6.js, but the minified output is gitignored, so it
+     * survived every checkout and shipped in releases for months.
+     */
+    #[Test]
+    public function failsWhenBuiltMediaHasNoSource(): void
+    {
+        $this->seedMediaParityFixture();
+
+        // Output whose source is gone — plus the derived files that travel with it.
+        $this->writeFile('media/lib_cwmscripture/js/translations-manager.min.js', 'stale');
+        $this->writeFile('media/lib_cwmscripture/js/translations-manager.min.js.gz', 'stale');
+        $this->writeFile('media/lib_cwmscripture/js/translations-manager.min.js.map', '{}');
+
+        $builder = new PackageBuilder($this->mediaParityConfig(), $this->tmpDir);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/translations-manager\.min\.js/');
+
+        $builder->build();
+    }
+
+    #[Test]
+    public function reportsEveryOrphanNotJustTheFirst(): void
+    {
+        $this->seedMediaParityFixture();
+        $this->writeFile('media/lib_cwmscripture/js/gone.min.js', 'stale');
+        $this->writeFile('media/lib_cwmscripture/css/also-gone.min.css', 'stale');
+
+        $builder = new PackageBuilder($this->mediaParityConfig(), $this->tmpDir);
+
+        try {
+            $builder->build();
+            $this->fail('Expected the orphan check to fail the build.');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('gone.min.js', $e->getMessage());
+            $this->assertStringContainsString('also-gone.min.css', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function acceptsEveryDerivedFormOfALiveSource(): void
+    {
+        $this->seedMediaParityFixture();
+
+        // All of these trace back to foo.es6.js / foo.css.
+        $this->writeFile('media/lib_cwmscripture/js/foo.min.js.gz', 'x');
+        $this->writeFile('media/lib_cwmscripture/js/foo.min.js.map', '{}');
+        $this->writeFile('media/lib_cwmscripture/css/foo.min.css.map', '{}');
+
+        // Not build products, so they need no source.
+        $this->writeFile('media/lib_cwmscripture/js/joomla.asset.json', '{}');
+        $this->writeFile('media/lib_cwmscripture/js/index.html', '');
+        $this->writeFile('media/lib_cwmscripture/css/LICENSE.txt', '');
+
+        $builder = new PackageBuilder($this->mediaParityConfig(), $this->tmpDir);
+
+        $this->expectOutputRegex('/Building lib_cwmscripture-1\.2\.0\.zip/');
+
+        $this->assertFileExists($builder->build());
+    }
+
+    #[Test]
+    public function ignoresSubdirectoriesOfTheOutputDirectory(): void
+    {
+        $this->seedMediaParityFixture();
+
+        // A copied third-party payload: no relationship to media_source, and
+        // flagging it would teach people to switch the check off.
+        $this->writeFile('media/lib_cwmscripture/js/vendor/chart.js/chart.min.js', 'x');
+
+        $builder = new PackageBuilder($this->mediaParityConfig(), $this->tmpDir);
+
+        $this->expectOutputRegex('/Building lib_cwmscripture-1\.2\.0\.zip/');
+
+        $this->assertFileExists($builder->build());
+    }
+
+    #[Test]
+    public function skipsPairsWhoseOutputDirectoryIsAbsent(): void
+    {
+        $this->seedMediaParityFixture();
+
+        $config = BuildConfig::fromArray(array_merge($this->libConfigArray(), [
+            'preBuild'           => null,
+            'verifyMediaSources' => [
+                ['source' => 'build/media_source/js', 'output' => 'media/lib_cwmscripture/js'],
+                ['source' => 'build/media_source/js', 'output' => 'media/not-built-here'],
+            ],
+        ]));
+
+        $builder = new PackageBuilder($config, $this->tmpDir);
+
+        $this->expectOutputRegex('/Building lib_cwmscripture-1\.2\.0\.zip/');
+
+        $this->assertFileExists($builder->build());
+    }
+
+    #[Test]
+    public function failsLoudlyWhenTheConfiguredSourceDirectoryIsMissing(): void
+    {
+        $this->seedMediaParityFixture();
+
+        $config = BuildConfig::fromArray(array_merge($this->libConfigArray(), [
+            'preBuild'           => null,
+            'verifyMediaSources' => [
+                ['source' => 'build/media_source/typo', 'output' => 'media/lib_cwmscripture/js'],
+            ],
+        ]));
+
+        $builder = new PackageBuilder($config, $this->tmpDir);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/source directory not found: build\/media_source\/typo/');
+
+        $builder->build();
+    }
+
+    #[Test]
+    public function rejectsMalformedVerifyMediaSourcesConfig(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/`source` and `output`/');
+
+        BuildConfig::fromArray(array_merge($this->libConfigArray(), [
+            'verifyMediaSources' => [['source' => 'build/media_source/js']],
+        ]));
+    }
+
+    /**
+     * A minimal project with one live JS source and one live CSS source, plus the
+     * manifest and the outputs a real build would leave behind.
+     */
+    private function seedMediaParityFixture(): void
+    {
+        $this->writeManifest('cwmscripture.xml', '1.2.0');
+        $this->writeFile('script.php', '<?php // install hook');
+        $this->writeFile('src/Service/Foo.php', '<?php // foo');
+        $this->writeFile('sql/install.mysql.utf8.sql', '-- DDL');
+        $this->writeFile('language/en-GB/en-GB.lib_cwmscripture.ini', '');
+
+        $this->writeFile('build/media_source/js/foo.es6.js', 'export default 1;');
+        $this->writeFile('build/media_source/css/foo.css', '.foo{}');
+
+        $this->writeFile('media/lib_cwmscripture/js/foo.js', 'console.log(1);');
+        $this->writeFile('media/lib_cwmscripture/js/foo.min.js', 'console.log(1)');
+        $this->writeFile('media/lib_cwmscripture/css/foo.css', '.foo{}');
+        $this->writeFile('media/lib_cwmscripture/css/foo.min.css', '.foo{}');
+    }
+
+    private function mediaParityConfig(): BuildConfig
+    {
+        // preBuild off: ensure-minified would fire first and mask what is under test.
+        return BuildConfig::fromArray(array_merge($this->libConfigArray(), [
+            'preBuild'           => null,
+            'verifyMediaSources' => [
+                ['source' => 'build/media_source/js',  'output' => 'media/lib_cwmscripture/js'],
+                ['source' => 'build/media_source/css', 'output' => 'media/lib_cwmscripture/css'],
+            ],
+        ]));
+    }
+
     private function libConfigArray(): array
     {
         return [


### PR DESCRIPTION
Implements the tooling half of Joomla-Bible-Study/lib_cwmscripture#25.

## The failure this prevents

The published `lib_cwmscripture-1.1.6.zip` contained three files no build could reproduce:

```
media/lib_cwmscripture/js/translations-manager.min.js
media/lib_cwmscripture/js/translations-manager.min.js.gz
media/lib_cwmscripture/js/translations-manager.min.js.map
```

Output of a source renamed to `bible-translations.es6.js` months earlier. Minified output is gitignored, so no checkout, branch switch or pull ever removed it — it sat in `media/`, and the packager ships whatever is there.

| | Files |
|---|---|
| Published v1.1.6 asset | 90 |
| Fresh build of the same tag | 87 |

Nothing referenced them, so there was no error, no missing-asset warning, nothing to notice. It surfaced only by comparing the published asset against a build from a different checkout.

The dead bytes are not the problem. **The release artifact stopped being a function of the source** and became a function of the source *plus that machine's build history* — two developers on the same tag produce different packages, and the library bundled inside `pkg_proclaim` (built locally, no stale files) differed from the published library of the same version number. Correcting it after publication is not free either: re-uploading invalidated the checksums ARS recorded at publish time, which Joomla verifies against the download, so the ARS item needed patching or the update would have failed integrity checking.

## What this adds

`build.verifyMediaSources` — `{ source, output }` directory pairs. Every file in `output` must trace back to a source in `source`, or the build fails listing every orphan:

```json
"verifyMediaSources": [
    { "source": "build/media_source/js",  "output": "media/lib_cwmscripture/js" },
    { "source": "build/media_source/css", "output": "media/lib_cwmscripture/css" }
]
```

It is the inverse of the existing `verifyAssets`: that catches an asset the manifest references that the build never produced, this catches output that outlived its source.

**Opt-in**, deliberately. A project that keeps hand-maintained files beside build output would fail — Proclaim copies vendor libraries into `media/vendor/`, for instance — so each project points the pairs at the directories its build actually owns.

Design decisions worth flagging, since each is a place the check could have been annoying instead of useful:

- **Every derived form counts as satisfied.** `foo.min.js`, `foo.min.js.gz`, `foo.min.js.map` and `foo.js` all reduce to `foo`, matched by `foo.es6.js`, `foo.esm.js` or `foo.js`.
- **Non-build files are ignored** — `joomla.asset.json`, `index.html`, licence files. They are shipped as-is and have no source.
- **Only the top level of each output dir is checked.** Subdirectories are usually copied third-party payloads whose layout has no relationship to `media_source`; flagging them would train people to disable the check.
- **A missing `output` dir is skipped** (the project may not build that kind of asset), but **a missing `source` dir is an error** — that is a config typo, not a state a build can legitimately be in.
- **Throws rather than `exit(1)`**, unlike `verifyAssets`, so it is testable. `scripts/build.php` already catches `\Throwable` and exits non-zero with the message.

## Tests

Seven new cases in `PackageBuilderTest`, all against a real temp fixture project:

- the exact lib_cwmscripture scenario — `translations-manager.min.js` + `.gz` + `.map` with no source — fails the build
- every orphan is reported, not just the first
- all derived forms of a live source are accepted, and non-build files need no source
- subdirectories are ignored
- a pair with a missing output dir is skipped; a missing source dir throws
- malformed config is rejected by `BuildConfig`

Full suite green: 379 PHP tests / 918 assertions, plus the python and shell suites.

## Follow-up

Consumers need `composer update cwm/build-tools` and the config block before they benefit. The issue also suggests pruning ignored output before the build (`git clean -Xfd media/`), which cannot live in the packager — `media/` output is gitignored, so pruning after `npm run build` would delete the fresh output it is meant to protect. That belongs in the project's npm build chain, and is worth doing alongside this rather than instead of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ti98Cc63bmWcXva2G4GdNq
