### PR TITLE
feat(ars): add `cwm-ars-reorder` to space out a category's ordering

### DIFF
--- a/bin/cwm-ars-reorder
+++ b/bin/cwm-ars-reorder
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# cwm-ars-reorder — space out an ARS category's `ordering` so the newest
+# release stays the latest release, with room to publish into.
+#
+# ARS reads "latest" as the lowest ordering in a category and cwm-ars-publish
+# places each release one below the current minimum, so a category numbered
+# contiguously from 1 runs out of room after a single publish. This renumbers
+# newest-first in steps.
+#
+# Plans by default and writes nothing; --apply performs the renumbering.
+#
+# Usage from a consuming project:
+#   composer ars-reorder                            # plan, category from config
+#   composer ars-reorder -- --category 1            # plan, explicit category
+#   composer ars-reorder -- --category 1 --apply    # do it
+#
+set -euo pipefail
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec bash "${TOOLS_DIR}/scripts/ars-reorder.sh" "$@"

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "bin/cwm-sync-languages",
         "bin/cwm-ars-publish",
         "bin/cwm-ars-list",
+        "bin/cwm-ars-reorder",
         "bin/cwm-ars-create-stream",
         "bin/cwm-changelog",
         "bin/cwm-article",

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -56,6 +56,7 @@ The full release flow is documented in [Releasing](releasing.md).
 | `cwm-ars-list` | List ARS categories, update streams, and releases. |
 | `cwm-ars-create-stream` | Create a new ARS Update Stream under a category. |
 | `cwm-ars-publish` | Push a built artifact to Akeeba Release System. |
