### PR TITLE
fix(release): stop substituteTokens writing into git submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`substituteTokens` no longer writes into git submodules.** A submodule
+  checkout carries a `.git` *file* rather than a directory, so the walk's
+  `ALWAYS_SKIP` list never recognised it as foreign code — and any configured path
+  containing a submodule got this project's version stamped into another
+  repository's source.
+
+  Observed on Proclaim 10.4.1: its `plugins/` path contains the CWMScriptureLinks
+  submodule, so the release wrote `@since 10.4.1` into a plugin whose own version
+  was 1.1.5, and left that repository dirty so the wrong values could be committed
+  there later by accident. CWMScriptureLinks had the same latent fault — its
+  `libraries/` path contains the lib_cwmscripture submodule.
+
+  Nested repositories are now skipped, detected by a `.git` entry rather than by
+  parsing `.gitmodules`, so a plain nested clone is covered too. The project's own
+  root is unaffected: only directories *inside* the walk are tested.
+
 ## [1.13.0] - 2026-07-30
 
 ### Added

--- a/src/Release/TokenSubstituter.php
+++ b/src/Release/TokenSubstituter.php
@@ -103,10 +103,28 @@ final class TokenSubstituter
             new \RecursiveCallbackFilterIterator(
                 new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
                 static function (\SplFileInfo $current): bool {
-                    if ($current->isDir() && in_array($current->getFilename(), self::ALWAYS_SKIP, true)) {
+                    if (!$current->isDir()) {
+                        return true;
+                    }
+
+                    if (in_array($current->getFilename(), self::ALWAYS_SKIP, true)) {
                         return false;
                     }
-                    return true;
+
+                    // A git submodule is another repository's source, with its own
+                    // version and its own release that substitutes its own token.
+                    // Writing this project's version into it produces @since tags
+                    // for a version that extension never had — Proclaim 10.4.1
+                    // stamped 10.4.1 into a plugin whose own version was 1.1.5 —
+                    // and leaves the submodule dirty, so the wrong values can be
+                    // committed there by accident later.
+                    //
+                    // Detected by the presence of a `.git` entry rather than by
+                    // parsing .gitmodules: a submodule checkout carries a `.git`
+                    // *file* pointing at the parent's modules dir, and ALWAYS_SKIP
+                    // only matches directories. Also catches a plain nested clone,
+                    // which is the same hazard without being declared anywhere.
+                    return !file_exists($current->getPathname() . '/.git');
                 },
             ),
         );

--- a/tests/Release/TokenSubstituterTest.php
+++ b/tests/Release/TokenSubstituterTest.php
@@ -23,6 +23,72 @@ final class TokenSubstituterTest extends TestCase
         $this->rrmdir($this->tmpDir);
     }
 
