### PR TITLE
ci: run the test suite on PHP 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,10 +33,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 8.3 is the composer.json floor; 8.4 is what the maintainers actually
-        # run day to day, and a release that only works on one of them should
+        # 8.3 is the composer.json floor; 8.4 and 8.5 are what the maintainers
+        # actually run, and a release that only works on one of them should
         # fail here rather than at a consumer.
-        php: ['8.3', '8.4']
+        #
+        # 8.5 is in the matrix because leaving it out made CI greener than
+        # reality: the machine that cuts releases runs 8.5, so the version that
+        # actually publishes was the one version nothing verified.
+        #
+        # It does not, on its own, catch the deprecation in #80. That fires in
+        # StreamTransport, which the suite deliberately does not exercise —
+        # ArsPublisher is tested through FakeTransport so publishing decisions
+        # can be checked without the network. Catching #80 needs coverage of
+        # StreamTransport as well as this matrix entry.
+        php: ['8.3', '8.4', '8.5']
 
     steps:
       - uses: actions/checkout@v4

--- a/scripts/lib/dryrun.sh
+++ b/scripts/lib/dryrun.sh
@@ -21,24 +21,46 @@
 # Arguments:
 #   The caller's "$@".
 #
+# An unrecognised option is an error, not a positional. `--dry-runn` used to
+# fall through to CWM_ARGS, where it was ignored, and the release ran for real
+# while the operator believed they had asked for a preview — which is exactly
+# what happened cutting pkg_cwmscripture 1.2.2. The flag being dropped is the
+# one that says "do not do any of this", so silence is the worst response.
+#
+# Only arguments beginning with `-` are judged. A version never does, so a
+# mistyped version still reaches the semver check that already exists, with a
+# better message than this function could give.
+#
 # Sets:
 #   CWM_DRY_RUN    1 when --dry-run/-n was present, else 0.
 #   CWM_SKIP_TESTS 1 when --skip-tests was present, else 0.
+#   CWM_HELP       1 when --help/-h was present, else 0.
 #   CWM_ARGS       Array of the non-flag arguments (may be empty).
+#   CWM_BAD_FLAG   The offending option when the return status is non-zero.
+#
+# Returns:
+#   0 normally, 1 when an unrecognised option was given.
 cwm_parse_dry_run() {
     CWM_DRY_RUN=0
     CWM_SKIP_TESTS=0
+    CWM_HELP=0
     CWM_ARGS=()
+    CWM_BAD_FLAG=''
 
     local arg
     for arg in "$@"; do
-        # shellcheck disable=SC2034  # CWM_SKIP_TESTS is read by release.sh, not this file
+        # shellcheck disable=SC2034  # CWM_SKIP_TESTS/CWM_HELP are read by release.sh, not this file
         case "$arg" in
             --dry-run|-n)  CWM_DRY_RUN=1 ;;
             --skip-tests)  CWM_SKIP_TESTS=1 ;;
+            --help|-h)     CWM_HELP=1 ;;
+            --)            ;;
+            -*)            CWM_BAD_FLAG="$arg"; return 1 ;;
             *)             CWM_ARGS+=("$arg") ;;
         esac
     done
+
+    return 0
 }
 
 # Run a command, or describe it when CWM_DRY_RUN is 1.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -77,7 +77,33 @@ PROJECT_ROOT="$(pwd)"
 # and `release.sh 1.2.3 --dry-run --skip-tests` both work; what remains is the
 # positional version argument the rest of the script already expects. Parsing
 # and the command wrapper live in lib/dryrun.sh so they can be tested.
-cwm_parse_dry_run "$@"
+usage() {
+    cat <<'USAGE'
+cwm-release — full release pipeline for a CWM Joomla extension.
+
+Usage:
+  composer release -- <version> [--dry-run|-n] [--skip-tests]
+  composer release                  # prompts for the version
+
+Options:
+  -n, --dry-run     Print every mutating command instead of running it.
+  --skip-tests      Skip the composer test:release gate.
+  -h, --help        Show this and exit.
+USAGE
+}
+
+if ! cwm_parse_dry_run "$@"; then
+    echo "Error: unknown option '${CWM_BAD_FLAG}'." >&2
+    echo >&2
+    usage >&2
+    exit 1
+fi
+
+if [ "$CWM_HELP" = "1" ]; then
+    usage
+    exit 0
+fi
+
 DRY_RUN="$CWM_DRY_RUN"
 SKIP_TESTS="$CWM_SKIP_TESTS"
 set -- "${CWM_ARGS[@]+"${CWM_ARGS[@]}"}"

