### PR TITLE
feat(ci): add a run-lint-js input to both reusable workflows

### DIFF
--- a/.github/workflows/joomla-library-ci.yml
+++ b/.github/workflows/joomla-library-ci.yml
@@ -81,6 +81,11 @@ on:
         required: false
         type: boolean
         default: true
+      run-lint-js:
+        description: 'Whether to run npm run lint:js (ESLint). Off by default, unlike the PHP lint inputs: a project without the script would fail on it. Turn it on per project once lint:js is clean.'
+        required: false
+        type: boolean
+        default: false
       php-extensions:
         description: 'Extensions for setup-php'
         required: false
@@ -141,8 +146,10 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist
 
+      # Also for run-lint-js, which needs node_modules whether or not this
+      # project builds assets. One install serves both.
       - name: Install npm dependencies
-        if: ${{ inputs.npm-build }}
+        if: ${{ inputs.npm-build || inputs.run-lint-js }}
         run: npm ci
 
       - name: Build minified assets
@@ -181,6 +188,10 @@ jobs:
       - name: Run PHP CS Fixer (dry-run)
         if: ${{ inputs.run-lint }}
         run: composer lint
+
+      - name: Run ESLint
+        if: ${{ inputs.run-lint-js }}
+        run: npm run lint:js
 
       - name: Run PHPUnit
         if: ${{ inputs.run-tests }}

--- a/.github/workflows/joomla-library-ci.yml
+++ b/.github/workflows/joomla-library-ci.yml
@@ -106,6 +106,35 @@ env:
   NODE_OPTIONS: --disable-warning=DEP0040
 
 jobs:
