### PR TITLE
feat(bump): rewrite version literals held in source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`versionTracking.sourceFiles` — cwm-bump rewrites version literals held in
+  source.** For a hardcoded constant shipping beside the manifest
+  (`public const VERSION = '1.2.3';`) that nothing in the toolchain wrote, so it
+  drifted. lib_cwmscripture's `LibraryVersion::VERSION` sat a release behind its
+  manifest while `satisfies()` and `needsUpgrade()` read it, telling downstream
+  extensions the library was older than it was
+  (Joomla-Bible-Study/lib_cwmscripture#15).
+
+  Configured as literal lines with a `{version}` placeholder rather than regexes,
+  so an author pastes the line they can see and cannot accidentally turn `$` or
+  `(` into syntax. The placeholder accepts pre-release and build suffixes and is
+  anchored to digits, so version-shaped text on unmatched lines — `@since` tags,
+  unrelated constants — is untouched.
+
+  A pattern that matches nothing throws instead of warning, as do a missing file,
+  a missing placeholder and a malformed entry: a rewrite that silently does
+  nothing is how the drift happens, so it has to stop the bump.
+
 ## [1.12.0] - 2026-07-30
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,51 @@ cwm-init` rather than authoring by hand. Minimal examples live in
 | `github` | `{ owner, repo, releaseBranch }` for release + changelog. |
 | `changelog` | `{ file, url }` — the Joomla changelog XML path and its raw URL. |
 | `announcement` | `{ command, bulletsDir }` for the release announcement article. |
-| `versionTracking` | Override layer, deep-merged on top of the profile. `versionsJson`, `packageJson`, `substituteTokens.paths[]`. **Lists replace wholesale.** |
+| `versionTracking` | Override layer, deep-merged on top of the profile. `versionsJson`, `packageJson`, `substituteTokens.paths[]`, `sourceFiles[]`. **Lists replace wholesale.** See [source-file version literals](#versiontrackingsourcefiles--version-literals-in-source) below. |
+
+### `versionTracking.sourceFiles` — version literals in source
+
+For a version hardcoded in code that ships beside the manifest — the shape
+`public const VERSION = '1.2.3';` — which nothing else in the toolchain writes,
+so it drifts. `cwm-bump` rewrites it along with the manifest:
+
+```json
+"versionTracking": {
+    "sourceFiles": [
+        { "path": "src/LibraryVersion.php",
+          "pattern": "public const VERSION = '{version}';" }
+    ]
+}
+```
+
+Why this exists: lib_cwmscripture's `LibraryVersion::VERSION` sat at 1.1.3 while
+its manifest said 1.1.4, and `satisfies()` / `needsUpgrade()` read that constant —
+so downstream extensions gating on a minimum library version were answered from a
+stale number and could refuse a library that was new enough.
+
+**Patterns are literals, not regexes.** The whole string is quoted and only
+`{version}` becomes a capture, so you paste the line as it appears in the file
+and `$`, `(` or `.` match themselves. That also keeps a pattern reviewable by
+someone who does not write regex.
+
+`{version}` matches a semver-ish token including pre-release and build suffixes
+(`1.2.3`, `1.2.3-beta1`, `1.2.3-dev`), anchored to digits so a pattern cannot
+drift onto arbitrary text. A version-shaped literal on a line the pattern does
+not match — an `@since` tag, an unrelated constant — is left alone.
+
+Unlike the JSON trackers, problems here are **fatal rather than warnings**:
+
+| Situation | Result |
+|---|---|
+| Pattern matches nothing | throws, naming the file and pattern |
+| `path` missing on disk | throws |
+| `pattern` has no `{version}` | throws |
+| Entry missing `path` or `pattern` | throws |
+| File already at the target version | no-op, reported as `(no change)` |
+
+That is deliberate. A rewrite that silently does nothing is precisely how the
+version drifted in the first place, so a misconfigured entry has to stop the
+bump rather than let a stale literal ship.
 | `assets` | Source-tree asset staging (`images`, `vendorMediaSource`, `packages[]`). Source paths, not install paths. |
 | `dev` | Optional dev-link overrides — `deriveLinks`, `links[]`, `internalLinks[]`, `cwmSiblings`. |
 | `gitignore` | `{ outputPaths[], mediaPaths[] }` feeding the managed `.gitignore` block. |

--- a/src/Release/VersionTracker.php
+++ b/src/Release/VersionTracker.php
@@ -18,17 +18,25 @@ namespace CWM\BuildTools\Release;
  *
  * The class is intentionally narrow:
  *   - updateForBump:    write the dev-side fields (active_development, package.json)
+ *                       and any configured source-file version literals
  *   - updateForRelease: write the post-release fields (current, next.*, _updated)
  *
  * Each method touches only files explicitly listed in the project's
  * `versionTracking` block. Absent block → no-op. Missing file on disk →
  * stderr warning + skip (same posture as bump.php's missing-manifest path).
  * Malformed JSON → throw (caller exits non-zero).
+ *
+ * `sourceFiles` is the exception to the skip-and-warn posture: a pattern that
+ * matches nothing throws. A version literal living in source is invisible until
+ * a consumer reads it and gets a stale answer — lib_cwmscripture's
+ * LibraryVersion::VERSION sat a release behind while satisfies() told downstream
+ * extensions the library was too old — so a rewrite that silently does nothing is
+ * the exact failure this feature exists to remove.
  */
 final class VersionTracker
 {
     /**
-     * @param  array{versionsJson?: string, packageJson?: string} $config
+     * @param  array{versionsJson?: string, packageJson?: string, sourceFiles?: list<array{path: string, pattern: string}>} $config
      *         The `versionTracking` block from cwm-build.config.json.
      */
     public function __construct(
@@ -61,6 +69,10 @@ final class VersionTracker
             }
         }
 
+        foreach ($this->rewriteSourceFiles($version) as $path) {
+            $touched[] = $path;
+        }
+
         return $touched;
     }
 
@@ -85,6 +97,127 @@ final class VersionTracker
         }
 
         return $touched;
+    }
+
+    /**
+     * Rewrite version literals held in source files.
+     *
+     * For hardcoded constants that ship alongside the manifest — the shape
+     * `public const VERSION = '1.2.3';` — which nothing else in the toolchain
+     * writes, so they drift.
+     *
+     * Configured as literal lines with a `{version}` placeholder rather than
+     * regexes:
+     *
+     *     "sourceFiles": [
+     *         { "path": "src/LibraryVersion.php",
+     *           "pattern": "public const VERSION = '{version}';" }
+     *     ]
+     *
+     * The pattern is escaped and only the placeholder becomes a capture, so an
+     * author writes the line they can see in the file and cannot accidentally
+     * turn `$` or `(` into syntax. It also means a pattern is readable in review
+     * by someone who does not write regex.
+     *
+     * @return list<string> Files rewritten.
+     *
+     * @throws \RuntimeException When a configured pattern matches nothing, or
+     *                          matches a version this rewrite cannot pin down.
+     */
+    private function rewriteSourceFiles(string $version): array
+    {
+        $entries = $this->config['sourceFiles'] ?? [];
+
+        if (!is_array($entries) || $entries === []) {
+            return [];
+        }
+
+        $touched = [];
+
+        foreach ($entries as $i => $entry) {
+            if (!is_array($entry) || !isset($entry['path'], $entry['pattern'])) {
+                throw new \RuntimeException(
+                    "versionTracking.sourceFiles[$i] must be an object with `path` and `pattern`"
+                );
+            }
+
+            $relative = (string) $entry['path'];
+            $pattern  = (string) $entry['pattern'];
+            $absolute = $this->projectRoot . '/' . $relative;
+
+            if (!is_file($absolute)) {
+                // Unlike the JSON trackers this is fatal: the file is named
+                // explicitly, so its absence is a broken config, and skipping
+                // would leave a stale version shipping.
+                throw new \RuntimeException(
+                    "versionTracking.sourceFiles[$i] path not found: $relative"
+                );
+            }
+
+            if (!str_contains($pattern, '{version}')) {
+                throw new \RuntimeException(
+                    "versionTracking.sourceFiles[$i] pattern must contain the {version} placeholder"
+                );
+            }
+
+            $contents = (string) file_get_contents($absolute);
+            $regex    = $this->patternToRegex($pattern);
+
+            if (preg_match_all($regex, $contents, $matches) === 0) {
+                throw new \RuntimeException(
+                    "versionTracking.sourceFiles[$i]: pattern did not match anything in $relative\n"
+                    . "  pattern: $pattern\n"
+                    . '  Nothing was rewritten. Check the literal against the file — a pattern that '
+                    . 'silently matches nothing is how a version drifts in the first place.'
+                );
+            }
+
+            $replacement = str_replace('{version}', $version, $pattern);
+            $updated     = preg_replace($regex, $this->escapeReplacement($replacement), $contents);
+
+            if ($updated === null) {
+                throw new \RuntimeException("versionTracking.sourceFiles[$i]: rewrite failed for $relative");
+            }
+
+            if ($updated === $contents) {
+                echo "  $relative (no change)\n";
+
+                continue;
+            }
+
+            file_put_contents($absolute, $updated);
+            echo "  $relative → version=$version\n";
+            $touched[] = $absolute;
+        }
+
+        return $touched;
+    }
+
+    /**
+     * Turn a literal pattern into a regex: everything quoted, `{version}`
+     * standing in for a semver-ish token.
+     *
+     * The token deliberately accepts pre-release and build suffixes
+     * (`1.2.3-beta1`, `1.2.3-dev`) because bump.php accepts them, and stays
+     * anchored to digits so a pattern cannot drift onto arbitrary text.
+     */
+    private function patternToRegex(string $pattern): string
+    {
+        $parts = array_map(
+            static fn (string $part): string => preg_quote($part, '/'),
+            explode('{version}', $pattern)
+        );
+
+        return '/' . implode('\\d+\\.\\d+\\.\\d+[0-9A-Za-z.\\-+]*', $parts) . '/';
+    }
+
+    /**
+     * Escape a literal replacement so `$1`-style sequences in the pattern are
+     * not read as backreferences by preg_replace.
+     */
+    private function escapeReplacement(string $replacement): string
+    {
+        return str_replace(['\\', '$'], ['\\\\', '\\$'], $replacement);
     }
 
     /**

--- a/tests/Release/VersionTrackerTest.php
+++ b/tests/Release/VersionTrackerTest.php
@@ -198,6 +198,181 @@ final class VersionTrackerTest extends TestCase
     /**
      * @param array{versionsJson?: string, packageJson?: string} $config
      */
+    // -----------------------------------------------------------------
+    // sourceFiles — version literals held in source
+    // -----------------------------------------------------------------
+
+    #[Test]
+    public function source_files_rewrites_a_version_constant(): void
+    {
+        $this->seedSourceFile("    public const VERSION = '1.1.7';\n");
+
+        $touched = $this->runQuiet(fn () => $this->tracker([
+            'sourceFiles' => [
+                ['path' => 'src/LibraryVersion.php', 'pattern' => "public const VERSION = '{version}';"],
+            ],
+        ])->updateForBump('1.2.0'));
+
+        self::assertCount(1, $touched);
+        self::assertStringContainsString("public const VERSION = '1.2.0';", $this->readSourceFile());
+    }
+
+    #[Test]
+    public function source_files_leaves_the_rest_of_the_file_alone(): void
+    {
+        $this->seedSourceFile(
+            "    /** @since 1.0.0 */\n"
+            . "    public const VERSION = '1.1.7';\n"
+            . "    public const OTHER = '1.1.7';\n"
+        );
+
+        $this->runQuiet(fn () => $this->tracker([
+            'sourceFiles' => [
+                ['path' => 'src/LibraryVersion.php', 'pattern' => "public const VERSION = '{version}';"],
+            ],
+        ])->updateForBump('1.2.0'));
+
+        $after = $this->readSourceFile();
+
+        self::assertStringContainsString("public const VERSION = '1.2.0';", $after);
+        // A version-shaped literal elsewhere on an unmatched line must survive:
+        // the pattern is a whole line, not a bare version search-and-replace.
+        self::assertStringContainsString("public const OTHER = '1.1.7';", $after);
+        self::assertStringContainsString('@since 1.0.0', $after);
+    }
+
+    #[Test]
+    public function source_files_accepts_prerelease_versions(): void
+    {
+        $this->seedSourceFile("    public const VERSION = '1.1.7-beta2';\n");
+
+        $this->runQuiet(fn () => $this->tracker([
+            'sourceFiles' => [
+                ['path' => 'src/LibraryVersion.php', 'pattern' => "public const VERSION = '{version}';"],
+            ],
+        ])->updateForBump('1.2.0-rc1'));
+
+        self::assertStringContainsString("public const VERSION = '1.2.0-rc1';", $this->readSourceFile());
+    }
+
+    #[Test]
+    public function source_files_treats_the_pattern_as_a_literal_not_a_regex(): void
+    {
+        // Parentheses and $ would be syntax in a regex; here they must match
+        // themselves, so an author can paste the line they see.
+        $this->seedSourceFile("    \$this->set('version', '1.1.7'); // (pinned)\n");
+
+        $this->runQuiet(fn () => $this->tracker([
+            'sourceFiles' => [
+                ['path' => 'src/LibraryVersion.php', 'pattern' => "\$this->set('version', '{version}'); // (pinned)"],
+            ],
+        ])->updateForBump('1.2.0'));
+
+        self::assertStringContainsString("\$this->set('version', '1.2.0'); // (pinned)", $this->readSourceFile());
+    }
+
+    #[Test]
+    public function source_files_is_idempotent_when_already_current(): void
+    {
+        $this->seedSourceFile("    public const VERSION = '1.2.0';\n");
+
+        $touched = $this->runQuiet(fn () => $this->tracker([
+            'sourceFiles' => [
+                ['path' => 'src/LibraryVersion.php', 'pattern' => "public const VERSION = '{version}';"],
+            ],
+        ])->updateForBump('1.2.0'));
+
+        self::assertSame([], $touched, 'An already-current file should not be reported as rewritten.');
+    }
+
+    /**
+     * The whole point of the feature: a rewrite that quietly does nothing is how
+     * a version drifts in the first place, so a non-matching pattern is fatal
+     * rather than a warning.
+     */
+    #[Test]
+    public function source_files_throws_when_the_pattern_matches_nothing(): void
+    {
+        $this->seedSourceFile("    public const VERSION = '1.1.7';\n");
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/did not match anything/');
+
+        $this->runQuiet(fn () => $this->tracker([
+            'sourceFiles' => [
+                ['path' => 'src/LibraryVersion.php', 'pattern' => "public const RELEASE = '{version}';"],
+            ],
+        ])->updateForBump('1.2.0'));
+    }
+
+    #[Test]
+    public function source_files_throws_on_a_missing_file(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/path not found/');
+
+        $this->runQuiet(fn () => $this->tracker([
+            'sourceFiles' => [
+                ['path' => 'src/Nope.php', 'pattern' => "public const VERSION = '{version}';"],
+            ],
+        ])->updateForBump('1.2.0'));
+    }
+
+    #[Test]
+    public function source_files_throws_when_the_placeholder_is_missing(): void
+    {
+        $this->seedSourceFile("    public const VERSION = '1.1.7';\n");
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/\{version\} placeholder/');
+
+        $this->runQuiet(fn () => $this->tracker([
+            'sourceFiles' => [
+                ['path' => 'src/LibraryVersion.php', 'pattern' => 'public const VERSION'],
+            ],
+        ])->updateForBump('1.2.0'));
+    }
+
+    #[Test]
+    public function source_files_throws_on_a_malformed_entry(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/`path` and `pattern`/');
+
+        $this->runQuiet(fn () => $this->tracker([
+            'sourceFiles' => [['path' => 'src/LibraryVersion.php']],
+        ])->updateForBump('1.2.0'));
+    }
+
+    #[Test]
+    public function source_files_absent_from_config_is_a_no_op(): void
+    {
+        $this->seedVersionsJson();
+
+        $touched = $this->runQuiet(fn () => $this->tracker([
+            'versionsJson' => 'build/versions.json',
+        ])->updateForBump('1.2.0'));
+
+        self::assertCount(1, $touched, 'Only versions.json should be touched.');
+    }
+
+    private function seedSourceFile(string $body): void
+    {
+        if (!is_dir($this->tmpDir . '/src')) {
+            mkdir($this->tmpDir . '/src', 0o777, true);
+        }
+
+        file_put_contents(
+            $this->tmpDir . '/src/LibraryVersion.php',
+            "<?php\n\nclass LibraryVersion\n{\n" . $body . "}\n"
+        );
+    }
+
+    private function readSourceFile(): string
+    {
+        return (string) file_get_contents($this->tmpDir . '/src/LibraryVersion.php');
+    }
+
     private function tracker(array $config): VersionTracker
     {
         return new VersionTracker($this->tmpDir, $config);


### PR DESCRIPTION
Option 1 of Joomla-Bible-Study/lib_cwmscripture#15 — the half that a test can only catch, not prevent.

## The gap

`cwm-bump` wrote the manifest and `VersionTracker` kept `versions.json` and `package.json` in step. A version hardcoded in code had no writer at all:

| Declaration | Written by |
|---|---|
| `cwmscripture.xml` | `ManifestVersionWriter` |
| `package.json` | `VersionTracker` |
| `src/LibraryVersion.php::VERSION` | **nothing** |

That constant sat at 1.1.3 while the manifest said 1.1.4 — and `LibraryVersion::satisfies()` / `needsUpgrade()` read it, so a downstream extension requiring 1.1.4 against a site *running* 1.1.4 was told 1.1.3 and could refuse to install.

## What this adds

```json
"versionTracking": {
    "sourceFiles": [
        { "path": "src/LibraryVersion.php",
          "pattern": "public const VERSION = '{version}';" }
    ]
}
```

Rewritten during the same bump that writes the manifest, so the two cannot part company.

## Design decisions

**Patterns are literals, not regexes.** The string is quoted and only `{version}` becomes a capture. An author pastes the line as it appears in the file; `$`, `(` and `.` match themselves rather than becoming syntax, and a reviewer who does not write regex can still see what a pattern targets. Tested with `$this->set('version', '{version}'); // (pinned)` — parens and sigil intact.

**The placeholder is anchored to digits** and accepts pre-release/build suffixes, because `bump.php` accepts them (`1.2.3-beta1`, `1.2.3-dev`). So it cannot drift onto arbitrary text: a version-shaped literal on a line the pattern does not match — an `@since` tag, an unrelated constant — is left alone. There is a test for exactly that, because a naive implementation would have been a bare search-and-replace on the old version string and would have rewritten every `@since 1.1.7` in the file.

**Failures throw rather than warn**, unlike the JSON trackers:

| Situation | Result |
|---|---|
| Pattern matches nothing | throws, naming file and pattern |
| `path` missing on disk | throws |
| `pattern` has no `{version}` | throws |
| Entry missing `path`/`pattern` | throws |
| Already at target version | no-op, `(no change)` |

Deliberate, and the point of the feature: a rewrite that silently does nothing is precisely how the version drifted in the first place. A misconfigured entry has to stop the bump rather than let a stale literal ship. `scripts/build.php` and `bump.php` already exit non-zero on `\Throwable` with the message.

## Tests

11 new cases: the rewrite, surrounding lines untouched, prerelease versions, literal-not-regex handling, idempotence, and each of the four fatal paths. Full suite green — **389 PHP tests / 935 assertions**, plus the python and shell suites.

## Follow-up

lib_cwmscripture can then declare its `LibraryVersion.php` entry and drop the hand-bump step; its guard test (Joomla-Bible-Study/lib_cwmscripture#28) stays useful as the belt to this braces, since it also catches a manifest edited by hand outside `cwm-bump`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ti98Cc63bmWcXva2G4GdNq