### PR TITLE
fix(http): read the response status without the deprecated `$http_response_header`

### DIFF
--- a/src/Http/StreamTransport.php
+++ b/src/Http/StreamTransport.php
@@ -51,16 +51,38 @@ final class StreamTransport implements HttpTransport
 
         $context = stream_context_create($options);
 
-        // $http_response_header is populated by the stream wrapper in the
-        // local scope of the call. It is the only way to see the status.
         $responseBody = @file_get_contents($url, false, $context);
 
-        if (!isset($http_response_header)) {
+        /**
+         * The stream wrapper has no return value for the status, so it has to
+         * be read back out of band. How, is version-dependent:
+         *
+         * - PHP 8.5 added http_get_last_response_headers() and deprecated the
+         *   older mechanism in the same release (#80).
+         * - Before that, the wrapper injected $http_response_header into the
+         *   local scope of whichever function called it. That is why this is
+         *   read here rather than in a helper — a helper has its own scope and
+         *   would never see it.
+         *
+         * The ternary short-circuits on 8.5, so the deprecated variable is
+         * never referenced there.
+         *
+         * Both report per-attempt state: a request that never reached the
+         * server leaves null/unset even if an earlier one on the same process
+         * succeeded, so this doubles as the "did we get a response at all" test.
+         *
+         * @var list<string>|null $responseHeaders
+         */
+        $responseHeaders = \function_exists('http_get_last_response_headers')
+            ? http_get_last_response_headers()
+            : ($http_response_header ?? null);
+
+        if ($responseHeaders === null) {
             throw new \RuntimeException("No HTTP response from {$url} (connection, DNS or TLS failure).");
         }
 
         return new HttpResponse(
-            self::statusFrom($http_response_header),
+            self::statusFrom($responseHeaders),
             $responseBody === false ? '' : $responseBody
         );
     }

