### PR TITLE
feat(release): gate cwm-release on composer test:release when defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`cwm-release` gates on `composer test:release` when a project defines it.**
+  Every release-blocking defect this tool has shipped — an uninstallable
+  package, a migration missing an index, a webservices plugin 500ing on every
+  request — looked structurally correct and failed only once actually
+  executed. `test:release` is that execution, and it previously ran only when
+  someone remembered to run it by hand. It's now a pre-flight step: present in
+  a project's `composer.json`, it runs before anything is bumped, built, or
+  published, and a failure stops the release. Absent, the release runs exactly
+  as before — this doesn't require every CWM project to have a test harness.
+  `--skip-tests` releases anyway; `--dry-run` still runs the gate for real,
+  since it verifies rather than writes.
+
 ## [1.13.2] - 2026-07-30
 
 ### Fixed

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -27,6 +27,13 @@ composer cwm-release
 5. **Finish** — update `versions.json` and push the release commit/tag to
    `github.releaseBranch`.
 
+Before any of that, if the project's `composer.json` defines a `test:release`
+script, `cwm-release` runs it as a pre-flight gate and stops before touching
+anything if it fails. This is opt-in by presence — a project with no
+`test:release` script is released exactly as before. Pass `--skip-tests` to
+release anyway; `--dry-run` still runs the gate for real, since it verifies
+rather than writes.
+
 Always check `--help` for the current flags and any dry-run option:
 
 ```bash

--- a/scripts/lib/dryrun.sh
+++ b/scripts/lib/dryrun.sh
@@ -12,27 +12,31 @@
 # the wrapper is a single choke point, and its behaviour is pinned by tests
 # rather than by reading the call sites.
 
-# Split --dry-run/-n out of the argument list.
+# Split release.sh's top-level flags out of the argument list.
 #
-# Sets CWM_DRY_RUN to 1 or 0 and CWM_ARGS to the remaining positional
-# arguments, so a caller can accept the flag before or after the version:
-# both `release.sh --dry-run 1.2.3` and `release.sh 1.2.3 --dry-run` work.
+# Both flags are stripped in the same pass so a caller can put either one
+# anywhere relative to the version: `release.sh --dry-run 1.2.3`,
+# `release.sh 1.2.3 --skip-tests`, and combinations of both all work.
 #
 # Arguments:
 #   The caller's "$@".
 #
 # Sets:
-#   CWM_DRY_RUN  1 when the flag was present, else 0.
-#   CWM_ARGS     Array of the non-flag arguments (may be empty).
+#   CWM_DRY_RUN    1 when --dry-run/-n was present, else 0.
+#   CWM_SKIP_TESTS 1 when --skip-tests was present, else 0.
+#   CWM_ARGS       Array of the non-flag arguments (may be empty).
 cwm_parse_dry_run() {
     CWM_DRY_RUN=0
+    CWM_SKIP_TESTS=0
     CWM_ARGS=()
 
     local arg
     for arg in "$@"; do
+        # shellcheck disable=SC2034  # CWM_SKIP_TESTS is read by release.sh, not this file
         case "$arg" in
-            --dry-run|-n) CWM_DRY_RUN=1 ;;
-            *)            CWM_ARGS+=("$arg") ;;
+            --dry-run|-n)  CWM_DRY_RUN=1 ;;
+            --skip-tests)  CWM_SKIP_TESTS=1 ;;
+            *)             CWM_ARGS+=("$arg") ;;
         esac
     done
 }

--- a/scripts/lib/testgate.sh
+++ b/scripts/lib/testgate.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Release gate: composer test:release as a release pre-condition.
+#
+# Every silent defect this tool has ever shipped — an uninstallable package,
+# a migration missing an index, an admin view 500ing on every request, a REST
+# API returning 500 on every single request — looked correct until something
+# actually executed it. composer test:release is that execution: clean
+# install, upgrade, accessibility, API acceptance, against a disposable site,
+# the same suite LivingWord's nightly/PR CI runs. A release built without it
+# is trusting exactly the thing the suite exists to not trust.
+#
+# Not every CWM project has this harness — a library with no install flow
+# has nothing for it to verify — so the gate is opt-in by presence: projects
+# without a test:release script are left alone rather than blocked on
+# tooling they were never given.
+#
+# Detection lives here, sourceable, so it can be tested without shelling out
+# to a real composer process — the same reason lib/artifacts.sh and
+# lib/version.sh exist.
+
+# Whether a project's composer.json defines a test:release script.
+#
+# Arguments:
+#   $1  Path to composer.json.
+#
+# Returns:
+#   0 (true) if the script is defined, 1 otherwise — including when the file
+#   is missing or not valid JSON.
+cwm_has_test_release_script() {
+    local composer_json="$1"
+
+    [ -f "$composer_json" ] || return 1
+
+    php -r '
+        $c = json_decode(file_get_contents($argv[1]), true);
+        exit(isset($c["scripts"]["test:release"]) ? 0 : 1);
+    ' "$composer_json" 2>/dev/null
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -22,6 +22,7 @@
 #   release.sh 1.2.3-beta1          # pre-release
 #   release.sh                      # prompts for version
 #   release.sh 1.2.3 --dry-run      # print the plan, change nothing
+#   release.sh 1.2.3 --skip-tests   # release without the test:release gate
 #
 # Dry run:
 #   --dry-run (-n) walks the whole pipeline and writes nothing: no manifest
@@ -34,7 +35,19 @@
 #   reported. The two pre-conditions a real run refuses to start without — the
 #   right branch and a clean tree — are reported as warnings rather than
 #   errors, since wanting to know what a release *would* do before tidying up
-#   is the normal reason to ask.
+#   is the normal reason to ask. The test:release gate (below) is a read-only
+#   check by this definition too — it verifies, it doesn't write release
+#   artifacts — so it runs under --dry-run as well.
+#
+# Test gate:
+#   If the project's composer.json defines a `test:release` script, it runs
+#   as a pre-flight step and a failure stops the release before anything is
+#   bumped, built, or published. Projects without that script are unaffected
+#   — the gate is opt-in by presence, not a hard requirement of every CWM
+#   project. Pass --skip-tests to release anyway (an emergency hotfix where
+#   the suite's own environment is the thing broken, say); the flag exists
+#   so that's a deliberate, visible choice rather than a reason to touch this
+#   script. See lib/testgate.sh.
 #
 # Prerequisites:
 #   - Clean working tree, on the configured release branch (default: main)
@@ -54,16 +67,19 @@ source "${SCRIPT_DIR}/lib/version.sh"
 source "${SCRIPT_DIR}/lib/notes.sh"
 # shellcheck source=lib/dryrun.sh
 source "${SCRIPT_DIR}/lib/dryrun.sh"
+# shellcheck source=lib/testgate.sh
+source "${SCRIPT_DIR}/lib/testgate.sh"
 PROJECT_ROOT="$(pwd)"
 
 # --- Parse flags ---
 #
-# The flag is pulled out wherever it appears, so `release.sh --dry-run 1.2.3`
-# and `release.sh 1.2.3 --dry-run` both work; what remains is the positional
-# version argument the rest of the script already expects. Parsing and the
-# command wrapper live in lib/dryrun.sh so they can be tested.
+# Flags are pulled out wherever they appear, so `release.sh --dry-run 1.2.3`
+# and `release.sh 1.2.3 --dry-run --skip-tests` both work; what remains is the
+# positional version argument the rest of the script already expects. Parsing
+# and the command wrapper live in lib/dryrun.sh so they can be tested.
 cwm_parse_dry_run "$@"
 DRY_RUN="$CWM_DRY_RUN"
+SKIP_TESTS="$CWM_SKIP_TESTS"
 set -- "${CWM_ARGS[@]+"${CWM_ARGS[@]}"}"
 
 CONFIG_FILE="${PROJECT_ROOT}/cwm-build.config.json"
@@ -178,6 +194,28 @@ if [ -f .gitmodules ]; then
             echo "           If this is unintentional, release the submodule first."
         fi
     '
+fi
+echo ""
+
+# --- Pre-flight: release gate (composer test:release) ---
+# Verifies the commit about to be released, not the commit that results from
+# bumping/building it — so this runs before step 1, against what's on disk
+# right now. See lib/testgate.sh for why this exists at all.
+if [ "$SKIP_TESTS" = "1" ]; then
+    echo "[pre-flight] Skipping composer test:release (--skip-tests)."
+elif ! cwm_has_test_release_script "${PROJECT_ROOT}/composer.json"; then
+    echo "[pre-flight] No composer test:release script — skipping pre-release verification."
+else
+    echo "[pre-flight] Running composer test:release..."
+    if composer test:release; then
+        echo "  test:release passed."
+    elif [ "$DRY_RUN" = "1" ]; then
+        echo "  WARNING: test:release failed. A real run would stop here."
+    else
+        echo ""
+        echo "Error: composer test:release failed. Fix the failure, or pass --skip-tests to release anyway."
+        exit 1
+    fi
 fi
 echo ""
 

--- a/tests/shell/dryrun.test.sh
+++ b/tests/shell/dryrun.test.sh
@@ -44,6 +44,19 @@ assert_equals "0" "${#CWM_ARGS[@]}" "no positional arguments remain"
 cwm_parse_dry_run 1.2.3-beta1
 assert_equals "1.2.3-beta1" "${CWM_ARGS[*]}" "a pre-release version passes through"
 
+# --- --skip-tests, parsed in the same pass -----------------------------------
+cwm_parse_dry_run 1.2.3
+assert_equals "0" "$CWM_SKIP_TESTS" "no flag means the gate runs"
+
+cwm_parse_dry_run 1.2.3 --skip-tests
+assert_equals "1" "$CWM_SKIP_TESTS" "--skip-tests after the version is found"
+assert_equals "1.2.3" "${CWM_ARGS[*]}" "and is removed from the arguments"
+
+cwm_parse_dry_run --skip-tests --dry-run 1.2.3
+assert_equals "1" "$CWM_SKIP_TESTS" "both flags are recognised together..."
+assert_equals "1" "$CWM_DRY_RUN" "...regardless of order..."
+assert_equals "1.2.3" "${CWM_ARGS[*]}" "...leaving only the version behind"
+
 # --- The wrapper actually withholds the command ------------------------------
 CWM_DRY_RUN=1
 rm -f "${WORK}/evidence"

--- a/tests/shell/testgate.test.sh
+++ b/tests/shell/testgate.test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/lib/testgate.sh.
+#
+# What matters here is the detection alone: whether a project opted in to the
+# release gate by defining test:release. release.sh decides what to do with
+# that answer; running composer for real isn't something a unit test should
+# do.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+# shellcheck source=../../scripts/lib/testgate.sh
+source "${SCRIPT_DIR}/../../scripts/lib/testgate.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- A project that defines the script ---------------------------------------
+cat > "${WORK}/with-gate.json" <<'JSON'
+{
+    "scripts": {
+        "test": "phpunit",
+        "test:release": "bash build/test-release.sh"
+    }
+}
+JSON
+if cwm_has_test_release_script "${WORK}/with-gate.json"; then
+    PASS=$((PASS + 1))
+else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: a project defining test:release is detected"
+fi
+
+# --- A project with scripts but not this one ---------------------------------
+cat > "${WORK}/without-gate.json" <<'JSON'
+{
+    "scripts": {
+        "test": "phpunit"
+    }
+}
+JSON
+if cwm_has_test_release_script "${WORK}/without-gate.json"; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: a project without test:release is left alone"
+else
+    PASS=$((PASS + 1))
+fi
+
+# --- A project with no scripts block at all -----------------------------------
+echo '{"name": "cwm/example"}' > "${WORK}/no-scripts.json"
+if cwm_has_test_release_script "${WORK}/no-scripts.json"; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: a composer.json with no scripts block is left alone"
+else
+    PASS=$((PASS + 1))
+fi
+
+# --- No composer.json at all --------------------------------------------------
+# A library or non-PHP consumer of the release pipeline shouldn't be blocked
+# on a file it has no reason to have.
+if cwm_has_test_release_script "${WORK}/does-not-exist.json"; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: a missing composer.json is left alone"
+else
+    PASS=$((PASS + 1))
+fi
+
+# --- Malformed JSON ------------------------------------------------------------
+# Read this as "not opted in" rather than crashing the release pipeline over
+# an unrelated syntax error someone else's editor introduced.
+echo '{ not valid json' > "${WORK}/broken.json"
+if cwm_has_test_release_script "${WORK}/broken.json"; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: invalid JSON is treated as not opted in, not a crash"
+else
+    PASS=$((PASS + 1))
+fi
+
+finish


### PR DESCRIPTION
## Summary

Decides and implements the open question from LivingWord PR #116's description: whether `composer release` should be blocked on a passing test suite, or whether nightly CI + discipline is enough.

**Decision: gate, but opt-in by presence.** `cwm-release` now runs a project's `composer test:release` script as a pre-flight step, before anything is bumped/built/published. A failure stops the release. A project with no `test:release` script (a library with no install harness, e.g. `lib_cwmscripture`) is released exactly as before — this doesn't require every CWM project to adopt a testing harness it doesn't have a use for.

Reasoning: every release-blocking defect this tool family has shipped so far — an uninstallable package (`pkg_livingword` for 5 releases), a migration missing an index, a webservices plugin returning 500 on every request — looked structurally correct and only failed once actually executed. `test:release` is that execution. Relying on someone remembering to run it by hand (the "nightly + discipline" model Proclaim currently uses) is exactly the failure mode that shipped those bugs in the first place.

- `--skip-tests` overrides for the rare case the suite's own environment is what's broken, not the release.
- `--dry-run` still runs the gate for real — it verifies, it doesn't write release artifacts, so it fits the existing "read-only checks still happen under dry-run" rule already documented at the top of `release.sh`.
- Both flags are parsed in the same pass in `lib/dryrun.sh` (extended, not duplicated).
- Detection (`cwm_has_test_release_script`) lives in a new `lib/testgate.sh`, sourceable and unit-tested, matching the existing pattern for `lib/artifacts.sh` / `lib/version.sh` / `lib/notes.sh`.

## Test plan

- [x] `composer test` (PHP + Python + shell) — all green, including new `tests/shell/testgate.test.sh` (5 cases: script present, script absent, no scripts block, missing composer.json, malformed JSON) and extended `tests/shell/dryrun.test.sh` (flag parsing for `--skip-tests` alone and combined with `--dry-run`).
- [x] `shellcheck -S warning` on all touched/added shell files — clean (matches CI's `tests.yml` check).
- [x] `bash -n scripts/release.sh` — syntax OK.
- [ ] Once merged and released, bump LivingWord's `cwm/build-tools` constraint (`^1.13` already covers a `1.14.0` release, so likely just `composer update cwm/build-tools`) and confirm `composer release -- --dry-run` there picks up and runs the gate against a real `test:release` script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KEBePPp3wwWcpgoZ1m5krC