### PR TITLE
fix(release): four release-pipeline defects found cutting 10.5.7 (#73, #74, #75, #76)

### DIFF
--- a/scripts/generate-changelog-entry.sh
+++ b/scripts/generate-changelog-entry.sh
@@ -188,6 +188,21 @@ if [ -z "$ENTRY" ]; then
     exit 1
 fi
 
+# An entry with no <item> is well-formed and says nothing. It happens when the
+# range the notes were generated from contains only chores — most often when the
+# previous tag was a release candidate, so everything worth describing sits under
+# a version no site was offered (#74). Releasing around it is a decision, not an
+# error, but it should be a decision someone makes rather than one that happens.
+ITEM_COUNT=$(printf '%s' "$ENTRY" | grep -c '<item>' || true)
+
+if [ "$ITEM_COUNT" -eq 0 ]; then
+    echo "WARNING: the ${VERSION} entry has no items — the release notes for this" >&2
+    echo "         range described nothing user-facing. If the previous tag was a" >&2
+    echo "         pre-release, the description you want is probably under it." >&2
+    echo "         Write the entry by hand before releasing; this script skips a" >&2
+    echo "         version already present in the file." >&2
+fi
+
 if [ "$DRY_RUN" = true ]; then
     echo "$ENTRY"
     exit 0

--- a/scripts/lib/dryrun.sh
+++ b/scripts/lib/dryrun.sh
@@ -21,24 +21,46 @@
 # Arguments:
 #   The caller's "$@".
 #
+# An unrecognised option is an error, not a positional. `--dry-runn` used to
+# fall through to CWM_ARGS, where it was ignored, and the release ran for real
+# while the operator believed they had asked for a preview — which is exactly
+# what happened cutting pkg_cwmscripture 1.2.2. The flag being dropped is the
+# one that says "do not do any of this", so silence is the worst response.
+#
+# Only arguments beginning with `-` are judged. A version never does, so a
+# mistyped version still reaches the semver check that already exists, with a
+# better message than this function could give.
+#
 # Sets:
 #   CWM_DRY_RUN    1 when --dry-run/-n was present, else 0.
 #   CWM_SKIP_TESTS 1 when --skip-tests was present, else 0.
+#   CWM_HELP       1 when --help/-h was present, else 0.
 #   CWM_ARGS       Array of the non-flag arguments (may be empty).
+#   CWM_BAD_FLAG   The offending option when the return status is non-zero.
+#
+# Returns:
+#   0 normally, 1 when an unrecognised option was given.
 cwm_parse_dry_run() {
     CWM_DRY_RUN=0
     CWM_SKIP_TESTS=0
+    CWM_HELP=0
     CWM_ARGS=()
+    CWM_BAD_FLAG=''
 
     local arg
     for arg in "$@"; do
-        # shellcheck disable=SC2034  # CWM_SKIP_TESTS is read by release.sh, not this file
+        # shellcheck disable=SC2034  # CWM_SKIP_TESTS/CWM_HELP are read by release.sh, not this file
         case "$arg" in
             --dry-run|-n)  CWM_DRY_RUN=1 ;;
             --skip-tests)  CWM_SKIP_TESTS=1 ;;
+            --help|-h)     CWM_HELP=1 ;;
+            --)            ;;
+            -*)            CWM_BAD_FLAG="$arg"; return 1 ;;
             *)             CWM_ARGS+=("$arg") ;;
         esac
     done
+
+    return 0
 }
 
 # Run a command, or describe it when CWM_DRY_RUN is 1.

--- a/scripts/lib/version.sh
+++ b/scripts/lib/version.sh
@@ -61,6 +61,46 @@ cwm_is_prerelease() {
     [[ "$1" == *-* ]]
 }
 