+    // -----------------------------------------------------------------
+    // nested repositories — submodules own their own version
+    // -----------------------------------------------------------------
+
+    /**
+     * Proclaim 10.4.1 stamped `@since 10.4.1` into a plugin whose own version was
+     * 1.1.5, because its `plugins/` path contains a submodule. The submodule was
+     * left dirty too, so the wrong values could be committed to that repository
+     * later by accident.
+     */
+    #[Test]
+    public function skips_a_submodule_checkout(): void
+    {
+        $this->seedFile('plugins/mine/Plugin.php', "<?php\n/** @since  __DEPLOY_VERSION__ */\n");
+        $this->seedFile('plugins/theirs/Plugin.php', "<?php\n/** @since  __DEPLOY_VERSION__ */\n");
+
+        // A submodule checkout carries a `.git` FILE pointing at the parent's
+        // modules directory — not a directory, which is why the existing
+        // ALWAYS_SKIP list never caught it.
+        file_put_contents(
+            $this->tmpDir . '/plugins/theirs/.git',
+            "gitdir: ../../.git/modules/plugins/theirs\n"
+        );
+
+        $touched = $this->runQuiet(fn () => $this->substituter(['paths' => ['plugins/']])->substitute('10.4.1'));
+
+        self::assertCount(1, $touched, 'Only our own plugin should be rewritten.');
+        self::assertStringContainsString('@since  10.4.1', $this->read('plugins/mine/Plugin.php'));
+        self::assertStringContainsString(
+            '__DEPLOY_VERSION__',
+            $this->read('plugins/theirs/Plugin.php'),
+            "A submodule's placeholder is its own release's business."
+        );
+    }
+
+    #[Test]
+    public function skips_a_plain_nested_clone(): void
+    {
+        $this->seedFile('libraries/ours/File.php', "<?php\n/** @since  __DEPLOY_VERSION__ */\n");
+        $this->seedFile('libraries/nested/File.php', "<?php\n/** @since  __DEPLOY_VERSION__ */\n");
+
+        // Same hazard as a submodule, undeclared: a clone sitting inside the tree
+        // has a `.git` directory. ALWAYS_SKIP would drop the `.git` dir itself but
+        // still walk into the clone's source.
+        mkdir($this->tmpDir . '/libraries/nested/.git', 0o777, true);
+
+        $touched = $this->runQuiet(fn () => $this->substituter(['paths' => ['libraries/']])->substitute('10.4.1'));
+
+        self::assertCount(1, $touched);
+        self::assertStringContainsString('__DEPLOY_VERSION__', $this->read('libraries/nested/File.php'));
+    }
+
+    #[Test]
+    public function still_substitutes_when_the_project_root_itself_is_a_repository(): void
+    {
+        // The guard must not fire on the project being released: its own root has
+        // a .git, and skipping it would make the whole feature a no-op.
+        mkdir($this->tmpDir . '/.git', 0o777, true);
+        $this->seedFile('src/Model.php', "<?php\n/** @since  __DEPLOY_VERSION__ */\n");
+
+        $touched = $this->runQuiet(fn () => $this->substituter(['paths' => ['src/']])->substitute('1.2.3'));
+
+        self::assertCount(1, $touched, 'A repository root is not a nested repository.');
+        self::assertStringContainsString('@since  1.2.3', $this->read('src/Model.php'));
+    }
+
     #[Test]
     public function replaces_default_token_in_php_files_under_configured_paths(): void
     {


### PR DESCRIPTION
Found by releasing Proclaim 10.4.1 an hour ago.

## What happened

Step 2 of the release reported this:

```
[2/9] Substituting __DEPLOY_VERSION__ placeholder...
  …/plugins/content/scripturelinks/script.php → 1 replacement(s)
  …/plugins/content/scripturelinks/plg_system_cwmscripture/…/Cwmscripture.php → 5 replacement(s)
```

Those files belong to **CWMScriptureLinks**, a submodule. Proclaim stamped `@since 10.4.1` into a plugin whose own version is 1.1.5 — a version that extension never had — and shipped it. It also left that repository dirty, so the wrong values could be committed there later by accident.

## Why ALWAYS_SKIP missed it

`ALWAYS_SKIP = ['vendor', 'node_modules', '.git']` is checked with `$current->isDir()`. A submodule checkout carries a `.git` **file** pointing at the parent's modules directory, not a directory:

```
-rw-r--r--  …/libraries/lib_cwmscripture/.git    # 102 bytes: "gitdir: ../../.git/modules/…"
```

So the walk dropped the `.git` entry itself and then descended into the submodule's source regardless.

## Not just Proclaim

CWMScriptureLinks has the same latent fault — its `substituteTokens.paths` is `["libraries/", "src/", "plg_task_cwmscripture/"]` and `libraries/` contains the lib_cwmscripture submodule. Its releases have been writing its version into the library's source. That is why this belongs in the tool rather than in each project's path list.

## The fix

Skip any directory containing a `.git` entry. Detected that way rather than by parsing `.gitmodules` so a plain nested clone is covered too — same hazard, just undeclared.

Only directories *inside* the walk are tested, so a project whose own root is a repository still substitutes normally. There is a test for precisely that, because the naive version of this guard fires on the project root and turns the whole feature into a silent no-op.

## Verified

Three new tests — submodule skipped, nested clone skipped, project root unaffected. **Both skip tests fail without the fix** (2 failures, confirmed by reverting the guard).

End to end against the real tree: Proclaim's own placeholders were consumed by the 10.4.1 release and 6 remain in the submodule, so the correct result is *nothing to do*:

```
files rewritten: 0
submodule status: clean
```

Full suite green — 392 PHP tests / 942 assertions, plus python and shell.

## Cleanup already done

The wrong `@since` values were reverted in the CWMScriptureLinks working tree before they could be committed. The already-published 10.4.1 package still contains them in docblocks; harmless, and not worth a re-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ti98Cc63bmWcXva2G4GdNq