+| `cwm-ars-reorder` | Space out a category's `ordering` so the newest release stays the latest, with room to publish into. Plans by default; `--apply` writes. |
 
 ARS endpoint, category, and stream IDs come from the `ars` block in
 `cwm-build.config.json`; the API token is read from 1Password (`tokenItem` /

--- a/scripts/ars-reorder.php
+++ b/scripts/ars-reorder.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The ARS API half of `cwm-ars-reorder`.
+ *
+ * scripts/ars-reorder.sh owns the shell work — reading the config, getting the
+ * token out of 1Password — and hands the result here, the same split as
+ * scripts/ars-publish-api.php. The renumbering itself lives in
+ * {@see ArsPublisher::reorderCategory} so the ordering decisions can be
+ * exercised against canned API responses instead of against a live download
+ * page.
+ *
+ * ## Why this command exists
+ *
+ * ARS reads "latest release" as the *lowest* `ordering` in a category, and the
+ * publisher places each new release one below the current minimum. That works
+ * until the minimum hits 0, because the column is unsigned. A category numbered
+ * contiguously from 1 — which is what dragging a release to the top in the ARS
+ * backend leaves, since Joomla's saveOrderAjax renumbers 1..N — therefore has
+ * exactly one publish of headroom before the next one stops with an error.
+ *
+ * This spaces a category out so that stops being a concern.
+ *
+ * ## Why the environment rather than arguments
+ *
+ * The API token arrives in `CWM_ARS_TOKEN`: command-line arguments are world
+ * readable through `ps` on a shared machine or CI runner, the environment of
+ * another user's process is not.
+ *
+ * Exit codes:
+ *   0  planned, or applied
+ *   1  a required value was missing, or ARS rejected a write
+ *
+ * @license GPL-2.0-or-later
+ */
+
+require_once __DIR__ . '/../src/Http/HttpResponse.php';
+require_once __DIR__ . '/../src/Http/HttpTransport.php';
+require_once __DIR__ . '/../src/Http/StreamTransport.php';
+require_once __DIR__ . '/../src/Release/ArsPublisher.php';
+
+use CWM\BuildTools\Http\StreamTransport;
+use CWM\BuildTools\Release\ArsPublisher;
+
+function requiredEnv(string $name): string
+{
+    $value = getenv($name);
+
+    if ($value === false || trim($value) === '') {
+        fwrite(\STDERR, "Error: {$name} is not set. This script is called by scripts/ars-reorder.sh,\n");
+        fwrite(\STDERR, "       which assembles the values it needs; it is not meant to be run by hand.\n");
+        exit(1);
+    }
+
+    return $value;
+}
+
+try {
+    $endpoint   = requiredEnv('CWM_ARS_ENDPOINT');
+    $token      = requiredEnv('CWM_ARS_TOKEN');
+    $categoryId = (int) requiredEnv('CWM_ARS_CATEGORY_ID');
+    $stride     = (int) (getenv('CWM_ARS_STRIDE') ?: '100');
+    $apply      = getenv('CWM_ARS_APPLY') === '1';
+
+    if ($categoryId <= 0) {
+        fwrite(\STDERR, "Error: CWM_ARS_CATEGORY_ID must be a positive category id.\n");
+        exit(1);
+    }
+
+    $publisher = new ArsPublisher($endpoint, $token, new StreamTransport());
+    $result    = $publisher->reorderCategory($categoryId, $stride, $apply);
+
+    $changes = $result['changes'];
+
+    printf(
+        "%s ARS category %d @ %s (stride %d)\n\n",
+        $apply ? 'Renumbering' : 'Planning',
+        $categoryId,
+        rtrim($endpoint, '/'),
+        $stride
+    );
+
+    if ($changes === []) {
+        print("  Already spaced as requested — nothing to change.\n");
+        exit(0);
+    }
+
+    printf("  %-20s  %8s  %8s\n", 'Version', 'From', 'To');
+    printf("  %-20s  %8s  %8s\n", str_repeat('-', 20), '--------', '--------');
+
+    foreach ($changes as $change) {
+        printf("  %-20s  %8d  %8d\n", substr($change['version'], 0, 20), $change['from'], $change['to']);
+    }
+
+    printf("\n  %d release(s) %s.\n", \count($changes), $apply ? 'renumbered' : 'would be renumbered');
+
+    if (!$apply) {
+        print("\n  Nothing was written. Re-run with --apply to make these changes.\n");
+    } else {
+        printf(
+            "\n  The newest release now holds ordering %d, so it is what the Latest Releases\n"
+            . "  page shows, and there is room for %d publishes below it.\n",
+            $stride,
+            $stride - 1
+        );
+    }
+
+    exit(0);
+} catch (\InvalidArgumentException $e) {
+    fwrite(\STDERR, "Error: {$e->getMessage()}\n");
+    exit(1);
+} catch (\Throwable $e) {
+    fwrite(\STDERR, "Error: {$e->getMessage()}\n");
+    exit(1);
+}

--- a/scripts/ars-reorder.sh
+++ b/scripts/ars-reorder.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Space out an ARS category's `ordering` so the newest release stays the
+# latest release, with room to publish into.
+#
+# ARS reads "latest" as the *lowest* ordering in a category, and cwm-ars-publish
+# places each new release one below the current minimum. The column is unsigned,
+# so a category numbered contiguously from 1 — which is what dragging a release
+# to the top in the ARS backend leaves behind — has exactly one publish of
+# headroom before the next one stops with an error. This renumbers newest-first
+# in steps so that stops being a concern.
+#
+# Reads ars.endpoint, ars.categoryId, ars.tokenItem, ars.tokenVault from
+# cwm-build.config.json. ARS_API_TOKEN env var override supported.
+#
+# Plans by default and writes nothing. --apply performs the renumbering.
+#
+# Usage:
+#   bash scripts/ars-reorder.sh                        # plan, config category
+#   bash scripts/ars-reorder.sh --category 1           # plan, explicit category
+#   bash scripts/ars-reorder.sh --category 1 --apply   # do it
+#   bash scripts/ars-reorder.sh --stride 500 --apply   # wider gaps
+#
+set -euo pipefail
+
+PROJECT_ROOT="$(pwd)"
+CONFIG_FILE="${PROJECT_ROOT}/cwm-build.config.json"
+
+CATEGORY_ID=""
+STRIDE="100"
+APPLY="0"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --category)
+            CATEGORY_ID="${2:-}"
+            shift 2
+            ;;
+        --stride)
+            STRIDE="${2:-}"
+            shift 2
+            ;;
+        --apply)
+            APPLY="1"
+            shift
+            ;;
+        -h|--help)
+            sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown argument '$1'. Try --help." >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "Error: $CONFIG_FILE not found" >&2
+    exit 1
+fi
+
+read_config() {
+    php -r "\$c = json_decode(file_get_contents('${CONFIG_FILE}'), true); \$keys = explode('.', '$1'); \$v = \$c; foreach (\$keys as \$k) { \$v = \$v[\$k] ?? null; if (\$v === null) break; } echo \$v ?? '';"
+}
+
+SITE_URL=$(read_config "ars.endpoint")
+TOKEN_ITEM=$(read_config "ars.tokenItem")
+TOKEN_VAULT=$(read_config "ars.tokenVault")
+
+TOKEN_ITEM="${TOKEN_ITEM:-CWM ARS API Token}"
+TOKEN_VAULT="${TOKEN_VAULT:-CWM}"
+
+if [ -z "$CATEGORY_ID" ]; then
+    CATEGORY_ID=$(read_config "ars.categoryId")
+fi
+
+if [ -z "$SITE_URL" ]; then
+    echo "Error: ars.endpoint not configured in cwm-build.config.json" >&2
+    exit 1
+fi
+
+if [ -z "$CATEGORY_ID" ]; then
+    echo "Error: no category. Set ars.categoryId in cwm-build.config.json, or pass --category." >&2
+    echo "       'composer ars-list -- categories' lists the ids." >&2
+    exit 1
+fi
+
+# --- Token ---
+if [ -n "${ARS_API_TOKEN:-}" ]; then
+    TOKEN="$ARS_API_TOKEN"
+elif command -v op >/dev/null 2>&1; then
+    TOKEN=$(op item get "$TOKEN_ITEM" --vault "$TOKEN_VAULT" --fields label=credential --reveal 2>/dev/null || echo "")
+else
+    echo "Error: ARS_API_TOKEN not set and 1Password CLI (op) not installed." >&2
+    exit 1
+fi
+
+if [ -z "$TOKEN" ]; then
+    echo "Error: Could not retrieve API token." >&2
+    exit 1
+fi
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+CWM_ARS_ENDPOINT="$SITE_URL" \
+CWM_ARS_TOKEN="$TOKEN" \
+CWM_ARS_CATEGORY_ID="$CATEGORY_ID" \
+CWM_ARS_STRIDE="$STRIDE" \
+CWM_ARS_APPLY="$APPLY" \
+    php "${TOOLS_DIR}/scripts/ars-reorder.php"

