### PR TITLE
chore(ci): enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+# Dependabot version updates.
+#
+# Security updates run without this file; version updates need it.
+#
+# Minor and patch bumps are grouped into a single PR per ecosystem. Major
+# bumps stay separate, since those want reading.
+version: 2
+
+updates:
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      composer-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Security updates already run without a config file; **version updates need one**.

Covers `composer` (phpunit, php-cs-fixer, nikic/php-parser and friends) and `github-actions`. No npm block — this repo has no `package.json` of its own; the rollup/csso templates it ships are consumed by the projects that use it.

Weekly, Mondays, 5 PRs per ecosystem max, minor and patch grouped into one PR per ecosystem, majors separate. Commit prefixes `chore(deps)` / `chore(deps-dev)` / `ci`.

No `ignore` block here — this repo isn't a consumer of itself.

Part of enabling Dependabot across the CWM repos. The consumers additionally ignore `cwm/build-tools`, since Dependabot's Composer support doesn't resolve the VCS repository they source it from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)