### PR TITLE
fix(ci): run the JS lint where its config exists

### DIFF
--- a/.github/workflows/joomla-library-ci.yml
+++ b/.github/workflows/joomla-library-ci.yml
@@ -106,35 +106,6 @@ env:
   NODE_OPTIONS: --disable-warning=DEP0040
 
 jobs:
-  # A job of its own rather than steps on `ci`, following Proclaim's js-checks:
-  # it needs none of the PHP setup, so running it in parallel keeps ESLint off
-  # the critical path. It also reports as its own check, so a JS failure is
-  # legible without opening the PHP job.
-  js-lint:
-    name: JS Lint
-    if: ${{ inputs.run-lint-js }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          submodules: ${{ inputs.submodules }}
-
-      - name: Setup Node
-        uses: actions/setup-node@v7
-        with:
-          node-version: ${{ inputs.node-version }}
-          cache: 'npm'
-          cache-dependency-path: |
-            **/package-lock.json
-
-      - name: Install npm dependencies
-        run: npm ci
-
-      - name: Run ESLint
-        run: npm run lint:js
-
   ci:
     name: PHP Lint, Tests, Build
     runs-on: ubuntu-latest
@@ -175,8 +146,11 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist
 
+      # Also for run-lint-js: ESLint extends the shared base config from
+      # vendor/cwm/build-tools, so it needs both this install and the composer
+      # one above. One npm ci serves the asset build and the lint.
       - name: Install npm dependencies
-        if: ${{ inputs.npm-build }}
+        if: ${{ inputs.npm-build || inputs.run-lint-js }}
         run: npm ci
 
       - name: Build minified assets
@@ -215,6 +189,10 @@ jobs:
       - name: Run PHP CS Fixer (dry-run)
         if: ${{ inputs.run-lint }}
         run: composer lint
+
+      - name: Run ESLint
+        if: ${{ inputs.run-lint-js }}
+        run: npm run lint:js
 
       - name: Run PHPUnit
         if: ${{ inputs.run-tests }}

--- a/.github/workflows/joomla-package-ci.yml
+++ b/.github/workflows/joomla-package-ci.yml
@@ -83,35 +83,6 @@ env:
   NODE_OPTIONS: --disable-warning=DEP0040
 
 jobs:
-  # A job of its own rather than steps on `ci`, following Proclaim's js-checks:
-  # it needs none of the PHP setup, so running it in parallel keeps ESLint off
-  # the critical path instead of adding an npm ci to it. It also reports as its
-  # own check, so a JS failure is legible without opening the PHP job.
-  js-lint:
-    name: JS Lint
-    if: ${{ inputs.run-lint-js }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          submodules: ${{ inputs.submodules }}
-
-      - name: Setup Node
-        uses: actions/setup-node@v7
-        with:
-          node-version: ${{ inputs.node-version }}
-          cache: 'npm'
-          cache-dependency-path: |
-            **/package-lock.json
-
-      - name: Install npm dependencies
-        run: npm ci
-
-      - name: Run ESLint
-        run: npm run lint:js
-
   ci:
     name: PHP Lint, Tests, Build
     runs-on: ubuntu-latest
@@ -151,6 +122,21 @@ jobs:
 
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist
+
+      # After composer install, not in a job of its own. The obvious design is a
+      # parallel js-lint job with no PHP setup — it was tried, and it fails:
+      # projects extend the shared ESLint base at
+      # vendor/cwm/build-tools/templates/eslint.config.base.mjs, which Composer
+      # puts there, so ESLint without composer install dies with
+      # ERR_MODULE_NOT_FOUND before linting a line. Proclaim's standalone
+      # js-checks job works because it runs Jest, which needs no such config.
+      - name: Install npm dependencies for JS lint
+        if: ${{ inputs.run-lint-js }}
+        run: npm ci
+
+      - name: Run ESLint
+        if: ${{ inputs.run-lint-js }}
+        run: npm run lint:js
 
       - name: Lint PHP syntax
         if: ${{ inputs.run-lint-syntax }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`run-lint-js` runs after `composer install` instead of in a job of its own.**
+  As shipped in 1.16.0 it could not work: projects extend the shared ESLint base
+  at `vendor/cwm/build-tools/templates/eslint.config.base.mjs`, which Composer
+  puts there, so ESLint in a job with no PHP setup died with
+  `ERR_MODULE_NOT_FOUND` before linting a line. Both CWMLivingWord and
+  lib_cwmscripture failed identically the first time they turned it on.
+
+  The parallel job was modelled on Proclaim's `js-checks`, which stands alone
+  quite happily — because it runs Jest, which needs no Composer-delivered
+  config. ESLint here does, so the step belongs on the PHP job after the install
+  that provides it. The cost is one `npm ci` on that job's critical path; the
+  library pipeline already installs npm dependencies before its lint steps, so
+  there it is free.
+
 ## [1.16.0] - 2026-08-13
 
 ### Added


### PR DESCRIPTION
`run-lint-js` as shipped in v1.16.0 **could not work**. Found the moment it was turned on: CWMLivingWord and lib_cwmscripture both failed identically, in 11 and 13 seconds.

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'.../libraries/vendor/cwm/build-tools/templates/eslint.config.base.mjs'
imported from .../eslint.config.mjs
```

Projects extend the shared ESLint base config — and that file is delivered by **Composer**, into `vendor/cwm/build-tools/`. A job with no PHP setup has no such directory, so ESLint dies before linting a line.

## Why I got it wrong

The standalone job was modelled on Proclaim's `js-checks`, which stands alone quite happily — checkout, setup-node, `npm ci`, done. It works there because it runs **Jest**, which needs no Composer-delivered config. ESLint here does. The shape didn't transfer, and the premise I argued it on ("ESLint needs none of the PHP setup") was simply false for this codebase.

That reasoning is now recorded as a comment in both workflows, so the next person who notices ESLint isn't parallel doesn't try the same thing.

## The fix

The step moves onto the `ci` job, after `composer install`:

- **`joomla-package-ci.yml`** — brings its own `npm ci`, costing that job's critical path about ten seconds. This is what the first draft of #84 did, before I reworked it.
- **`joomla-library-ci.yml`** — already installs npm dependencies before its lint steps; widening that condition to `npm-build || run-lint-js` covers it for free.

The separate `JS Lint` check name goes away; a JS failure now surfaces inside the PHP job, which is the trade for it working at all.

## After merge

This needs a **v1.16.1** cut to reach anyone — `run-lint-js` is live but broken in v1.16.0, and the two consumer PRs turning it on (CWMLivingWord#124, lib_cwmscripture#56) stay red until then. The major-tag workflow will move `v1` automatically on publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)