+# Pick the newest stable tag from a list, ignoring pre-releases.
+#
+# The changelog and the generated release notes are built from the range
+# "previous tag → this tag". `git describe` answers with the nearest tag, which
+# after a release candidate is the candidate itself — so cutting 1.1.10 straight
+# after 1.1.10-rc1 produced a range containing only the version bump, and an
+# entry with nothing in it. The description of what changed sat under the rc,
+# which no site was ever offered (#74).
+#
+# What a reader wants is "since the last thing anyone could install", so
+# pre-release tags are skipped. If every tag is a pre-release — a project that
+# has only ever shipped betas — the newest of those is returned rather than
+# nothing, because an approximate base still beats no notes at all.
+#
+# Arguments:
+#   $1  newline-separated tags, newest last (as `git tag --sort=v:refname` gives)
+#
+# Outputs:
+#   The chosen tag, or nothing when the list is empty.
+cwm_latest_stable_tag() {
+    local tags="$1"
+    local tag newest_stable='' newest_any=''
+
+    while IFS= read -r tag; do
+        [ -n "$tag" ] || continue
+        newest_any="$tag"
+
+        # Compare the version, not the tag, so a leading v is not read as a suffix.
+        if ! cwm_is_prerelease "${tag#v}"; then
+            newest_stable="$tag"
+        fi
+    done <<< "$tags"
+
+    if [ -n "$newest_stable" ]; then
+        printf '%s\n' "$newest_stable"
+    elif [ -n "$newest_any" ]; then
+        printf '%s\n' "$newest_any"
+    fi
+}
+
 # The `gh release create` flag for a version: "--prerelease" or nothing.
 #
 # Arguments:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -370,9 +370,12 @@ echo ""
 # --- Step 5: GitHub release ---
 echo "[5/9] Creating GitHub release ${TAG}..."
 