--- a/tests/Http/StreamTransportTest.php
+++ b/tests/Http/StreamTransportTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Http;
+
+use CWM\BuildTools\Http\StreamTransport;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The one place the toolkit actually talks HTTP, exercised for real.
+ *
+ * Everything above this is tested through FakeTransport, which is the right
+ * seam — publishing decisions should be checkable without the network. The
+ * cost is that this class was covered by nothing at all, and it is where the
+ * version-dependent parts live: `ignore_errors`, the redirect cap, and reading
+ * the status back out of band, which PHP 8.5 changed and deprecated in the same
+ * release (#80).
+ *
+ * A local `php -S` fixture server is used rather than mocks because the things
+ * worth testing here are the stream wrapper's behaviour, not ours: that a 404
+ * still yields its body, that a redirect chain reports the *final* status, and
+ * that a connection failure is distinguishable from an HTTP error. None of that
+ * survives being faked.
+ *
+ * On PHP 8.5 this exercises `http_get_last_response_headers()`; on 8.3 and 8.4
+ * it exercises the `$http_response_header` fallback. Both paths only ever run
+ * on one version each, so the CI matrix is what covers the pair.
+ */
+final class StreamTransportTest extends TestCase
+{
+    /** @var resource|null */
+    private static $server;
+
+    private static int $port = 0;
+
+    private static string $docRoot = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$docRoot = sys_get_temp_dir() . '/cwm-st-' . bin2hex(random_bytes(6));
+
+        if (!mkdir(self::$docRoot, 0o777, true) && !is_dir(self::$docRoot)) {
+            self::markTestSkipped('Could not create a document root for the fixture server.');
+        }
+
+        file_put_contents(self::$docRoot . '/router.php', self::router());
+
+        self::$port = self::freePort();
+
+        $descriptors = [0 => ['pipe', 'r'], 1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+
+        $server = proc_open(
+            sprintf(
+                '%s -S 127.0.0.1:%d -t %s %s',
+                escapeshellarg(\PHP_BINARY),
+                self::$port,
+                escapeshellarg(self::$docRoot),
+                escapeshellarg(self::$docRoot . '/router.php')
+            ),
+            $descriptors,
+            $pipes
+        );
+
+        if (!\is_resource($server)) {
+            self::markTestSkipped('Could not start the fixture server.');
+        }
+
+        self::$server = $server;
+
+        if (!self::waitForServer()) {
+            self::stopServer();
+            self::markTestSkipped('Fixture server did not come up in time.');
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::stopServer();
+
+        foreach (glob(self::$docRoot . '/*') ?: [] as $file) {
+            @unlink($file);
+        }
+
+        @rmdir(self::$docRoot);
+    }
+
+    #[Test]
+    public function a_successful_request_returns_status_and_body(): void
+    {
+        $response = (new StreamTransport())->request('GET', self::url('/ok'));
+
+        self::assertSame(200, $response->status);
+        self::assertSame('{"ok":true}', $response->body);
+        self::assertTrue($response->isSuccess());
+    }
+
+    #[Test]
+    public function an_error_response_still_carries_its_body(): void
+    {
+        // The `ignore_errors` option is load-bearing: without it PHP returns
+        // false for any 4xx/5xx and the body — where ARS explains what it
+        // objected to — is thrown away before anyone can read it.
+        $response = (new StreamTransport())->request('GET', self::url('/error'));
+
+        self::assertSame(422, $response->status);
+        self::assertSame('{"errors":[{"title":"nope"}]}', $response->body);
+        self::assertFalse($response->isSuccess());
+    }
+
+    #[Test]
+    public function a_redirect_reports_the_status_it_ended_on(): void
+    {
+        // The wrapper accumulates one status line per hop, so a naive read of
+        // the first would report 301 for a request that ended 200.
+        $response = (new StreamTransport())->request('GET', self::url('/redirect'));
+
+        self::assertSame(200, $response->status);
+        self::assertSame('{"ok":true}', $response->body);
+    }
+
+    #[Test]
+    public function an_unreachable_server_is_an_exception_not_a_status(): void
+    {
+        // "No response" and "a response saying no" lead to opposite actions
+        // upstream, so they must not arrive looking the same.
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/No HTTP response/');
+
+        // Port 9 is discard; nothing accepts on it.
+        (new StreamTransport(2))->request('GET', 'http://127.0.0.1:9/nope');
+    }
+
+    #[Test]
+    public function request_headers_and_body_reach_the_server(): void
+    {
+        $response = (new StreamTransport())->request(
+            'POST',
+            self::url('/echo'),
+            ['X-Joomla-Token' => 'secret-token', 'Accept' => 'application/vnd.api+json'],
+            '{"hello":"world"}'
+        );
+
+        $echo = json_decode($response->body, true);
+
+        self::assertSame(200, $response->status);
+        self::assertSame('POST', $echo['method']);
+        self::assertSame('secret-token', $echo['token']);
+        self::assertSame('application/vnd.api+json', $echo['accept']);
+        self::assertSame('{"hello":"world"}', $echo['body']);
+    }
+
+    // --- fixture server --------------------------------------------------
+
+    private static function url(string $path): string
+    {
+        return 'http://127.0.0.1:' . self::$port . $path;
+    }
+
+    /**
+     * A port nothing is listening on right now.
+     *
+     * Racy in principle — something could take it between the check and the
+     * server binding — but the alternative is a hard-coded port, which
+     * collides with whatever else a CI runner happens to be running.
+     */
+    private static function freePort(): int
+    {
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+
+        if ($socket === false) {
+            self::markTestSkipped("Could not find a free port: {$errstr} ({$errno}).");
+        }
+
+        $name = stream_socket_get_name($socket, false);
+        fclose($socket);
+
+        return (int) substr((string) $name, (int) strrpos((string) $name, ':') + 1);
+    }
+
+    private static function waitForServer(float $timeoutSeconds = 5.0): bool
+    {
+        $deadline = microtime(true) + $timeoutSeconds;
+
+        while (microtime(true) < $deadline) {
+            $client = @stream_socket_client(
+                'tcp://127.0.0.1:' . self::$port,
+                $errno,
+                $errstr,
+                0.2
+            );
+
+            if ($client !== false) {
+                fclose($client);
+
+                return true;
+            }
+
+            usleep(50_000);
+        }
+
+        return false;
+    }
+
+    private static function stopServer(): void
+    {
+        if (\is_resource(self::$server)) {
+            proc_terminate(self::$server);
+            proc_close(self::$server);
+        }
+
+        self::$server = null;
+    }
+
+    private static function router(): string
+    {
+        return <<<'PHP'
+            <?php
+            // Fixture routes for StreamTransportTest. Not part of the shipped tool.
+            $path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH);
+
+            switch ($path) {
+                case '/ok':
+                    header('Content-Type: application/json');
+                    echo '{"ok":true}';
+                    return true;
+
+                case '/error':
+                    http_response_code(422);
+                    header('Content-Type: application/json');
+                    echo '{"errors":[{"title":"nope"}]}';
+                    return true;
+
+                case '/redirect':
+                    http_response_code(301);
+                    header('Location: /ok');
+                    return true;
+
+                case '/echo':
+                    header('Content-Type: application/json');
+                    echo json_encode([
+                        'method' => $_SERVER['REQUEST_METHOD'] ?? '',
+                        'token'  => $_SERVER['HTTP_X_JOOMLA_TOKEN'] ?? '',
+                        'accept' => $_SERVER['HTTP_ACCEPT'] ?? '',
+                        'body'   => file_get_contents('php://input'),
+                    ]);
+                    return true;
+            }
+
+            http_response_code(404);
+            echo 'not found';
+
+            return true;
+            PHP;
+    }
+}


### PR DESCRIPTION
Closes #80.

Two things that had to land together: the coverage is what surfaces the deprecation, and with `failOnDeprecation="true"` in `phpunit.xml` adding it alone would have turned the new PHP 8.5 job red.

## The fix

PHP 8.5 deprecated `$http_response_header` in the same release that added `http_get_last_response_headers()`. It can't simply be swapped in — `composer.json` requires `^8.3` and CI runs 8.3/8.4/8.5 — so the function is used when available and the variable stays the fallback:

```php
$responseHeaders = \function_exists('http_get_last_response_headers')
    ? http_get_last_response_headers()
    : ($http_response_header ?? null);
```

The ternary short-circuits on 8.5, so the deprecated variable is never referenced there. It has to stay **inline in `request()`**: the wrapper injects it into the local scope of whichever function called `file_get_contents`, so a helper would have its own scope and never see it. I tried that first and it doesn't work.

I checked the behaviour rather than assuming it: **both mechanisms report per-attempt state.** A request that never reached the server leaves `null`/unset even after an earlier success in the same process, so the "did we get a response at all" guard still holds and `http_clear_last_response_headers()` isn't needed. That distinction is load-bearing — no response and a response saying no lead to opposite actions upstream.

## The coverage

First tests for `StreamTransport`. Everything above it goes through `FakeTransport`, which is the right seam, but it left the version-dependent HTTP layer untested. Against a local `php -S` fixture server:

- a 200 returns status and body
- **a 422 still carries its body** — the load-bearing `ignore_errors` option; without it PHP returns `false` and the body ARS uses to explain itself is discarded
- **a redirect chain reports the status it ended on**, not the 301 — the wrapper accumulates one status line per hop
- **an unreachable server raises** rather than returning a status
- request headers and body actually arrive

## This gates the deprecation, it doesn't just describe it

| Implementation | `phpunit --filter StreamTransportTest` |
|---|---|
| Previous | **exit 1** — deprecation at `StreamTransport.php:63` |
| This PR | **exit 0** |

Worth recording how I nearly got this wrong: my first "does the test catch it?" check reverted the code using `$http_response_header ?? null` and the test passed, which looked like the coverage was useless. It wasn't a faithful revert — `??` is an existence check and doesn't trigger the deprecation, while the original's direct read does. Restoring the true original from git showed the failure.

## Verification

`OK (412 tests, 982 assertions)` plus all seven shell suites, on PHP 8.5.7.

The fallback branch can't run on 8.5, so it's unverified locally — the 8.3 and 8.4 jobs added in #81 are what cover it. That's the pair working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)