--- a/scripts/init.php
+++ b/scripts/init.php
@@ -57,6 +57,7 @@ const CWM_COMPOSER_SCRIPTS = [
     'changelog'      => 'vendor/bin/cwm-changelog',
     'ars-publish'    => 'vendor/bin/cwm-ars-publish',
     'ars-list'       => 'vendor/bin/cwm-ars-list',
+    'ars-reorder'    => 'vendor/bin/cwm-ars-reorder',
     'sync-configs'   => 'vendor/bin/cwm-sync-configs',
     'sync-languages' => 'vendor/bin/cwm-sync-languages',
 ];

--- a/src/Release/ArsPublisher.php
+++ b/src/Release/ArsPublisher.php
@@ -210,27 +210,7 @@ final class ArsPublisher
      */
     private function orderingForNewest(int $categoryId): int
     {
-        $query = http_build_query([
-            'category_id' => $categoryId,
-            'page'        => ['limit' => self::PAGE_LIMIT],
-        ]);
-
-        $rows = $this->readList("/releases?{$query}", 'releases');
-
-        // A full page means the list was probably cut off, and a minimum taken
-        // from part of a category is not a minimum. Guessing here would place
-        // the release above a sibling we never saw and quietly reinstate the
-        // bug this method exists to prevent.
-        if (\count($rows) >= self::PAGE_LIMIT) {
-            throw new \RuntimeException(sprintf(
-                'ARS category %d returned the full %d-row page, so this may not be all of it and the lowest '
-                . '`ordering` cannot be established. Refusing to guess: a release ordered above an unseen '
-                . 'sibling would not become the latest, and nothing about the publish would say so. '
-                . 'Raise ArsPublisher::PAGE_LIMIT above the number of releases in the category.',
-                $categoryId,
-                self::PAGE_LIMIT
-            ));
-        }
+        $rows = $this->categoryReleases($categoryId);
 
         $orderings = array_map(
             static fn (array $row): int => (int) (($row['attributes'] ?? [])['ordering'] ?? 0),
@@ -250,15 +230,142 @@ final class ArsPublisher
                 'ARS category %d has a release at ordering 0, so there is no room to place this one below it. '
                 . '`ordering` is unsigned, 0 is the floor, and a tie for the lowest value is exactly the bug '
                 . 'that made the Latest Releases page stick on an old version (cwm-build-tools#77). '
-                . 'Renumber the category once so the newest release has the lowest ordering and nothing sits '
-                . 'at 0 — in the ARS backend: Releases, filter to the category, sort by Ordering, drag the '
-                . 'newest release to the top. Leave a gap by numbering in steps if you publish often. '
-                . 'Then re-run this publish.',
+                . 'Renumber the category once, then re-run this publish: '
+                . '`composer ars-reorder -- --category %d` shows what it would change, and '
+                . '`composer ars-reorder -- --category %d --apply` does it. That spaces the category out so '
+                . 'this does not come back after the next publish, which is what dragging to the top in the '
+                . 'ARS backend would leave you with.',
+                $categoryId,
+                $categoryId,
                 $categoryId
             ));
         }
 
         return $minimum - 1;