-# `HEAD` is the bump commit we just pushed; `git describe` from there finds the
-# previous reachable tag, which is what we want for the changelog "since" base.
-PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
+# The changelog base is "since the last thing anyone could install", so
+# pre-release tags are skipped. `git describe` answers with the nearest tag,
+# which straight after a release candidate is the candidate — and the range
+# then holds only the version bump, producing an entry with nothing in it
+# while the real description sits under a tag no site was offered (#74).
+PREV_TAG=$(cwm_latest_stable_tag "$(git tag --merged HEAD --sort=v:refname 2>/dev/null || echo "")")
 if [ -n "$PREV_TAG" ] && [ -n "$GH_OWNER" ] && [ -n "$GH_REPO" ]; then
     NOTES=$(gh api "repos/${GH_OWNER}/${GH_REPO}/releases/generate-notes" \
         -f tag_name="$TAG" -f target_commitish="$RELEASE_BRANCH" -f previous_tag_name="$PREV_TAG" \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -77,7 +77,33 @@ PROJECT_ROOT="$(pwd)"
 # and `release.sh 1.2.3 --dry-run --skip-tests` both work; what remains is the
 # positional version argument the rest of the script already expects. Parsing
 # and the command wrapper live in lib/dryrun.sh so they can be tested.
-cwm_parse_dry_run "$@"
+usage() {
+    cat <<'USAGE'
+cwm-release — full release pipeline for a CWM Joomla extension.
+
+Usage:
+  composer release -- <version> [--dry-run|-n] [--skip-tests]
+  composer release                  # prompts for the version
+
+Options:
+  -n, --dry-run     Print every mutating command instead of running it.
+  --skip-tests      Skip the composer test:release gate.
+  -h, --help        Show this and exit.
+USAGE
+}
+
+if ! cwm_parse_dry_run "$@"; then
+    echo "Error: unknown option '${CWM_BAD_FLAG}'." >&2
+    echo >&2
+    usage >&2
+    exit 1
+fi
+
+if [ "$CWM_HELP" = "1" ]; then
+    usage
+    exit 0
+fi
+
 DRY_RUN="$CWM_DRY_RUN"
 SKIP_TESTS="$CWM_SKIP_TESTS"
 set -- "${CWM_ARGS[@]+"${CWM_ARGS[@]}"}"

--- a/scripts/substitute-tokens.php
+++ b/scripts/substitute-tokens.php
@@ -52,6 +52,13 @@ if (!is_array($substituteConfig)) {
     exit(0);
 }
 
+// The install script ships but lives in build/, which no project lists under
+// `paths` — so it was the one shipped file never substituted (#75).
+$substituteConfig['paths'] = CWM\BuildTools\Release\TokenSubstituter::pathsWithInstaller(
+    $substituteConfig,
+    $config
+);
+
 $substituter = new CWM\BuildTools\Release\TokenSubstituter($projectRoot, $substituteConfig);
 
 try {

--- a/src/Release/TokenSubstituter.php
+++ b/src/Release/TokenSubstituter.php
@@ -50,6 +50,45 @@ final class TokenSubstituter
     }
 
     /**
+     * Fold the extension's install script into the configured paths.
+     *
+     * The installer named by `package.installer` (or `build.scriptFile`) is
+     * shipped source — it is the manifest's <scriptfile>, and Joomla runs it on
+     * every install. It also lives in `build/`, which no project lists under
+     * `substituteTokens.paths` because the rest of that directory is tooling
+     * that must not be rewritten. So the one file in there that genuinely ships
+     * was the one file never substituted, and every release published it with a
+     * literal __DEPLOY_VERSION__ in its docblocks (#75).
+     *
+     * Derived from configuration the tool already reads, so no project has to
+     * remember to add it, and it cannot over-reach into the rest of build/.
+     *
+     * @param  array{paths?: list<string>} $substituteConfig the versionTracking.substituteTokens block
+     * @param  array<string, mixed>        $config           the whole cwm-build.config.json
+     * @return list<string> paths to walk, installer included, without duplicates
+     */
+    public static function pathsWithInstaller(array $substituteConfig, array $config): array
+    {
+        $paths = array_values(array_filter(
+            $substituteConfig['paths'] ?? [],
+            static fn ($p): bool => \is_string($p) && $p !== '',
+        ));
+
+        $candidates = [
+            $config['package']['installer'] ?? null,
+            $config['build']['scriptFile']  ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (\is_string($candidate) && $candidate !== '' && !\in_array($candidate, $paths, true)) {
+                $paths[] = $candidate;
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
      * Walk configured paths, replace the token with $version in every file
      * matching the extension filter. Files without the token are left
      * untouched (no mtime bump, no needless writes).

--- a/src/Release/VersionTracker.php
+++ b/src/Release/VersionTracker.php
@@ -67,6 +67,12 @@ final class VersionTracker
             if ($this->writePackageJson($packagePath, $version)) {
                 $touched[] = $packagePath;
             }
+
+            if ($lockPath = $this->packageLockBeside($packagePath)) {
+                if ($this->writePackageLock($lockPath, $version)) {
+                    $touched[] = $lockPath;
+                }
+            }
         }
 
         foreach ($this->rewriteSourceFiles($version) as $path) {
@@ -299,6 +305,63 @@ final class VersionTracker
 
         $this->writeJson($path, $data);
         echo "  $path → current=$version, next.patch={$nexts['patch']}\n";
+
+        return true;
+    }
+
+    /**
+     * The package-lock.json sitting beside a package.json, when there is one.
+     *
+     * @return string|null absolute path, or null when the project has no lock
+     */
+    private function packageLockBeside(string $packageJsonPath): ?string
+    {
+        $lock = \dirname($packageJsonPath) . '/package-lock.json';
+
+        return is_file($lock) ? $lock : null;
+    }
+
+    /**
+     * Carry the version into package-lock.json.
+     *
+     * npm records the version in two places in the lock, and nothing here used
+     * to write either — so the lock drifted from package.json release after
+     * release. At the v1.1.10 tag of lib_cwmscripture the manifest said 1.1.10
+     * and the lock still said 1.1.8, two releases behind, having last moved in
+     * an unrelated Dependabot commit (#76).
+     *
+     * The cost is not untidiness. npm rewrites that field the next time anyone
+     * runs `npm install`, which lands as an unexplained modification in a clean
+     * tree and stops the *next* release at the "working tree is not clean"
+     * pre-check — a failure created by an omission several releases earlier, in
+     * a file nobody edited.
+     *
+     * Only the two version fields are touched. The dependency tree is left
+     * exactly as npm wrote it, which is the same thing `npm version` does.
+     */
+    private function writePackageLock(string $path, string $version): bool
+    {
+        $data = $this->readJson($path);
+
+        $rootMatches = ($data['packages'][''] ?? null) === null
+            || ($data['packages']['']['version'] ?? null) === $version;
+
+        if (($data['version'] ?? null) === $version && $rootMatches) {
+            echo "  $path (no change)\n";
+
+            return false;
+        }
+
+        $data['version'] = $version;
+
+        // lockfileVersion 2 and 3 carry it again under packages[""]; version 1
+        // has no packages block at all, so only write what is already there.
+        if (isset($data['packages']) && \is_array($data['packages']) && \array_key_exists('', $data['packages'])) {
+            $data['packages']['']['version'] = $version;
+        }
+
+        $this->writeJson($path, $data, indent: 2);
+        echo "  $path → version=$version\n";
 
         return true;
     }

--- a/tests/Release/TokenSubstituterTest.php
+++ b/tests/Release/TokenSubstituterTest.php
@@ -226,4 +226,41 @@ final class TokenSubstituterTest extends TestCase
 
         @rmdir($dir);
     }
+
+    public function testInstallerIsFoldedIntoThePaths(): void
+    {
+        // The shape that shipped __DEPLOY_VERSION__ for every release: build/ is
+        // deliberately absent from paths, and the installer lives there.
+        $paths = TokenSubstituter::pathsWithInstaller(
+            ['paths' => ['admin/', 'site/']],
+            ['package' => ['installer' => 'build/script.install.php']],
+        );
+
+        $this->assertSame(['admin/', 'site/', 'build/script.install.php'], $paths);
+    }
+
+    public function testBuildScriptFileIsAlsoFoldedIn(): void
+    {
+        $paths = TokenSubstituter::pathsWithInstaller(
+            ['paths' => ['src/']],
+            ['build' => ['scriptFile' => 'script.php']],
+        );
+
+        $this->assertSame(['src/', 'script.php'], $paths);
+    }
+
+    public function testInstallerIsNotAddedTwiceWhenAlreadyListed(): void
+    {
+        $paths = TokenSubstituter::pathsWithInstaller(
+            ['paths' => ['build/script.install.php']],
+            ['package' => ['installer' => 'build/script.install.php']],
+        );
+
+        $this->assertSame(['build/script.install.php'], $paths);
+    }
+
+    public function testNoInstallerConfiguredLeavesPathsAlone(): void
+    {
+        $this->assertSame(['admin/'], TokenSubstituter::pathsWithInstaller(['paths' => ['admin/']], []));
+    }
 }

--- a/tests/Release/VersionTrackerTest.php
+++ b/tests/Release/VersionTrackerTest.php
@@ -449,4 +449,65 @@ final class VersionTrackerTest extends TestCase
 
         @rmdir($dir);
     }