+  # A job of its own rather than steps on `ci`, following Proclaim's js-checks:
+  # it needs none of the PHP setup, so running it in parallel keeps ESLint off
+  # the critical path. It also reports as its own check, so a JS failure is
+  # legible without opening the PHP job.
+  js-lint:
+    name: JS Lint
+    if: ${{ inputs.run-lint-js }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          submodules: ${{ inputs.submodules }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: 'npm'
+          cache-dependency-path: |
+            **/package-lock.json
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint:js
+
   ci:
     name: PHP Lint, Tests, Build
     runs-on: ubuntu-latest
@@ -146,10 +175,8 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist
 
-      # Also for run-lint-js, which needs node_modules whether or not this
-      # project builds assets. One install serves both.
       - name: Install npm dependencies
-        if: ${{ inputs.npm-build || inputs.run-lint-js }}
+        if: ${{ inputs.npm-build }}
         run: npm ci
 
       - name: Build minified assets
@@ -188,10 +215,6 @@ jobs:
       - name: Run PHP CS Fixer (dry-run)
         if: ${{ inputs.run-lint }}
         run: composer lint
-
-      - name: Run ESLint
-        if: ${{ inputs.run-lint-js }}
-        run: npm run lint:js
 
       - name: Run PHPUnit
         if: ${{ inputs.run-tests }}

--- a/.github/workflows/joomla-package-ci.yml
+++ b/.github/workflows/joomla-package-ci.yml
@@ -63,6 +63,11 @@ on:
         required: false
         type: boolean
         default: true
+      run-lint-js:
+        description: 'Whether to run npm run lint:js (ESLint). Off by default, unlike the PHP lint inputs: it costs an npm ci of its own, and a project without the script would fail on it. Turn it on per project once lint:js is clean.'
+        required: false
+        type: boolean
+        default: false
       php-extensions:
         description: 'Extensions for setup-php'
         required: false
@@ -125,6 +130,18 @@ jobs:
       - name: Run PHP CS Fixer (dry-run)
         if: ${{ inputs.run-lint }}
         run: composer lint
+
+      # Its own npm ci, because the only other npm install in this workflow is
+      # the one inside the project's build command, which runs after every lint
+      # step — too late to lint against. Cheap after Setup Node's npm cache, and
+      # it leaves node_modules in place, so the later install is a near no-op.
+      - name: Install npm dependencies for JS lint
+        if: ${{ inputs.run-lint-js }}
+        run: npm ci
+
+      - name: Run ESLint
+        if: ${{ inputs.run-lint-js }}
+        run: npm run lint:js
 
       - name: Run PHPUnit
         if: ${{ inputs.run-tests }}

--- a/.github/workflows/joomla-package-ci.yml
+++ b/.github/workflows/joomla-package-ci.yml
@@ -83,6 +83,35 @@ env:
   NODE_OPTIONS: --disable-warning=DEP0040
 
 jobs:
+  # A job of its own rather than steps on `ci`, following Proclaim's js-checks:
+  # it needs none of the PHP setup, so running it in parallel keeps ESLint off
+  # the critical path instead of adding an npm ci to it. It also reports as its
+  # own check, so a JS failure is legible without opening the PHP job.
+  js-lint:
+    name: JS Lint
+    if: ${{ inputs.run-lint-js }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          submodules: ${{ inputs.submodules }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: 'npm'
+          cache-dependency-path: |
+            **/package-lock.json
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint:js
+
   ci:
     name: PHP Lint, Tests, Build
     runs-on: ubuntu-latest
@@ -130,18 +159,6 @@ jobs:
       - name: Run PHP CS Fixer (dry-run)
         if: ${{ inputs.run-lint }}
         run: composer lint
-
-      # Its own npm ci, because the only other npm install in this workflow is
-      # the one inside the project's build command, which runs after every lint
-      # step — too late to lint against. Cheap after Setup Node's npm cache, and
-      # it leaves node_modules in place, so the later install is a near no-op.
-      - name: Install npm dependencies for JS lint
-        if: ${{ inputs.run-lint-js }}
-        run: npm ci
-
-      - name: Run ESLint
-        if: ${{ inputs.run-lint-js }}
-        run: npm run lint:js
 
       - name: Run PHPUnit
         if: ${{ inputs.run-tests }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   script would fail on it, and in the package pipeline it costs an `npm ci` of
   its own. Turn it on per project once `lint:js` is clean.
 
-  In `joomla-package-ci.yml` the step brings its own `npm ci`, because the only
-  other npm install there happens inside the project's build command, which runs
-  after every lint step. In `joomla-library-ci.yml` the existing npm install now
-  also fires for `run-lint-js`, so a library that lints but does not build assets
-  still gets `node_modules`, and one that does both installs once.
+  Runs as a `JS Lint` job of its own in both workflows, not as steps on the PHP
+  job, following the shape Proclaim already uses for its `js-checks`. ESLint
+  needs none of the PHP setup, so a parallel job keeps it off the critical path
+  rather than adding an `npm ci` to it, and a JS failure reports as its own
+  check instead of hiding inside the PHP job's log.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`run-lint-js` input on both reusable CI workflows.** Neither pipeline ran
+  ESLint, so `npm run lint:js` was gated nowhere across the org — CWMLivingWord
+  carried 394 errors in three source files without CI noticing, found only by
+  running the script by hand.
+
+  Off by default, unlike `run-lint` and `run-lint-syntax`: a project without the
+  script would fail on it, and in the package pipeline it costs an `npm ci` of
+  its own. Turn it on per project once `lint:js` is clean.
+
+  In `joomla-package-ci.yml` the step brings its own `npm ci`, because the only
+  other npm install there happens inside the project's build command, which runs
+  after every lint step. In `joomla-library-ci.yml` the existing npm install now
+  also fires for `run-lint-js`, so a library that lints but does not build assets
+  still gets `node_modules`, and one that does both installs once.
+
 ### Fixed
 
 - **`substituteTokens` no longer writes into git submodules.** A submodule


### PR DESCRIPTION
Neither reusable pipeline ran ESLint, so **`npm run lint:js` was gated nowhere across the org**.

The concrete case: CWMLivingWord carried **394 errors** across its three JS sources — the shared ESLint base enforces 4-space indent while that project's files were 2-space, and its `.editorconfig` agreed with the files, not the linter. CI never noticed, because CI never ran the script. It surfaced only when someone ran it by hand (CWMLivingWord#121).

## The input

`run-lint-js`, **off by default** — unlike `run-lint` and `run-lint-syntax`, which default on. A project without a `lint:js` script would fail on it, and in the package pipeline it costs an `npm ci` of its own. Opt in per project once `lint:js` is clean.

## Shape: a job of its own, following Proclaim

Proclaim already solved this — its `js-checks` job stands alone with just checkout, setup-node and `npm ci`, parallel to the PHP work. Both reusable workflows now do the same rather than inventing a second answer:

```yaml
js-lint:
  name: JS Lint
  if: ${{ inputs.run-lint-js }}
  runs-on: ubuntu-latest
  steps: [checkout, setup-node, npm ci, npm run lint:js]
```

ESLint needs none of the PHP setup, so a parallel job keeps it **off the critical path** instead of adding ~20s of `npm ci` to the PHP job — and it reports as its own check, so a JS failure is legible without opening the PHP job's log.

(The first commit here put it inline as steps; the second reworks it to the Proclaim shape. Review the branch as a whole, or the second commit alone for the delta.)

## Verification

Both files parse, and `run-lint-js` resolves to `false` in each — no consumer's pipeline changes until it opts in.

## Blocker for the rollout, and it isn't this PR

**The `v1` tag is stale.** The header of `joomla-package-ci.yml` documents it as "a moving tag re-pointed at each release", but on the remote it still points at **v1.13.2** (`6b9f2ff`) while the latest release is **v1.15.1** (`5aacbd4`).

So every consumer pinned to `@v1` — CWMLivingWord, CWMScriptureLinks, lib_cwmscripture — is running the v1.13.2 pipeline, two minor releases behind. Until `v1` moves, this input does not exist as far as they are concerned, and flipping `run-lint-js: true` in any of them would fail the workflow outright with an unknown-input error rather than merely being ignored.

That wants looking at on its own terms — either the release step that re-points `v1` isn't running, or it stopped being run by hand. Worth knowing regardless of this PR, since it means no pipeline fix since v1.13.2 has reached anyone.

## Rollout, once `v1` moves

`lint:js` is already clean in all three repos that have it — CWMLivingWord (since #121), lib_cwmscripture, and Proclaim (114 files, exit 0) — so there is no cleanup cost, just the flips:

- CWMLivingWord → `run-lint-js: true`
- lib_cwmscripture → `run-lint-js: true`
- CWMScriptureLinks has no `package.json`; stays off by default, no change
- Proclaim and cwmconnect run self-hosted workflows and aren't affected either way

🤖 Generated with [Claude Code](https://claude.com/claude-code)