+    }
+
+    /**
+     * Renumber a category so the newest release sorts first, with gaps.
+     *
+     * {@see orderingForNewest} places each new release one below the category
+     * minimum, which works until the minimum reaches 0 — `ordering` is
+     * unsigned, so there is no room below that and the publish stops. A
+     * category numbered contiguously from 1 therefore has exactly one publish
+     * of headroom, which is what a drag-to-top in the ARS backend leaves
+     * behind: Joomla's saveOrderAjax renumbers 1..N with no gaps.
+     *
+     * This spaces the category out instead. Releases are numbered newest-first
+     * as `stride`, `2 * stride`, `3 * stride`, so the newest is the minimum ARS
+     * looks for, the public category listing (ordered by this same column) runs
+     * newest to oldest, and there are `stride - 1` publishes of room underneath
+     * before anyone has to think about this again.
+     *
+     * Ordering by `created` rather than by version string is deliberate: version
+     * strings do not sort (10.3.10 vs 10.3.2), and a release's date is what the
+     * download page shows anyway.
+     *
+     * ## What a write here costs
+     *
+     * Only releases whose ordering actually changes are written, and each write
+     * is a PATCH carrying that release's whole record — a partial PATCH would
+     * blank fields to their form defaults (see the `ordering` note on this
+     * class). So `check()` re-runs on those releases, which re-filters their
+     * notes through Joomla's InputFilter. That is idempotent on already-filtered
+     * HTML, but it is a write to a live download page and the reason `$apply`
+     * defaults to false.
+     *
+     * Note the record sent back is what the API returns, and the API does not
+     * expose a release's tags. A release that has tags may lose them. ARS gained
+     * tags in 7.4 and CWM has never set any, so this is a caveat rather than a
+     * known loss — check before running it against a category that uses them.
+     *
+     * @param  int  $categoryId Category to renumber.
+     * @param  int  $stride     Gap between releases. 100 gives 99 publishes of room.
+     * @param  bool $apply      false plans without writing anything.
+     *
+     * @return array{stride: int, applied: bool, changes: list<array{id: int, version: string, from: int, to: int}>}
+     */
+    public function reorderCategory(int $categoryId, int $stride = 100, bool $apply = false): array
+    {
+        if ($stride < 2) {
+            throw new \InvalidArgumentException(
+                "A stride of {$stride} leaves no room to publish into. Use at least 2, and prefer 100 or more "
+                . 'unless the category is nearly dormant — each publish consumes one step.'
+            );
+        }
+
+        $rows = $this->categoryReleases($categoryId);
+
+        usort($rows, static function (array $a, array $b): int {
+            $aa = $a['attributes'] ?? [];
+            $ba = $b['attributes'] ?? [];
+
+            // Newest first. `created` is an ARS datetime string; fall back to
+            // the id, which is monotonic, when it is missing or unparseable.
+            $at = strtotime((string) ($aa['created'] ?? '')) ?: 0;
+            $bt = strtotime((string) ($ba['created'] ?? '')) ?: 0;
+
+            return $bt <=> $at ?: ((int) ($ba['id'] ?? 0) <=> (int) ($aa['id'] ?? 0));
+        });
+
+        $changes = [];
+
+        foreach (array_values($rows) as $index => $row) {
+            $attributes = $row['attributes'] ?? [];
+            $target     = ($index + 1) * $stride;
+            $current    = (int) ($attributes['ordering'] ?? 0);
+
+            if ($current === $target) {
+                continue;
+            }
+
+            $changes[] = [
+                'id'      => (int) ($attributes['id'] ?? 0),
+                'version' => (string) ($attributes['version'] ?? '?'),
+                'from'    => $current,
+                'to'      => $target,
+            ];
+
+            if ($apply) {
+                $attributes['ordering'] = $target;
+
+                $this->send('PATCH', '/releases/' . (int) $attributes['id'], $attributes);
+            }
+        }
+
+        return ['stride' => $stride, 'applied' => $apply, 'changes' => $changes];
+    }
+
+    /**
+     * Every release in a category, refusing a read that may be truncated.
+     *
+     * A minimum — or a renumbering — taken from part of a category is worse
+     * than no answer: it would place a release above a sibling that was never
+     * seen, and the publish would report success.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function categoryReleases(int $categoryId): array
+    {
+        $query = http_build_query([
+            'category_id' => $categoryId,
+            'page'        => ['limit' => self::PAGE_LIMIT],
+        ]);
+
+        $rows = $this->readList("/releases?{$query}", 'releases');
+
+        if (\count($rows) >= self::PAGE_LIMIT) {
+            throw new \RuntimeException(sprintf(
+                'ARS category %d returned the full %d-row page, so this may not be all of it and the lowest '
+                . '`ordering` cannot be established. Refusing to guess: a release ordered above an unseen '
+                . 'sibling would not become the latest, and nothing about the publish would say so. '
+                . 'Raise ArsPublisher::PAGE_LIMIT above the number of releases in the category.',
+                $categoryId,
+                self::PAGE_LIMIT
+            ));
+        }
+
+        return $rows;
     }
 
     /**

--- a/tests/Release/ArsPublisherTest.php
+++ b/tests/Release/ArsPublisherTest.php
@@ -168,6 +168,99 @@ final class ArsPublisherTest extends TestCase
     }
 
     #[Test]
+    public function reorder_numbers_newest_first_in_strides(): void
+    {
+        // Newest gets the lowest ordering because that is what ARS reads as
+        // "latest"; the gaps are what later publishes are placed into.
+        $http = new FakeTransport([
+            self::releaseList([
+                ['id' => 1, 'version' => '1.0.0', 'ordering' => 0, 'created' => '2026-01-01 00:00:00'],
+                ['id' => 2, 'version' => '1.2.0', 'ordering' => 0, 'created' => '2026-03-01 00:00:00'],
+                ['id' => 3, 'version' => '1.1.0', 'ordering' => 0, 'created' => '2026-02-01 00:00:00'],
+            ]),
+        ]);
+
+        $result = self::publisher($http)->reorderCategory(7);
+
+        self::assertSame(
+            [
+                ['id' => 2, 'version' => '1.2.0', 'from' => 0, 'to' => 100],
+                ['id' => 3, 'version' => '1.1.0', 'from' => 0, 'to' => 200],
+                ['id' => 1, 'version' => '1.0.0', 'from' => 0, 'to' => 300],
+            ],
+            $result['changes']
+        );
+    }
+
+    #[Test]
+    public function reorder_plans_without_writing_unless_applied(): void
+    {
+        $http = new FakeTransport([
+            self::releaseList([
+                ['id' => 1, 'version' => '1.0.0', 'ordering' => 0, 'created' => '2026-01-01 00:00:00'],
+            ]),
+        ]);
+
+        $result = self::publisher($http)->reorderCategory(7);
+
+        self::assertFalse($result['applied']);
+        // The read, and nothing else.
+        self::assertCount(1, $http->calls);
+    }
+
+    #[Test]
+    public function reorder_writes_a_full_record_when_applied(): void
+    {
+        // A partial PATCH blanks whatever it omits to the form default, so the
+        // renumber has to send the release back whole with ordering swapped.
+        $http = new FakeTransport([
+            self::releaseList([
+                ['id' => 9, 'version' => '2.0.0', 'ordering' => 4, 'created' => '2026-01-01 00:00:00', 'notes' => '<p>x</p>'],
+            ]),
+            self::ok(['data' => ['attributes' => ['id' => 9]]]),
+        ]);
+
+        self::publisher($http)->reorderCategory(7, 100, true);
+
+        self::assertSame('PATCH', $http->calls[1]['method']);
+        self::assertStringContainsString('/releases/9', $http->calls[1]['url']);
+
+        $sent = json_decode((string) $http->calls[1]['body'], true);
+
+        self::assertSame(100, $sent['ordering']);
+        self::assertSame('2.0.0', $sent['version']);
+        self::assertSame('<p>x</p>', $sent['notes']);
+    }
+
+    #[Test]
+    public function reorder_leaves_releases_that_are_already_right_alone(): void
+    {
+        $http = new FakeTransport([
+            self::releaseList([
+                ['id' => 2, 'version' => '1.1.0', 'ordering' => 100, 'created' => '2026-02-01 00:00:00'],
+                ['id' => 1, 'version' => '1.0.0', 'ordering' => 200, 'created' => '2026-01-01 00:00:00'],
+            ]),
+        ]);
+
+        $result = self::publisher($http)->reorderCategory(7, 100, true);
+
+        self::assertSame([], $result['changes']);
+        // No writes: the read is the only call.
+        self::assertCount(1, $http->calls);
+    }
+
+    #[Test]
+    public function reorder_refuses_a_stride_with_no_room_to_publish_into(): void
+    {
+        $http = new FakeTransport([]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/no room to publish into/');
+
+        self::publisher($http)->reorderCategory(7, 1);
+    }
+
+    #[Test]
     public function version_match_is_exact_not_substring(): void
     {
         // ARS `search` substring-matches, so a search for 10.3.1 returns


### PR DESCRIPTION
Follow-up to #78. That fix works, but it has a headroom problem I under-thought when I chose "refuse rather than renumber".

## The gap

ARS reads "latest" as the **lowest `ordering`** in a category, and `ArsPublisher` places each new release one below the current minimum. `ordering` is unsigned, so **0 is the floor**: a category numbered contiguously from 1 gets exactly *one* publish before the next one stops with the no-room error.

And contiguous-from-1 is exactly what the manual fix produces. Dragging a release to the top in the ARS backend goes through Joomla's `saveOrderAjax`, which renumbers `1..N` with no gaps. So the four CWM categories renumbered by hand this morning would each have published once and then wedged — the refusal firing mid-release, which is the worst moment for it.

## What this adds

`cwm-ars-reorder` renumbers a category **newest-first in strides** (100 by default):

- the newest release holds the minimum ARS looks for, so it is what the Latest Releases page shows
- the public category listing — ordered by this same column — runs newest to oldest
- there are `stride - 1` publishes of room underneath before anyone thinks about this again

```
composer ars-reorder -- --category 1            # plan, writes nothing
composer ars-reorder -- --category 1 --apply    # do it
composer ars-reorder -- --stride 500 --apply    # wider gaps
```

Sorting is by `created`, not version string, because version strings do not sort — 10.3.10 against 10.3.2.

## Safety

- **Plans by default.** `--apply` is required to write anything.
- **Only changed rows are written.** A category already spaced correctly makes zero writes.
- Each write is a PATCH carrying the **whole record**, because a partial one blanks fields to their form defaults. The docblock is explicit that this re-runs `check()` and re-filters notes, and that the API does not expose tags — a release with tags could lose them. ARS gained tags in 7.4 and CWM has never set any, but it is called out rather than buried.

The no-room error from #78 now names this command instead of describing the drag that recreates the problem.

## Shape

Follows the existing split: `bin/cwm-ars-reorder` → `scripts/ars-reorder.sh` (config, 1Password token) → `scripts/ars-reorder.php` → `ArsPublisher::reorderCategory()`, so the ordering decisions sit where the suite can reach them. Registered in `composer.json` bin, `scripts/init.php`, and `docs/commands.md`.

## Tests

`OK (400 tests, 956 assertions)` — 5 new: newest-first strides, plan makes no writes, apply sends a full record, an already-correct category is left alone, a stride with no room is refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)