### PR TITLE
fix(release): survive a bump that produces no diff

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -283,7 +283,23 @@ if [ -n "$UNTRACKED" ]; then
     printf '    %s\n' $UNTRACKED
 fi
 cwm_mutate git add -A
-cwm_mutate git commit -m "chore: bump version to ${VERSION}"
+
+# The bump does not always produce a diff. Bumping first, running the release
+# gate against that build, and only then releasing is a sound workflow — and it
+# leaves the tree already at the target version, so `git commit` exits non-zero
+# with "nothing to commit" and takes the whole release down with it under
+# `set -e`: after the build has run, before anything is tagged.
+#
+# Staged changes are committed exactly as before; an already-bumped tree simply
+# carries on to the tag.
+if [ "${CWM_DRY_RUN:-0}" = "1" ]; then
+    cwm_mutate git commit -m "chore: bump version to ${VERSION}"
+elif git diff --cached --quiet; then
+    echo "  Version already at ${VERSION} — nothing to commit, continuing."
+else
+    git commit -m "chore: bump version to ${VERSION}"
+fi
+
 cwm_mutate git push
 echo ""
 


### PR DESCRIPTION
`cwm-release` dies at step 4 when the tree is already at the target version.

## Symptom

```
[4/9] Committing version bump...
On branch main
Your branch is up to date with 'origin/main'.

nothing to commit, working tree clean
Script cwm-release handling the release event returned with error code 1
```

The build has already run at that point; nothing is tagged or published. The output gives no sign that "nothing to commit" was fatal.

## Why it is not an edge case

Bumping first, running the release gate against **that exact build**, and only then releasing is the workflow install/upgrade test suites are built for — and it leaves the version already bumped every time. Hit while releasing CWMLivingWord 5.6.0, whose version had been bumped in a prior PR so the upgrade test had something newer than the last release to upgrade to.

## Fix

Staged changes are committed exactly as before. An already-bumped tree says so and carries on to the tag:

```
  Version already at 5.6.0 — nothing to commit, continuing.
```

Dry-run output is unchanged — the branch still routes through `cwm_mutate` so it prints the `would run: git commit` line as before.

Full suite green: 35 python, 82 shell assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)