### PR TITLE
ci: move the major tag automatically on release

### DIFF
--- a/.github/workflows/major-tag.yml
+++ b/.github/workflows/major-tag.yml
@@ -1,0 +1,83 @@
+name: Move major tag
+
+# Re-points the moving major tag (`v1`) at each published release.
+#
+# This was step 6 of the hand-run release flow in CLAUDE.md, and being a human
+# step is exactly why it failed: v1 was moved for v1.13.2 on 2026-07-30 and then
+# missed for v1.14.0, v1.15.0 and v1.15.1, three releases cut about an hour
+# apart on 2026-08-10. Consumers pin the reusable workflows as `...@v1`, so for
+# eleven days every project ran the v1.13.2 pipeline while three releases' worth
+# of fixes sat published and unreachable. Nothing failed loudly; the tag simply
+# stayed where it was.
+#
+# So the step moves here. Releases of this repository are cut by hand — it has
+# no cwm-build.config.json and no `composer release` script — so putting it in
+# scripts/release.sh would not have caught this.
+#
+# The tag this creates is unsigned, unlike the one it replaces. A signature on a
+# tag that is force-moved on every release attests to little; reachability from
+# a signed release tag is the property that matters, and that is preserved
+# because this only ever points the major tag at a tag the release created.
+
+on:
+  release:
+    types: [published]
+  # For repairing the tag by hand after a release that predates this workflow,
+  # or one published while it was broken.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to point the major tag at, e.g. v1.16.0'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  move:
+    name: Re-point major tag
+    # A pre-release is not what `@v1` should hand to every consumer.
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # Full history and tags: the release tag has to be resolvable here.
+          fetch-depth: 0
+
+      - name: Re-point the moving major tag
+        env:
+          # Via env rather than inline ${{ }}: a tag name is user-supplied text,
+          # and the shell must never be asked to parse it as code.
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # Stable vX.Y.Z only. A tag like v1.16.0-alpha1 or a non-version tag
+          # must not become what every consumer runs.
+          if ! printf '%s' "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::notice::$TAG is not a stable vX.Y.Z tag; leaving the major tag alone."
+            exit 0
+          fi
+
+          MAJOR="${TAG%%.*}"
+
+          if ! git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "::error::${TAG} does not exist in this repository."
+            exit 1
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          # ^{commit} dereferences an annotated tag to the commit it points at,
+          # so the major tag lands on the same commit rather than on a tag
+          # object pointing at a tag object.
+          git tag -fa "$MAJOR" -m "Latest ${MAJOR}.x release (${TAG})" "${TAG}^{commit}"
+          git push origin "$MAJOR" --force
+
+          echo "::notice::${MAJOR} now points at ${TAG} ($(git rev-parse --short "${TAG}^{commit}"))."
+          echo "${MAJOR} -> ${TAG}" >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,14 +115,22 @@ on top of auto-derive (deduped by target).
 3. `git tag -a vX.Y.Z -m "vX.Y.Z"`.
 4. `git push origin main && git push origin vX.Y.Z`.
 5. `gh release create vX.Y.Z --title 'vX.Y.Z' --notes "..."`.
-6. **Re-point the moving major tag:**
-   `git tag -fa v1 -m "v1 -> vX.Y.Z" && git push origin v1 --force`.
 
-Step 6 is not optional. Consumers reference the reusable CI workflows as
-`...@v1` (the CI equivalent of their `^1.0` Composer constraint), so a
-release that skips it ships pipeline changes that no project actually
-runs — the workflows keep executing the previous release's code, silently.
-Drop the step only when cutting `v2`, which gets its own moving tag.
+The moving major tag re-points itself. Publishing the release fires
+`.github/workflows/major-tag.yml`, which force-moves `v1` onto the released
+commit. Check it went green; if a release predates the workflow or it failed,
+run it by hand from the Actions tab (`workflow_dispatch`, tag = `vX.Y.Z`).
+
+This used to be step 6, done by hand, and being a human step is why it broke:
+`v1` was moved for v1.13.2 and then missed for v1.14.0, v1.15.0 and v1.15.1,
+three releases cut about an hour apart. Consumers reference the reusable CI
+workflows as `...@v1` (the CI equivalent of their `^1.0` Composer constraint),
+so for eleven days every project kept running the v1.13.2 pipeline while three
+releases' worth of fixes sat published and unreachable — silently, because
+nothing about a stale tag fails.
+
+Cutting `v2` means teaching that workflow about a second moving tag, rather
+than remembering a step.
 
 No `version` field in `composer.json` — Composer reads the git tag.
 


### PR DESCRIPTION
`v1` is documented as a moving tag re-pointed at each release, and every consumer pins the reusable workflows to it. **It stopped moving eleven days ago and nothing noticed.**

## What happened

It was **step 6 of a hand-run checklist** in CLAUDE.md — `git tag -fa v1 … && git push origin v1 --force`. Moved correctly for v1.13.2 on 2026-07-30 (the tag object is signed and dated 21 seconds before that release). Then v1.14.0 (21:52), v1.15.0 (22:10) and v1.15.1 (23:05) all landed on 2026-08-10, about an hour apart, and `v1` was left behind on all three.

The checklist itself warned the step was not optional. It was skipped anyway, during exactly the kind of fast fix-chain evening where a manual step gets dropped. Nothing failed loudly — a stale tag has no failure mode, it just keeps serving old code. CWMLivingWord, CWMScriptureLinks and lib_cwmscripture have been running the v1.13.2 pipeline this whole time.

## The fix

A workflow on `release: published`. It lands **here rather than in `scripts/release.sh`** because this repository is released by hand — no `cwm-build.config.json`, no `composer release` script — so `release.sh` would never have run.

Guards, ordered by how badly each would hurt if missing:

| guard | why |
|---|---|
| stable `vX.Y.Z` only, by regex | a `-alpha` or non-version tag must never become what every consumer runs |
| pre-releases skipped | same, via the release payload |
| major derived from the tag (`v1.16.0` → `v1`) | cutting `v2.0.0` moves `v2` and leaves `v1` alone |
| `^{commit}` dereference | the major tag lands on the commit, not on a tag object pointing at a tag object |
| tag name passed via `env:` | never interpolated into the script, so a tag with shell metacharacters can't become a command |

`workflow_dispatch` takes a tag, for repairing a release that predates this workflow or one published while it was broken.

## Two things worth reviewing rather than skimming

**The tag it writes is unsigned**, unlike the one it replaces (`v1` today carries an SSH signature). My reasoning: a signature on a tag that is force-moved at every release attests to very little, and the property that actually matters — the major tag only ever pointing at a commit a signed release tag already points at — is preserved by construction. If you'd rather keep it signed, that needs a signing key in Actions and is a different change.

**CLAUDE.md's release flow is rewritten** — step 6 is gone, replaced by "check the workflow went green, and here's how to run it by hand". The history of why is recorded there too, so the next person to touch it knows what the automation is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)