+
+    public function testBumpCarriesTheVersionIntoPackageLock(): void
+    {
+        // The drift that stopped a later release: package.json moves every bump,
+        // the lock never did, and npm rewrites it on the next install (#76).
+        $root = $this->makeProject([
+            'package.json'      => ['name' => 'x', 'version' => '1.1.8'],
+            'package-lock.json' => [
+                'name'            => 'x',
+                'version'         => '1.1.8',
+                'lockfileVersion' => 3,
+                'packages'        => ['' => ['name' => 'x', 'version' => '1.1.8']],
+            ],
+        ]);
+
+        $this->runQuiet(fn () => (new VersionTracker($root, ['packageJson' => 'package.json']))->updateForBump('1.1.10'));
+
+        $lock = json_decode((string) file_get_contents($root . '/package-lock.json'), true);
+        $this->assertSame('1.1.10', $lock['version'], 'the top-level version');
+        $this->assertSame('1.1.10', $lock['packages']['']['version'], 'and the root package entry');
+        $this->assertSame(3, $lock['lockfileVersion'], 'the lock format is left alone');
+    }
+
+    public function testLockfileVersion1HasNoPackagesBlockToWrite(): void
+    {
+        $root = $this->makeProject([
+            'package.json'      => ['name' => 'x', 'version' => '1.0.0'],
+            'package-lock.json' => ['name' => 'x', 'version' => '1.0.0', 'lockfileVersion' => 1],
+        ]);
+
+        $this->runQuiet(fn () => (new VersionTracker($root, ['packageJson' => 'package.json']))->updateForBump('1.1.0'));
+
+        $lock = json_decode((string) file_get_contents($root . '/package-lock.json'), true);
+        $this->assertSame('1.1.0', $lock['version']);
+        $this->assertArrayNotHasKey('packages', $lock, 'no packages block is invented');
+    }
+
+    public function testMissingLockIsNotAnError(): void
+    {
+        $root = $this->makeProject(['package.json' => ['name' => 'x', 'version' => '1.0.0']]);
+
+        $touched = $this->runQuiet(fn () => (new VersionTracker($root, ['packageJson' => 'package.json']))->updateForBump('1.1.0'));
+
+        $this->assertNotEmpty($touched);
+        $this->assertFileDoesNotExist($root . '/package-lock.json');
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $files
+     */
+    private function makeProject(array $files): string
+    {
+        $root = sys_get_temp_dir() . '/cwm-vt-' . bin2hex(random_bytes(4));
+        mkdir($root, 0777, true);
+
+        foreach ($files as $name => $data) {
+            file_put_contents($root . '/' . $name, json_encode($data, JSON_PRETTY_PRINT) . "\n");
+        }
+
+        return $root;
+    }
 }

