### PR TITLE
fix(release): set ARS `ordering` so a new release is actually the latest

### DIFF
--- a/src/Release/ArsPublisher.php
+++ b/src/Release/ArsPublisher.php
@@ -60,6 +60,17 @@ use CWM\BuildTools\Http\HttpTransport;
  *   every real site; Proclaim 10.3.4-10.4.0 all shipped that way (#58).
  *   ItemTable stores the field as a JSON-encoded array, so a JSON array is
  *   what goes on the wire.
+ * - **`ordering`.** ARS reads "latest release" as "lowest `ordering` in the
+ *   category", never as newest version or date, and assigns nothing useful on
+ *   its own — the column has no DEFAULT and ReleaseTable::check() only turns
+ *   null into 0. Publish without setting it and every release ties at 0, so
+ *   the Latest Releases page freezes on whichever row the database returns
+ *   last. It is also the one field where *omitting* it on an update is
+ *   destructive rather than neutral: release.xml declares `default="0"`, the
+ *   form fills defaults for absent fields, so a PATCH that leaves it out drags
+ *   that release to the front of its category. This class therefore always
+ *   sends it — one below the category minimum when creating, unchanged when
+ *   updating. See {@see orderingForNewest} (#77).
  *
  * ## Authorisation, as of ARS 7.5.0
  *
@@ -143,9 +154,18 @@ final class ArsPublisher
         self::assertMaturity((string) ($release['maturity'] ?? 'stable'));
         self::assertRenderedNotes((string) ($release['notes'] ?? ''));
 
-        $existingId = $this->findReleaseId($categoryId, $version);
+        $existing = $this->findRelease($categoryId, $version);
 
-        if ($existingId !== null) {
+        if ($existing !== null) {
+            $existingId = (int) $existing['id'];
+
+            // Preserve the ordering this release already has. Omitting the key
+            // does NOT leave it alone — release.xml declares ordering with
+            // default="0", the form fills the default for absent fields, and
+            // the release silently jumps to 0. Re-publishing a version to fix
+            // its notes would otherwise drag it to the front of its category.
+            $release['ordering'] ??= $existing['ordering'];
+
             // ReleaseTable::check() is a full-record check; PATCHing a subset
             // is how fields get reset to defaults. The caller passes the whole
             // record, and `id` goes with it so the body agrees with the route.
@@ -154,9 +174,91 @@ final class ArsPublisher
             return ['id' => $existingId, 'created' => false];
         }
 
+        $release['ordering'] ??= $this->orderingForNewest($categoryId);
+
         $response = $this->send('POST', '/releases', $release);
 
         return ['id' => $this->idFromWriteResponse($response, 'release'), 'created' => true];
+    }
+
+    /**
+     * The `ordering` value that makes a new release the latest in its category.
+     *
+     * ARS decides "latest" with an anti-join in ReleasesModel::getListQuery()
+     * (`filter.latest`): it keeps the releases with **no published sibling of a
+     * smaller `ordering`**, i.e. the *minimum* ordering in the category. Version
+     * numbers and dates are never consulted. Whatever holds the lowest ordering
+     * is what the Latest Releases page shows, forever, no matter what is
+     * published afterwards.
+     *
+     * ARS itself never assigns a useful value: `#__ars_releases.ordering` is
+     * `bigint unsigned NOT NULL` with no DEFAULT, and ReleaseTable::check() only
+     * does `$this->ordering = $this->ordering ?? 0`. So every release published
+     * without an explicit ordering lands on 0, they all tie for the minimum, the
+     * anti-join returns all of them, and Latest\HtmlView keeps whichever row the
+     * database happened to return last. That is how christianwebministries.org
+     * ended up serving Proclaim 10.3.1 for three months while 10.5.7 was out
+     * (cwm-build-tools#77).
+     *
+     * Going one below the current minimum makes the new release the unique
+     * minimum and touches no other record — which matters, because "just bump
+     * the old one out of the way" would mean PATCHing a live release, and a
+     * PATCH has to carry the whole record (see the ordering note above) so it
+     * re-runs check() over that release's notes. One release, one write.
+     *
+     * @throws \RuntimeException When the category has no room below its minimum.
+     */
+    private function orderingForNewest(int $categoryId): int
+    {
+        $query = http_build_query([
+            'category_id' => $categoryId,
+            'page'        => ['limit' => self::PAGE_LIMIT],
+        ]);
+
+        $rows = $this->readList("/releases?{$query}", 'releases');
+
+        // A full page means the list was probably cut off, and a minimum taken
+        // from part of a category is not a minimum. Guessing here would place
+        // the release above a sibling we never saw and quietly reinstate the
+        // bug this method exists to prevent.
+        if (\count($rows) >= self::PAGE_LIMIT) {
+            throw new \RuntimeException(sprintf(
+                'ARS category %d returned the full %d-row page, so this may not be all of it and the lowest '
+                . '`ordering` cannot be established. Refusing to guess: a release ordered above an unseen '
+                . 'sibling would not become the latest, and nothing about the publish would say so. '
+                . 'Raise ArsPublisher::PAGE_LIMIT above the number of releases in the category.',
+                $categoryId,
+                self::PAGE_LIMIT
+            ));
+        }
+
+        $orderings = array_map(
+            static fn (array $row): int => (int) (($row['attributes'] ?? [])['ordering'] ?? 0),
+            $rows
+        );
+
+        // An empty category: start at 1 rather than 0, so the next release has
+        // somewhere to go.
+        if ($orderings === []) {
+            return 1;
+        }
+
+        $minimum = min($orderings);
+
+        if ($minimum <= 0) {
+            throw new \RuntimeException(sprintf(
+                'ARS category %d has a release at ordering 0, so there is no room to place this one below it. '
+                . '`ordering` is unsigned, 0 is the floor, and a tie for the lowest value is exactly the bug '
+                . 'that made the Latest Releases page stick on an old version (cwm-build-tools#77). '
+                . 'Renumber the category once so the newest release has the lowest ordering and nothing sits '
+                . 'at 0 — in the ARS backend: Releases, filter to the category, sort by Ordering, drag the '
+                . 'newest release to the top. Leave a gap by numbering in steps if you publish often. '
+                . 'Then re-run this publish.',
+                $categoryId
+            ));
+        }
+
+        return $minimum - 1;
     }
 
     /**
@@ -203,6 +305,22 @@ final class ArsPublisher
      */
     public function findReleaseId(int $categoryId, string $version): ?int
     {
+        $release = $this->findRelease($categoryId, $version);
+
+        return $release === null ? null : $release['id'];
+    }
+
+    /**
+     * The id and current ordering of the release with exactly this version.
+     *
+     * `ordering` comes back with the id because the update path has to send it
+     * again to keep it — see the note in {@see upsertRelease}. Reading it here
+     * keeps that to the one lookup the upsert already performs.
+     *
+     * @return array{id: int, ordering: int}|null
+     */
+    public function findRelease(int $categoryId, string $version): ?array
+    {
         $query = http_build_query([
             'category_id' => $categoryId,
             'search'      => $version,
@@ -215,7 +333,10 @@ final class ArsPublisher
             $attributes = $row['attributes'] ?? [];
 
             if (($attributes['version'] ?? null) === $version) {
-                return (int) $attributes['id'];
+                return [
+                    'id'       => (int) $attributes['id'],
+                    'ordering' => (int) ($attributes['ordering'] ?? 0),
+                ];
             }
         }
 

--- a/tests/Release/ArsPublisherTest.php
+++ b/tests/Release/ArsPublisherTest.php
@@ -43,13 +43,128 @@ final class ArsPublisherTest extends TestCase
     {
         $http = new FakeTransport([
             self::releaseList([]),
+            self::releaseList([['id' => 5, 'version' => '1.1.0', 'ordering' => 3]]),
             self::ok(['data' => ['attributes' => ['id' => 77]]]),
         ]);
 
         $result = self::publisher($http)->upsertRelease(self::release('1.2.0'));
 
         self::assertSame(['id' => 77, 'created' => true], $result);
-        self::assertSame('POST', $http->calls[1]['method']);
+        self::assertSame('POST', $http->calls[2]['method']);
+    }
+
+    #[Test]
+    public function a_new_release_is_ordered_below_the_category_minimum(): void
+    {
+        // ARS reads "latest" as the lowest ordering in the category, so the
+        // new release has to land under every sibling or the Latest Releases
+        // page keeps showing the old one.
+        $http = new FakeTransport([
+            self::releaseList([]),
+            self::releaseList([
+                ['id' => 5, 'version' => '1.0.0', 'ordering' => 9],
+                ['id' => 6, 'version' => '1.1.0', 'ordering' => 4],
+            ]),
+            self::ok(['data' => ['attributes' => ['id' => 77]]]),
+        ]);
+
+        self::publisher($http)->upsertRelease(self::release('1.2.0'));
+
+        $sent = json_decode((string) $http->calls[2]['body'], true);
+
+        self::assertSame(3, $sent['ordering']);
+    }
+
+    #[Test]
+    public function a_new_release_in_an_empty_category_leaves_room_below_itself(): void
+    {
+        // Starting at 0 would work once and then wedge: the next release has
+        // nowhere lower to go, because ordering is unsigned.
+        $http = new FakeTransport([
+            self::releaseList([]),
+            self::releaseList([]),
+            self::ok(['data' => ['attributes' => ['id' => 77]]]),
+        ]);
+
+        self::publisher($http)->upsertRelease(self::release('1.2.0'));
+
+        $sent = json_decode((string) $http->calls[2]['body'], true);
+
+        self::assertSame(1, $sent['ordering']);
+    }
+
+    #[Test]
+    public function a_category_already_pinned_at_zero_is_refused_not_tied(): void
+    {
+        // Publishing a second release at 0 is the actual bug: they tie for the
+        // minimum and ARS shows whichever row the database returns last.
+        $http = new FakeTransport([
+            self::releaseList([]),
+            self::releaseList([['id' => 5, 'version' => '1.1.0', 'ordering' => 0]]),
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/ordering 0.*no room/s');
+
+        self::publisher($http)->upsertRelease(self::release('1.2.0'));
+    }
+
+    #[Test]
+    public function a_truncated_category_read_is_refused_not_guessed_at(): void
+    {
+        // A minimum taken from part of a category is not a minimum. Placing
+        // the release above an unseen sibling would leave it not-latest, and
+        // the publish would report success anyway.
+        $full = array_map(
+            static fn (int $n): array => ['id' => $n, 'version' => "0.0.{$n}", 'ordering' => $n + 1],
+            range(1, 200)
+        );
+
+        $http = new FakeTransport([
+            self::releaseList([]),
+            self::releaseList($full),
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/full 200-row page/');
+
+        self::publisher($http)->upsertRelease(self::release('1.2.0'));
+    }
+
+    #[Test]
+    public function updating_a_release_keeps_the_ordering_it_already_has(): void
+    {
+        // release.xml gives ordering default="0" and the form fills defaults
+        // for absent fields, so omitting it on a PATCH is not "leave alone" —
+        // it drags that release to the front of its category. Re-publishing
+        // 10.3.1 to fix its notes must not make it the latest release.
+        $http = new FakeTransport([
+            self::releaseList([['id' => 42, 'version' => '1.2.0', 'ordering' => 12]]),
+            self::ok(['data' => ['attributes' => ['id' => 42]]]),
+        ]);
+
+        self::publisher($http)->upsertRelease(self::release('1.2.0'));
+
+        $sent = json_decode((string) $http->calls[1]['body'], true);
+
+        self::assertSame('PATCH', $http->calls[1]['method']);
+        self::assertSame(12, $sent['ordering']);
+    }
+
+    #[Test]
+    public function an_explicit_ordering_from_the_caller_is_respected(): void
+    {
+        $http = new FakeTransport([
+            self::releaseList([]),
+            self::ok(['data' => ['attributes' => ['id' => 77]]]),
+        ]);
+
+        self::publisher($http)->upsertRelease(self::release('1.2.0', ['ordering' => 42]));
+
+        // No category read: the caller decided, so there is nothing to look up.
+        $sent = json_decode((string) $http->calls[1]['body'], true);
+
+        self::assertSame(42, $sent['ordering']);
     }
 
     #[Test]
@@ -77,7 +192,11 @@ final class ArsPublisherTest extends TestCase
         // Sent as filter[category_id] it arrives as a PHP array named
         // `filter`, the filter is silently not applied, and the match runs
         // against an arbitrary window of every release on the site.
-        $http = new FakeTransport([self::releaseList([]), self::ok(['data' => ['attributes' => ['id' => 1]]])]);
+        $http = new FakeTransport([
+            self::releaseList([]),
+            self::releaseList([['id' => 5, 'version' => '1.1.0', 'ordering' => 3]]),
+            self::ok(['data' => ['attributes' => ['id' => 1]]]),
+        ]);
 
         self::publisher($http)->upsertRelease(self::release('1.2.0'));
 
@@ -127,13 +246,17 @@ final class ArsPublisherTest extends TestCase
     #[Test]
     public function requests_carry_the_token_and_jsonapi_accept_header(): void
     {
-        $http = new FakeTransport([self::releaseList([]), self::ok(['data' => ['attributes' => ['id' => 1]]])]);
+        $http = new FakeTransport([
+            self::releaseList([]),
+            self::releaseList([['id' => 5, 'version' => '1.1.0', 'ordering' => 3]]),
+            self::ok(['data' => ['attributes' => ['id' => 1]]]),
+        ]);
 
         self::publisher($http)->upsertRelease(self::release('1.2.0'));
 
         self::assertSame('secret-token', $http->calls[0]['headers']['X-Joomla-Token']);
         self::assertSame('application/vnd.api+json', $http->calls[0]['headers']['Accept']);
-        self::assertSame('application/json', $http->calls[1]['headers']['Content-Type']);
+        self::assertSame('application/json', $http->calls[2]['headers']['Content-Type']);
     }
 
     #[Test]
@@ -141,11 +264,15 @@ final class ArsPublisherTest extends TestCase
     {
         // AssertApiAccess::getRequestData() json_decodes the raw body and
         // treats its top-level keys as the record fields.
-        $http = new FakeTransport([self::releaseList([]), self::ok(['data' => ['attributes' => ['id' => 1]]])]);
+        $http = new FakeTransport([
+            self::releaseList([]),
+            self::releaseList([['id' => 5, 'version' => '1.1.0', 'ordering' => 3]]),
+            self::ok(['data' => ['attributes' => ['id' => 1]]]),
+        ]);
 
         self::publisher($http)->upsertRelease(self::release('1.2.0'));
 
-        $sent = json_decode((string) $http->calls[1]['body'], true);
+        $sent = json_decode((string) $http->calls[2]['body'], true);
 
         self::assertSame('1.2.0', $sent['version']);
         self::assertSame(7, $sent['category_id']);
@@ -294,6 +421,7 @@ final class ArsPublisherTest extends TestCase
     {
         $http = new FakeTransport([
             self::releaseList([]),
+            self::releaseList([['id' => 5, 'version' => '1.1.0', 'ordering' => 3]]),
             self::ok(['data' => ['attributes' => ['id' => 88]]]),
             self::itemList([]),
             self::ok(['data' => ['attributes' => ['id' => 99]]]),
@@ -308,14 +436,18 @@ final class ArsPublisherTest extends TestCase
             ['releaseId' => 88, 'itemId' => 99, 'releaseCreated' => true, 'itemCreated' => true],
             $result
         );
-        self::assertStringContainsString('release_id=88', $http->calls[2]['url']);
-        self::assertSame(88, json_decode((string) $http->calls[3]['body'], true)['release_id']);
+        self::assertStringContainsString('release_id=88', $http->calls[3]['url']);
+        self::assertSame(88, json_decode((string) $http->calls[4]['body'], true)['release_id']);
     }
 
     #[Test]
     public function a_create_that_returns_no_id_is_an_error(): void
     {
-        $http = new FakeTransport([self::releaseList([]), self::ok(['data' => ['attributes' => []]])]);
+        $http = new FakeTransport([
+            self::releaseList([]),
+            self::releaseList([['id' => 5, 'version' => '1.1.0', 'ordering' => 3]]),
+            self::ok(['data' => ['attributes' => []]]),
+        ]);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessageMatches('/returned no id/');


### PR DESCRIPTION
Closes #77.

## What was wrong

ARS decides "latest release" by the **lowest `ordering` in the category** — an anti-join in `ReleasesModel::getListQuery()` that keeps rows with no published sibling of a smaller `ordering`. Version numbers and dates are never consulted.

Nothing here set that field, and ARS assigns nothing useful: the column is `bigint unsigned NOT NULL` with no DEFAULT, and `ReleaseTable::check()` only turns null into 0. So every release we published landed on **0**, all tied for the minimum, the anti-join returned all of them, and `Latest\HtmlView` kept whichever row MySQL happened to return last.

christianwebministries.org served **Proclaim 10.3.1 from May until today** while 10.5.7 was out. All 60 releases across its four categories were at `ordering = 0`. The update streams were correct throughout, so Joomla's updater was unaffected — this only ever showed on the Latest Releases page.

## What changed

**Creating** a release places it one below the category minimum. It becomes the unique minimum and **no other record is touched**.

The obvious alternative — bump whatever holds 0 out of the way — is worse on two counts. A PATCH has to carry the whole record (`check()` is a full-record check and the form fills defaults for absent fields), so it would re-run `check()` over a live release's notes. And the public category listing is ordered by this same column, so each superseded release would get flung to the bottom of the page.

**Updating** a release now sends back the ordering it already has. Omitting the key is *not* neutral: `release.xml` declares `ordering` with `default="0"` and the form fills defaults for absent fields, so re-publishing a version to fix its notes silently dragged it to the front of its category. That is the likelier explanation for how everything ended up at 0 in the first place.

A caller-supplied `ordering` is still respected, and skips the lookup entirely.

## What it refuses to do

In line with the rest of this class, two cases error instead of guessing:

- **Category already pinned at 0** — `ordering` is unsigned, so there is no room below. The message says how to renumber.
- **Category read came back a full page** — a minimum taken from part of a category is not a minimum, and a release ordered above an unseen sibling would silently not be the latest.

## Cost

One extra GET on the create path. The update path is unchanged at two requests.

## Tests

`OK (395 tests, 944 assertions)` — 6 new, covering: ordered below the minimum, empty category leaves room below itself, zero-pinned category refused, truncated read refused, update preserves its ordering, explicit ordering respected.

## Not covered here

The four CWM categories were renumbered by hand today, so they have room below their minimum and this works immediately. Any *other* category still sitting at 0 will hit the refusal on first publish and needs renumbering once — that is the intended behaviour rather than a silent tie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)