### PR TITLE
fix(changelog): do not insert entries inside the header comment

### DIFF
--- a/scripts/changelog-insert.py
+++ b/scripts/changelog-insert.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Insert a generated <changelog> entry at the top of a Joomla changelog file.
+
+Split out of generate-changelog-entry.sh so the placement rule is testable:
+
+    python3 -m unittest discover -s tests/python -v
+
+The rule is "insert immediately after the opening <changelogs> tag", and the
+subtlety is which occurrence of that string counts. A naive substring search
+matches the first one anywhere in the file — including inside the header
+comment, where these files routinely explain what the root element is. When
+that happened the entry was spliced into the middle of the comment, truncating
+it and leaving a document that no longer parsed. Silently: the script still
+reported success, and a changelog that will not parse looks to Joomla exactly
+like one that is empty.
+
+So occurrences inside XML comments are skipped.
+
+Usage:
+    changelog-insert.py <changelog-file>
+
+The entry is read from the CHANGELOG_ENTRY environment variable.
+"""
+
+import os
+import re
+import sys
+
+ROOT_TAG = 'changelogs'
+
+
+def find_root_open_tag(content, root_tag=ROOT_TAG):
+    """
+    Return the index of the opening <root_tag> that starts the document body,
+    ignoring any occurrence inside an XML comment.
+
+    Returns -1 when the file has no such tag outside a comment.
+    """
+    commented = [
+        (m.start(), m.end())
+        for m in re.finditer(r'<!--.*?-->', content, re.S)
+    ]
+
+    for match in re.finditer(r'<%s(?:\s[^>]*)?>' % re.escape(root_tag), content):
+        start = match.start()
+
+        if any(lo <= start < hi for lo, hi in commented):
+            continue
+
+        return start
+
+    return -1
+
+
+def insert_entry(content, entry, root_tag=ROOT_TAG):
+    """
+    Return `content` with `entry` inserted on the line after the opening tag.
+
+    Raises ValueError when no opening tag exists outside a comment.
+    """
+    pos = find_root_open_tag(content, root_tag)
+
+    if pos == -1:
+        raise ValueError(
+            'Could not find a <%s> root element outside of comments.' % root_tag
+        )
+
+    line_end = content.find('\n', pos)
+
+    # A file whose root tag is on the last line, with no trailing newline.
+    if line_end == -1:
+        return content + '\n\n' + entry + '\n'
+
+    insert_at = line_end + 1
+
+    return content[:insert_at] + '\n' + entry + '\n' + content[insert_at:]
+
+
+def main(argv):
+    if len(argv) != 2:
+        print('Usage: changelog-insert.py <changelog-file>', file=sys.stderr)
+        return 2
+
+    changelog_file = argv[1]
+    entry = os.environ.get('CHANGELOG_ENTRY', '')
+
+    if not entry:
+        print('Error: CHANGELOG_ENTRY is empty.', file=sys.stderr)
+        return 1
+
+    with open(changelog_file, 'r') as handle:
+        content = handle.read()
+
+    try:
+        updated = insert_entry(content, entry)
+    except ValueError as error:
+        print('Error: %s' % error, file=sys.stderr)
+        return 1
+
+    with open(changelog_file, 'w') as handle:
+        handle.write(updated)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/scripts/generate-changelog-entry.sh
+++ b/scripts/generate-changelog-entry.sh
@@ -27,6 +27,7 @@
 set -euo pipefail
 
 PROJECT_ROOT="$(pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_FILE="${PROJECT_ROOT}/cwm-build.config.json"
 
 if [ ! -f "$CONFIG_FILE" ]; then
@@ -199,26 +200,6 @@ if [ ! -f "$CHANGELOG_PATH" ]; then
 fi
 
 export CHANGELOG_ENTRY="$ENTRY"
-python3 - "$CHANGELOG_PATH" <<'INSERT_SCRIPT'
-import os, sys
-
-changelog_file = sys.argv[1]
-entry = os.environ.get('CHANGELOG_ENTRY', '')
-
-with open(changelog_file, 'r') as f:
-    content = f.read()
-
-marker = '<changelogs>'
-pos = content.find(marker)
-if pos == -1:
-    print("Error: Could not find <changelogs> tag in changelog file.", file=sys.stderr)
-    sys.exit(1)
-
-insert_pos = content.index('\n', pos) + 1
-new_content = content[:insert_pos] + '\n' + entry + '\n' + content[insert_pos:]
-
-with open(changelog_file, 'w') as f:
-    f.write(new_content)
-INSERT_SCRIPT
+python3 "${SCRIPT_DIR}/changelog-insert.py" "$CHANGELOG_PATH"
 
 echo "Changelog entry for ${VERSION} added to $(basename "$CHANGELOG_PATH")."

--- a/tests/python/test_changelog_insert.py
+++ b/tests/python/test_changelog_insert.py
@@ -1,0 +1,138 @@
+"""
+Tests for the entry placement in scripts/changelog-insert.py.
+
+The regression these exist for shipped silently. The insertion used to be a
+plain content.find('<changelogs>'), which matches the first occurrence
+anywhere in the file — and these changelog files carry a header comment that
+explains what the root element is, so the first occurrence was usually inside
+that comment. The entry was spliced into the middle of the comment, truncating
+it and leaving XML that no longer parsed, while the script still reported
+success. A changelog that will not parse looks to Joomla exactly like one that
+is empty, so nothing surfaced it.
+
+Stdlib unittest, no dependencies:
+
+    python3 -m unittest discover -s tests/python -v
+"""
+
+import importlib.util
+import os
+import unittest
+import xml.etree.ElementTree as ET
+
+# Hyphenated filename, so it is not importable as a module; load it by path.
+_SCRIPT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    'scripts', 'changelog-insert.py'
+)
+_spec = importlib.util.spec_from_file_location('changelog_insert', _SCRIPT)
+changelog_insert = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(changelog_insert)
+
+
+ENTRY = """    <changelog>
+        <element>pkg_example</element>
+        <type>package</type>
+        <version>2.0.0</version>
+        <date>2026-07-30</date>
+        <fix>
+            <item>Something was fixed.</item>
+        </fix>
+    </changelog>"""
+
+
+PLAIN = """<?xml version="1.0" encoding="UTF-8"?>
+<changelogs>
+
+    <changelog>
+        <element>pkg_example</element>
+        <type>package</type>
+        <version>1.0.0</version>
+        <date>2026-01-01</date>
+    </changelog>
+
+</changelogs>
+"""
+
+# The shape that broke: the header comment names the root element.
+COMMENT_NAMES_ROOT = """<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Joomla update changelog for pkg_example.
+
+    This file must exist with a <changelogs> root before a release runs.
+-->
+<changelogs>
+
+    <changelog>
+        <element>pkg_example</element>
+        <type>package</type>
+        <version>1.0.0</version>
+        <date>2026-01-01</date>
+    </changelog>
+
+</changelogs>
+"""
+
+
+def versions(xml_text):
+    root = ET.fromstring(xml_text)
+    return [c.findtext('version') for c in root.findall('changelog')]
+
+
+class FindRootOpenTag(unittest.TestCase):
+    def test_finds_a_bare_root(self):
+        pos = changelog_insert.find_root_open_tag(PLAIN)
+        self.assertEqual('<changelogs>', PLAIN[pos:pos + len('<changelogs>')])
+
+    def test_skips_an_occurrence_inside_a_comment(self):
+        pos = changelog_insert.find_root_open_tag(COMMENT_NAMES_ROOT)
+        self.assertGreater(
+            pos,
+            COMMENT_NAMES_ROOT.index('-->'),
+            'matched the root named inside the header comment',
+        )
+
+    def test_accepts_attributes_on_the_root(self):
+        content = '<changelogs xmlns:foo="urn:x">\n</changelogs>\n'
+        self.assertEqual(0, changelog_insert.find_root_open_tag(content))
+
+    def test_reports_a_missing_root(self):
+        self.assertEqual(-1, changelog_insert.find_root_open_tag('<other/>\n'))
+
+    def test_a_root_only_ever_mentioned_in_a_comment_is_not_a_root(self):
+        content = '<!-- the <changelogs> element -->\n<other/>\n'
+        self.assertEqual(-1, changelog_insert.find_root_open_tag(content))
+
+
+class InsertEntry(unittest.TestCase):
+    def test_inserts_at_the_top_and_stays_parseable(self):
+        got = changelog_insert.insert_entry(PLAIN, ENTRY)
+        self.assertEqual(['2.0.0', '1.0.0'], versions(got))
+
+    def test_does_not_splice_into_the_header_comment(self):
+        got = changelog_insert.insert_entry(COMMENT_NAMES_ROOT, ENTRY)
+
+        # The regression: this raised ParseError, because the entry landed
+        # inside the comment and truncated it.
+        self.assertEqual(['2.0.0', '1.0.0'], versions(got))
+
+        # And the comment itself survives intact.
+        self.assertIn('This file must exist with a <changelogs> root', got)
+
+    def test_preserves_existing_entries_verbatim(self):
+        got = changelog_insert.insert_entry(COMMENT_NAMES_ROOT, ENTRY)
+        self.assertIn('<version>1.0.0</version>', got)
+
+    def test_handles_a_root_on_the_final_line(self):
+        got = changelog_insert.insert_entry(
+            '<changelogs></changelogs>', ENTRY
+        )
+        self.assertIn('<version>2.0.0</version>', got)
+
+    def test_raises_when_there_is_no_root(self):
+        with self.assertRaises(ValueError):
+            changelog_insert.insert_entry('<other/>\n', ENTRY)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`generate-changelog-entry.sh` could splice a generated entry into the changelog file's header comment, silently.

## Cause

The insertion was a plain substring search:

```python
marker = '<changelogs>'
pos = content.find(marker)
```

That matches the **first occurrence anywhere in the file**. These changelog files carry a header comment explaining what the root element is, so the first occurrence is usually inside that comment — and the entry gets inserted there.

## Two failure modes, both silent

The script reported success in both cases, and a changelog that won't parse looks to Joomla exactly like one that's empty, so nothing surfaced either:

```
OLD, plain entry:  parses, but versions = ['1.0.0']  <- 2.0.0 silently lost
OLD, real entry:   INVALID -> not well-formed (invalid token): line 7, column 8
NEW, real entry:   VALID -> ['2.0.0', '1.0.0']
```

1. **Entry swallowed by the comment.** The file still parses; the release just quietly has no changelog entry.
2. **Document corrupted.** The entry's own `<!-- version banner -->` lines close the enclosing comment at their first `-->`, and everything after becomes garbage. This is what the generator actually emits, so it's the common case.

## Fix

Skips occurrences inside XML comments when locating the root element. Also handles a root carrying attributes, and a root on the final line with no trailing newline.

Moves the insertion out of the inline heredoc into `scripts/changelog-insert.py`, so the placement rule is testable — matching the existing `scripts/sync-languages.py` + `tests/python` pattern rather than introducing a new one.

## Tests

Ten new cases in `tests/python/test_changelog_insert.py`, including the exact regression. Full suite green:

```
Ran 35 tests in 0.001s — OK
ars.test.sh: 15 passed        artifacts.test.sh: 11 passed
bullets.test.sh: 13 passed    dryrun.test.sh: 18 passed
notes.test.sh: 8 passed       version.test.sh: 17 passed
```

## How it was found

Creating a changelog file for CWMLivingWord (Joomla-Bible-Study/CWMLivingWord#88). Its header mentioned the root element, and the first generated entry produced an unparseable file. Related: Joomla-Bible-Study/CWMScriptureLinks#15, a changelog that had never parsed for a different reason — a double hyphen in the same header comment.

Both are the same shape of bug: correctly configured, silently non-functional, with no error anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)