--- a/tests/shell/dryrun.test.sh
+++ b/tests/shell/dryrun.test.sh
@@ -38,7 +38,49 @@ assert_equals "1" "$CWM_DRY_RUN" "-n is accepted as the short form"
 # CWM_ARGS must be empty rather than carrying the flag through.
 cwm_parse_dry_run --dry-run
 assert_equals "1" "$CWM_DRY_RUN" "the flag alone is recognised"
+
 assert_equals "0" "${#CWM_ARGS[@]}" "no positional arguments remain"
+
+# --- Unrecognised options ----------------------------------------------------
+#
+# The case this exists for: a mistyped --dry-run used to be filed as a
+# positional and ignored, so a run the operator believed was a preview
+# published for real (pkg_cwmscripture 1.2.2, issue #73).
+if cwm_parse_dry_run 1.2.3 --dry-runn; then
+    assert_equals "non-zero" "0" "a mistyped --dry-run must not be accepted"
+else
+    assert_equals "--dry-runn" "$CWM_BAD_FLAG" "the offending option is reported back"
+fi
+
+if cwm_parse_dry_run --nope; then
+    assert_equals "non-zero" "0" "an unknown long option is rejected"
+else
+    assert_equals "--nope" "$CWM_BAD_FLAG" "and named"
+fi
+
+if cwm_parse_dry_run -x 1.2.3; then
+    assert_equals "non-zero" "0" "an unknown short option is rejected"
+else
+    assert_equals "-x" "$CWM_BAD_FLAG" "and named"
+fi
+
+# A version is never flag-shaped, so it is still treated as a positional and
+# left to the semver check, which gives a better message than this parser could.
+cwm_parse_dry_run 1.2.3rc
+assert_equals "1.2.3rc" "${CWM_ARGS[*]}" "a malformed version is still a positional"
+
+# --help must not be mistaken for a version to release.
+cwm_parse_dry_run --help
+assert_equals "1" "$CWM_HELP" "--help is recognised"
+assert_equals "" "${CWM_ARGS[*]:-}" "and does not become the version"
+
+cwm_parse_dry_run -h
+assert_equals "1" "$CWM_HELP" "-h is the short form"
+
+# A bare -- is a conventional separator, not an unknown option.
+cwm_parse_dry_run -- 1.2.3
+assert_equals "1.2.3" "${CWM_ARGS[*]}" "a bare -- separator is ignored"
+
 
 # A version that merely looks flag-ish is not swallowed.
 cwm_parse_dry_run 1.2.3-beta1

--- a/tests/shell/version.test.sh
+++ b/tests/shell/version.test.sh
@@ -74,4 +74,32 @@ printf '<extension><name>x</name></extension>\n' > "$WORK/noversion.xml"
 cwm_version_from_manifest "$WORK/noversion.xml" >/dev/null
 assert_equals "1" "$?" "a manifest without a <version> element returns 1"
 