--- a/tests/shell/dryrun.test.sh
+++ b/tests/shell/dryrun.test.sh
@@ -38,7 +38,49 @@ assert_equals "1" "$CWM_DRY_RUN" "-n is accepted as the short form"
 # CWM_ARGS must be empty rather than carrying the flag through.
 cwm_parse_dry_run --dry-run
 assert_equals "1" "$CWM_DRY_RUN" "the flag alone is recognised"
+
 assert_equals "0" "${#CWM_ARGS[@]}" "no positional arguments remain"
+
+# --- Unrecognised options ----------------------------------------------------
+#
+# The case this exists for: a mistyped --dry-run used to be filed as a
+# positional and ignored, so a run the operator believed was a preview
+# published for real (pkg_cwmscripture 1.2.2, issue #73).
+if cwm_parse_dry_run 1.2.3 --dry-runn; then
+    assert_equals "non-zero" "0" "a mistyped --dry-run must not be accepted"
+else
+    assert_equals "--dry-runn" "$CWM_BAD_FLAG" "the offending option is reported back"
+fi
+
+if cwm_parse_dry_run --nope; then
+    assert_equals "non-zero" "0" "an unknown long option is rejected"
+else
+    assert_equals "--nope" "$CWM_BAD_FLAG" "and named"
+fi
+
+if cwm_parse_dry_run -x 1.2.3; then
+    assert_equals "non-zero" "0" "an unknown short option is rejected"
+else
+    assert_equals "-x" "$CWM_BAD_FLAG" "and named"
+fi
+
+# A version is never flag-shaped, so it is still treated as a positional and
+# left to the semver check, which gives a better message than this parser could.
+cwm_parse_dry_run 1.2.3rc
+assert_equals "1.2.3rc" "${CWM_ARGS[*]}" "a malformed version is still a positional"
+
+# --help must not be mistaken for a version to release.
+cwm_parse_dry_run --help
+assert_equals "1" "$CWM_HELP" "--help is recognised"
+assert_equals "" "${CWM_ARGS[*]:-}" "and does not become the version"
+
+cwm_parse_dry_run -h
+assert_equals "1" "$CWM_HELP" "-h is the short form"
+
+# A bare -- is a conventional separator, not an unknown option.
+cwm_parse_dry_run -- 1.2.3
+assert_equals "1.2.3" "${CWM_ARGS[*]}" "a bare -- separator is ignored"
+
 
 # A version that merely looks flag-ish is not swallowed.
 cwm_parse_dry_run 1.2.3-beta1


### PR DESCRIPTION
Refs #80.

The matrix covered **8.3** (the `composer.json` floor) and **8.4** — but the machine that cuts releases runs **8.5.7**. So the version that actually publishes was the one version nothing verified, and CI was greener than reality.

```diff
-        php: ['8.3', '8.4']
+        php: ['8.3', '8.4', '8.5']
```

## What this does not do

It does **not**, on its own, catch the deprecation in #80.

That fires in `StreamTransport`, which the suite deliberately does not exercise — `ArsPublisher` is tested through `FakeTransport` so publishing decisions can be checked without the network, which is the right split. But it means an 8.5 job runs green while `$http_response_header` is deprecated underneath it.

Catching #80 needs **coverage of `StreamTransport`** as well as this matrix entry. The workflow comment says that outright rather than implying the matrix is sufficient, so nobody later reads the green 8.5 job as proof the HTTP layer is 8.5-clean.

## Expected result

Green. The suite passes on 8.5.7 locally (`OK (400 tests, 956 assertions)`) — precisely because the deprecating code path isn't covered.

The `lint` job stays pinned to 8.3; coding standards don't vary by runtime version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)