+
+# --- cwm_latest_stable_tag ---------------------------------------------------
+#
+# The case that produced empty changelog entries: 1.1.10 cut straight after
+# 1.1.10-rc1, where git describe answers with the rc and the range holds only
+# the version bump (#74).
+assert_equals "v1.1.9" "$(cwm_latest_stable_tag "$(printf 'v1.1.8\nv1.1.9\nv1.1.10-rc1')")" \
+    "an rc is skipped in favour of the last stable"
+
+assert_equals "v1.1.9" "$(cwm_latest_stable_tag "$(printf 'v1.1.9\nv1.1.10-beta1\nv1.1.10-rc1\nv1.1.10-rc2')")" \
+    "a run of pre-releases is skipped wholesale"
+
+assert_equals "v1.2.0" "$(cwm_latest_stable_tag "$(printf 'v1.1.9\nv1.2.0')")" \
+    "with no pre-releases the newest tag is used"
+
+assert_equals "v2.0.0-beta1" "$(cwm_latest_stable_tag "$(printf 'v1.0.0-alpha1\nv2.0.0-beta1')")" \
+    "a project with only pre-releases still gets a base"
+
+assert_equals "" "$(cwm_latest_stable_tag "")" \
+    "no tags yields nothing rather than an error"
+
+assert_equals "1.1.9" "$(cwm_latest_stable_tag "$(printf '1.1.9\n1.1.10-rc1')")" \
+    "tags without a v prefix work too"
+
+# A v prefix must not be mistaken for a pre-release suffix.
+assert_equals "v10.5.7" "$(cwm_latest_stable_tag "$(printf 'v10.5.6\nv10.5.7')")" \
+    "the leading v is not read as a hyphenated suffix"
+
 finish


### PR DESCRIPTION
All four surfaced in one afternoon cutting lib_cwmscripture 1.1.10, pkg_cwmscripture 1.2.2 and Proclaim 10.5.7. Each has a repro from that run.

## #73 — unknown options were ignored, so `--dry-runn` released for real

`release.sh 1.2.2 --dry-runn` filed the typo as a positional, ignored it, and published. No error, no warning, output indistinguishable from a normal run. That is how pkg_cwmscripture 1.2.2 went out while the operator was expecting a preview.

Unrecognised `-`-prefixed arguments are now an error naming the option. Only flag-shaped arguments are judged, so a mistyped *version* still reaches the existing semver check, which gives a better message. `--help`/`-h` are recognised — previously they became the version and failed on semver, a poor way to discover there is no help. A bare `--` is accepted and ignored.

## #74 — the changelog was based on a release candidate

Cutting 1.1.10 right after 1.1.10-rc1 produced an entry with **nothing in it**: `git describe` answers with the nearest tag, so the range was rc1..1.1.10 — the version bump alone — while the description of the actual fix sat under the rc, which no site was ever offered. Same for pkg_cwmscripture 1.2.2.

`cwm_latest_stable_tag` picks the newest non-prerelease tag, which is what "since the last thing anyone could install" means. A project that has only ever shipped betas still gets a base rather than nothing. The leading `v` is stripped before the suffix test, or every `v`-prefixed tag reads as prerelease.

An entry can still be empty when a range genuinely holds only chores, so the generator now warns and points at the likely cause — a warning, not an error, since releasing around it is a legitimate decision.

## #75 — the install script shipped `__DEPLOY_VERSION__`

`pkg_proclaim-10.5.7.zip` carries three literal `__DEPLOY_VERSION__` tags in `script.install.php`; `pkg_cwmscripture` carries one. That file is the manifest's `<scriptfile>` — shipped source Joomla runs on every install — but it lives in `build/`, which no project lists under `substituteTokens.paths` because the rest of that directory is tooling that must not be rewritten. So the one file in there that ships was the one file never substituted.

The path is now derived from `package.installer` / `build.scriptFile`, config the tool already reads. No project has to remember it, and it cannot over-reach into the rest of `build/`.

## #76 — `package-lock.json` never moved

At the `v1.1.10` tag of lib_cwmscripture the manifest said 1.1.10 and the lock said **1.1.8** — two releases behind, last moved by an unrelated Dependabot commit.

The cost isn't untidiness: npm rewrites that field on the next `npm install`, which appears as an unexplained modification in a clean tree and stops the *next* release at the "working tree is not clean" pre-check. That is what aborted the pkg_cwmscripture 1.2.2 run — a failure produced by an omission several releases earlier, in a file nobody edited.

Only the two version fields are touched, leaving the dependency tree as npm wrote it. `lockfileVersion` 1 has no `packages` block and none is invented.

## Tests

`composer test` green: **407 PHPUnit, 35 Python, 108 shell assertions.**

New coverage: 9 shell assertions for option rejection and `--help`; 7 for stable-tag selection including the rc case and the `v`-prefix trap; 4 PHPUnit for installer path folding; 3 for the lock, including lockfileVersion 1 and a project with no lock.

## Note

Not rebased onto `bc11b1c`. Another session had uncommitted work in the tree while I was here and I wasn't going to stash it. No file overlap, so this merges clean.