### PR TITLE
feat(release): refuse to publish an artifact still carrying the token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`cwm-release` refuses to publish an artifact containing unsubstituted
+  `__DEPLOY_VERSION__`.** A new gate between build and push unzips the artifact
+  it is about to ship — recursing into nested zips — and stops the release if
+  the placeholder survives anywhere in it. Nothing has been committed, pushed,
+  tagged or published at that point, so a failure costs a re-run. (#85)
+
+  Substitution is driven by `substituteTokens.paths`, a hand-maintained list
+  that nothing validates. Three separate releases shipped the literal token
+  because of it: the `package.installer` blind spot (#75), a `paths` entry that
+  covered one of three sub-extensions (CWMScriptureLinks#27), and a vendored
+  copy of these tools that predated #75 (CWMScriptureLinks#29). Every one is
+  invisible to a check that reads configuration, so this one reads the bytes.
+
+  Run against the published `pkg_cwmscripture-1.2.5.zip` it reports all 16
+  occurrences across three files and two nesting levels in a single pass.
+
+  - Deliberately ignores `substituteTokens.extensions`. That defaults to
+    `['php']`, which is why a token in an XML manifest or a JS file ships
+    unnoticed — filtering the assertion the same way would give it the blind
+    spot it exists to catch. Binary entries are skipped by content, not by
+    extension.
+  - Under `--dry-run` it reports and never fails: no build ran, so the artifact
+    on disk is usually the *previous* release, and a finding there describes
+    that zip rather than the one being cut.
+  - Skips projects with no `substituteTokens` block, matching
+    `substitute-tokens.php` — but says so rather than exiting silently.
+  - Usable on its own: `php scripts/verify-artifact-tokens.php -f <artifact>`,
+    with `--warn-only` to report without a non-zero exit.
+
 ## [1.16.1] - 2026-08-13
 
 ### Fixed

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -22,10 +22,46 @@ composer cwm-release
    running the `preBuild` hook (e.g. `npm run build`) and the optional
    [`verifyAssets`](javascript-and-joomladialog.md#72-buildverifyassets-fail-loudly-if-an-asset-didnt-build)
    check first.
-4. **ARS publish** — push the artifact to Akeeba Release System using the `ars`
+4. **Token gate** — unzip the built artifact and refuse to go further if any
+   `__DEPLOY_VERSION__` survived step 2. See below.
+5. **ARS publish** — push the artifact to Akeeba Release System using the `ars`
    block (token from 1Password).
-5. **Finish** — update `versions.json` and push the release commit/tag to
+6. **Finish** — update `versions.json` and push the release commit/tag to
    `github.releaseBranch`.
+
+## The token gate
+
+Step 2 substitutes across `substituteTokens.paths`. That list is hand-maintained
+and validated against nothing, so whether a release ships the literal placeholder
+depends on someone having remembered every directory that ships. Three releases
+proved it does not hold: the installer blind spot (#75), a `paths` entry that
+covered one of three sub-extensions (CWMScriptureLinks#27), and a vendored copy
+of these tools older than #75's fix (CWMScriptureLinks#29).
+
+So the gate does not read configuration. It reads the artifact:
+
+```bash
+php vendor/cwm/build-tools/scripts/verify-artifact-tokens.php -f build/dist/pkg_thing-1.2.3.zip
+```
+
+- **Recurses into nested zips.** `pkg_proclaim.zip` → `packages/pkg_cwmscripture.zip`
+  → `lib_cwmscripture.zip` is three levels; findings are reported as
+  `outer.zip!inner.zip!path/file.php:12`.
+- **Ignores `substituteTokens.extensions`** — that defaults to `['php']`, which
+  is exactly why a token in a manifest or a JS file goes unnoticed. Binary
+  entries are skipped by content, not by extension.
+- **Placed between build and push**, so a failure costs a re-run rather than a
+  cleanup: nothing is committed, tagged, released or published yet.
+- **Reports every occurrence**, not the first.
+- Under `--dry-run` it reports without failing — no build ran, so the artifact on
+  disk is usually the previous release.
+- Projects with no `substituteTokens` block are skipped, and told so.
+
+If it fires, the usual causes are a shipped directory missing from `paths`
+(remember paths resolve from the **repo root**, so a sub-extension's own `src/`
+is not covered by a bare `src/` entry) or a vendored `cwm/build-tools` older than
+the fix for the file in question — `composer.lock` is not evidence the installed
+tree is current.
 
 Before any of that, if the project's `composer.json` defines a `test:release`
 script, `cwm-release` runs it as a pre-flight gate and stops before touching

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -323,6 +323,34 @@ else
 fi
 echo ""
 
+# --- Gate: no unsubstituted placeholder tokens in the artifact ---
+#
+# Deliberately placed between build and push. At this point nothing has been
+# committed, pushed, tagged, released or published, so a failure costs a re-run;
+# thirty lines further down it would cost a cleanup.
+#
+# This asks whether the token is in the bytes about to ship, rather than whether
+# `substituteTokens.paths` looks right — the only form of the question that
+# survives a stale vendored copy of these tools (CWMScriptureLinks#29), a path
+# list that never covered a sub-extension (#27), or the installer blind spot
+# that #75 fixed narrowly. See #85.
+if [ "$DRY_RUN" = "1" ]; then
+    # No build ran, so this is whatever the artifact selection above found on
+    # disk — usually the *previous* release. Scanning it is still informative
+    # (same reasoning as that selection block), but a hit describes that older
+    # zip, not the release being cut, so it must never fail the run.
+    if [ -f "${ARTIFACTS[0]}" ]; then
+        echo "[gate] Scanning ${ARTIFACTS[0]} for unsubstituted tokens (previously built — report only)..."
+        php "${TOOLS_DIR}/scripts/verify-artifact-tokens.php" -f "${ARTIFACTS[0]}" --warn-only || true
+    else
+        echo "[gate] Would scan the built artifact for unsubstituted tokens (nothing built under --dry-run)."
+    fi
+else
+    echo "[gate] Scanning ${ARTIFACTS[0]} for unsubstituted tokens..."
+    php "${TOOLS_DIR}/scripts/verify-artifact-tokens.php" -f "${ARTIFACTS[0]}" || exit 1
+fi
+echo ""
+
 # --- Step 4: Commit and push ---
 echo "[4/9] Committing version bump..."
 # Add only files modified by step 1 + 2, not unrelated untracked files. The

--- a/scripts/verify-artifact-tokens.php
+++ b/scripts/verify-artifact-tokens.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * CLI entry for ArtifactTokenScanner — used by cwm-release between build and push.
+ *
+ * Asserts the built artifact carries no unsubstituted placeholder tokens,
+ * recursing into nested zips. This is the check that does not depend on
+ * `substituteTokens.paths` being maintained correctly, on the vendored copy of
+ * these tools being current, or on anyone remembering a new sub-extension.
+ *
+ * Usage:
+ *   php verify-artifact-tokens.php -f build/dist/pkg_thing-1.2.3.zip
+ *   php verify-artifact-tokens.php -f <artifact> --warn-only
+ *
+ * Exit codes:
+ *   0  clean, not opted in, or --warn-only
+ *   1  tokens found, or the artifact could not be read
+ *
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/Release/ArtifactTokenScanner.php';
+require_once __DIR__ . '/../src/Config/ProfileResolver.php';
+
+$projectRoot = getcwd();
+$configFile  = $projectRoot . '/cwm-build.config.json';
+
+$opts     = getopt('f:', ['warn-only']);
+$artifact = $opts['f'] ?? null;
+$warnOnly = isset($opts['warn-only']);
+
+if (!is_string($artifact) || $artifact === '') {
+    fwrite(STDERR, "Usage: verify-artifact-tokens.php -f <artifact.zip> [--warn-only]\n");
+    exit(1);
+}
+
+if (!is_file($configFile)) {
+    fwrite(STDERR, "Error: cwm-build.config.json not found in $projectRoot\n");
+    exit(1);
+}
+
+$config = json_decode((string) file_get_contents($configFile), true);
+
+if (!is_array($config)) {
+    fwrite(STDERR, "Error: cwm-build.config.json is not valid JSON\n");
+    exit(1);
+}
+
+$tracking         = CWM\BuildTools\Config\ProfileResolver::resolve($config);
+$substituteConfig = $tracking['substituteTokens'] ?? null;
+
+// Gated on the same opt-in as substitution itself, for consistency with the
+// rest of the pipeline — but said out loud rather than exiting silently. A
+// project with no substituteTokens block can still ship the token if someone
+// typed it, and that is precisely the case this check would catch.
+if (!is_array($substituteConfig)) {
+    echo "  Skipped: no versionTracking.substituteTokens configured.\n";
+    exit(0);
+}
+
+if (!is_file($artifact)) {
+    fwrite(STDERR, "Error: artifact not found: $artifact\n");
+    exit(1);
+}
+
+$token   = $substituteConfig['token'] ?? '__DEPLOY_VERSION__';
+$scanner = new CWM\BuildTools\Release\ArtifactTokenScanner((string) $token);
+
+try {
+    $findings = $scanner->scan($artifact);
+} catch (\Throwable $e) {
+    fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+if ($findings === []) {
+    echo '  No unsubstituted ' . $token . ' in ' . basename($artifact) . ".\n";
+    exit(0);
+}
+
+// Report every hit, not the first. All three failures that motivated this were
+// multi-file, and one run should tell you the whole scope rather than making
+// you re-cut to discover the next one.
+$label = $warnOnly ? 'WARNING' : 'Error';
+
+fwrite(STDERR, "\n$label: " . count($findings) . ' unsubstituted ' . $token
+    . ' occurrence(s) in ' . basename($artifact) . ":\n\n");
+
+foreach ($findings as $finding) {
+    fwrite(STDERR, sprintf(
+        "  %s:%d\n      %s\n",
+        $finding['path'],
+        $finding['line'],
+        $finding['text'],
+    ));
+}
+
+if ($warnOnly) {
+    fwrite(STDERR, "\nContinuing anyway (--warn-only).\n");
+    exit(0);
+}
+
+fwrite(STDERR, <<<TEXT
+
+This artifact would ship the literal placeholder to sites. Nothing has been
+pushed, tagged or published yet, so fixing it now costs only a re-run.
+
+Usual causes:
+  - a shipped directory missing from versionTracking.substituteTokens.paths
+    (paths resolve from the repo root, so a sub-extension's own src/ is NOT
+    covered by a bare "src/" entry)
+  - a vendored cwm/build-tools older than the fix for the file in question
+    (composer.lock is not evidence the installed tree is current)
+
+TEXT);
+
+exit(1);

--- a/src/Release/ArtifactTokenScanner.php
+++ b/src/Release/ArtifactTokenScanner.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Release;
+
+use ZipArchive;
+
+/**
+ * Scans a built artifact for placeholder tokens that release-time substitution
+ * should already have replaced, recursing into nested zips.
+ *
+ * `TokenSubstituter` rewrites `__DEPLOY_VERSION__` across the directories a
+ * project lists in `substituteTokens.paths`. That list is hand-maintained and
+ * validated against nothing, so whether a release ships the literal token comes
+ * down to whether someone remembered every directory that ships. Three times it
+ * did not:
+ *
+ * - #75 — `package.installer` lives in `build/`, which no project lists because
+ *   the rest of that directory is tooling. The one shipped file in there was the
+ *   one never substituted.
+ * - CWMScriptureLinks#27 — `src/` resolves from the repo root, so a bare `src/`
+ *   entry covered one of three sub-extensions. Two zips shipped literal tokens
+ *   through two releases with nobody noticing.
+ * - CWMScriptureLinks#29 — that repo's vendored copy of these tools predated
+ *   #75's fix, so the installer shipped ten literal tags even after #27.
+ *
+ * Every one of those is invisible to a check that reads configuration. This
+ * class answers the only question that survives a stale vendor tree, a moved
+ * directory or a new sub-extension: **is the token in the bytes we are about to
+ * publish?**
+ *
+ * It deliberately does NOT filter by `substituteTokens.extensions`. That option
+ * defaults to `['php']`, which is exactly why a token in an XML manifest or a JS
+ * file would ship unnoticed — the assertion has to be independent of what the
+ * substituter covers, or it inherits the blind spot it exists to catch.
+ */
+final class ArtifactTokenScanner
+{
+    private const DEFAULT_TOKEN = '__DEPLOY_VERSION__';
+
+    /**
+     * Entries larger than this are skipped unread.
+     *
+     * Source files carrying `@since` tags are kilobytes. Anything in the
+     * megabytes is a bundled asset, a sprite sheet or a vendored library, and
+     * reading it costs more than the finding is worth.
+     */
+    private const MAX_ENTRY_BYTES = 4 * 1024 * 1024;
+
+    /**
+     * How many levels of nested zip to open.
+     *
+     * `pkg_proclaim.zip` → `packages/pkg_cwmscripture.zip` → `lib_cwmscripture.zip`
+     * is three, so the default clears the deepest real case with room to spare
+     * while still refusing to follow a maliciously self-nesting archive forever.
+     */
+    private const MAX_DEPTH = 5;
+
+    public function __construct(
+        private readonly string $token = self::DEFAULT_TOKEN,
+    ) {
+    }
+
+    /**
+     * @return list<array{path: string, line: int, text: string}>
+     *         Every occurrence, in archive order. Empty means the artifact is clean.
+     */
+    public function scan(string $archivePath): array
+    {
+        return $this->scanArchive($archivePath, basename($archivePath), 1);
+    }
+
+    /**
+     * @return list<array{path: string, line: int, text: string}>
+     */
+    private function scanArchive(string $archivePath, string $displayPath, int $depth): array
+    {
+        if ($depth > self::MAX_DEPTH) {
+            return [];
+        }
+
+        $zip = new ZipArchive();
+
+        if ($zip->open($archivePath) !== true) {
+            // A child that will not open is reported rather than thrown: the
+            // caller is a release gate, and "one entry was unreadable" should
+            // not be indistinguishable from "the artifact is clean".
+            return [[
+                'path' => $displayPath,
+                'line' => 0,
+                'text' => 'could not be opened as a zip archive',
+            ]];
+        }
+
+        $findings = [];
+
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $stat = $zip->statIndex($i);
+
+            if ($stat === false || str_ends_with($stat['name'], '/')) {
+                continue;
+            }
+
+            $entryPath = $displayPath . '!' . $stat['name'];
+
+            if (str_ends_with(strtolower($stat['name']), '.zip')) {
+                $findings = array_merge(
+                    $findings,
+                    $this->scanNestedZip($zip, $i, $entryPath, $depth),
+                );
+                continue;
+            }
+
+            if ($stat['size'] > self::MAX_ENTRY_BYTES) {
+                continue;
+            }
+
+            $contents = $zip->getFromIndex($i);
+
+            if ($contents === false || !$this->isText($contents)) {
+                continue;
+            }
+
+            $findings = array_merge($findings, $this->scanText($contents, $entryPath));
+        }
+
+        $zip->close();
+
+        return $findings;
+    }
+
+    /**
+     * Nested archives have to hit disk — ZipArchive cannot open a stream, and a
+     * package's children are themselves zips.
+     *
+     * @return list<array{path: string, line: int, text: string}>
+     */
+    private function scanNestedZip(ZipArchive $parent, int $index, string $entryPath, int $depth): array
+    {
+        $contents = $parent->getFromIndex($index);
+
+        if ($contents === false) {
+            return [];
+        }
+
+        $temp = tempnam(sys_get_temp_dir(), 'cwm-artifact-scan-');
+
+        if ($temp === false) {
+            return [];
+        }
+
+        try {
+            file_put_contents($temp, $contents);
+
+            return $this->scanArchive($temp, $entryPath, $depth + 1);
+        } finally {
+            @unlink($temp);
+        }
+    }
+
+    /**
+     * @return list<array{path: string, line: int, text: string}>
+     */
+    private function scanText(string $contents, string $entryPath): array
+    {
+        if (!str_contains($contents, $this->token)) {
+            return [];
+        }
+
+        $findings = [];
+
+        foreach (explode("\n", $contents) as $number => $line) {
+            if (str_contains($line, $this->token)) {
+                $findings[] = [
+                    'path' => $entryPath,
+                    'line' => $number + 1,
+                    'text' => trim($line),
+                ];
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Binary entries are skipped rather than filtered by extension, so a token
+     * in an unexpected file type is still caught.
+     */
+    private function isText(string $contents): bool
+    {
+        if ($contents === '') {
+            return false;
+        }
+
+        if (str_contains($contents, "\0")) {
+            return false;
+        }
+
+        return mb_check_encoding($contents, 'UTF-8');
+    }
+}

--- a/tests/Release/ArtifactTokenScannerTest.php
+++ b/tests/Release/ArtifactTokenScannerTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Release;
+
+use CWM\BuildTools\Release\ArtifactTokenScanner;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ZipArchive;
+
+final class ArtifactTokenScannerTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/cwm-artifact-scanner-' . bin2hex(random_bytes(6));
+        mkdir($this->tmpDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->rrmdir($this->tmpDir);
+    }
+
+    // -----------------------------------------------------------------
+    // the case the check exists for
+    // -----------------------------------------------------------------
+
+    /**
+     * pkg_proclaim.zip → packages/pkg_cwmscripture.zip → lib_cwmscripture.zip is
+     * three levels, and #75's evidence was found one level in. A scanner that
+     * only reads the outer archive would have reported every failure that
+     * motivated this as clean.
+     */
+    #[Test]
+    public function finds_a_token_three_archives_deep(): void
+    {
+        $inner = $this->zip('lib.zip', [
+            'lib/src/Provider.php' => "<?php\n/** @since  __DEPLOY_VERSION__ */\n",
+        ]);
+
+        $middle = $this->zip('pkg_child.zip', [
+            'child/manifest.xml' => "<extension/>\n",
+            'lib.zip'            => file_get_contents($inner),
+        ]);
+
+        $outer = $this->zip('pkg_outer.zip', [
+            'script.install.php' => "<?php\n// clean\n",
+            'packages/pkg_child.zip' => file_get_contents($middle),
+        ]);
+
+        $findings = (new ArtifactTokenScanner())->scan($outer);
+
+        self::assertCount(1, $findings);
+        self::assertSame(
+            'pkg_outer.zip!packages/pkg_child.zip!lib.zip!lib/src/Provider.php',
+            $findings[0]['path'],
+            'The report has to name every archive on the way down, or it cannot be acted on.'
+        );
+        self::assertSame(2, $findings[0]['line']);
+    }
+
+    /**
+     * CWMScriptureLinks#29: the package installer shipped ten literal tags. One
+     * run must show all ten — re-cutting a release to discover the next
+     * occurrence is the failure mode this replaces.
+     */
+    #[Test]
+    public function reports_every_occurrence_not_just_the_first(): void
+    {
+        $php = "<?php\n";
+
+        for ($i = 0; $i < 10; $i++) {
+            $php .= "/** @since  __DEPLOY_VERSION__ */\nfunction f$i() {}\n";
+        }
+
+        $archive = $this->zip('pkg.zip', ['script.install.php' => $php]);
+
+        self::assertCount(10, (new ArtifactTokenScanner())->scan($archive));
+    }
+
+    // -----------------------------------------------------------------
+    // independence from substituteTokens.extensions
+    // -----------------------------------------------------------------
+
+    /**
+     * `extensions` defaults to ['php'], which is why a token in a manifest or a
+     * JS file ships unnoticed. Filtering the assertion the same way would make
+     * it inherit the blind spot it exists to catch.
+     */
+    #[Test]
+    public function scans_file_types_the_substituter_never_rewrites(): void
+    {
+        $archive = $this->zip('pkg.zip', [
+            'manifest.xml'      => "<version>__DEPLOY_VERSION__</version>\n",
+            'media/js/thing.js' => "// @since __DEPLOY_VERSION__\n",
+            'language/en-GB.ini' => "KEY=\"__DEPLOY_VERSION__\"\n",
+        ]);
+
+        $paths = array_column((new ArtifactTokenScanner())->scan($archive), 'path');
+
+        self::assertCount(3, $paths);
+        self::assertContains('pkg.zip!manifest.xml', $paths);
+        self::assertContains('pkg.zip!media/js/thing.js', $paths);
+        self::assertContains('pkg.zip!language/en-GB.ini', $paths);
+    }
+
+    #[Test]
+    public function a_clean_artifact_reports_nothing(): void
+    {
+        $archive = $this->zip('pkg.zip', [
+            'src/Thing.php' => "<?php\n/** @since  1.2.3 */\n",
+            'manifest.xml'  => "<version>1.2.3</version>\n",
+        ]);
+
+        self::assertSame([], (new ArtifactTokenScanner())->scan($archive));
+    }
+
+    #[Test]
+    public function honours_a_custom_token(): void
+    {
+        $archive = $this->zip('pkg.zip', [
+            'src/Thing.php' => "<?php\n/** @since  @@VERSION@@ */\n",
+        ]);
+
+        self::assertSame([], (new ArtifactTokenScanner())->scan($archive));
+        self::assertCount(1, (new ArtifactTokenScanner('@@VERSION@@'))->scan($archive));
+    }
+
+    // -----------------------------------------------------------------
+    // robustness — a release gate must not fall over on real archives
+    // -----------------------------------------------------------------
+
+    #[Test]
+    public function skips_binary_entries_without_choking(): void
+    {
+        $archive = $this->zip('pkg.zip', [
+            'media/logo.png' => "\x89PNG\r\n\x1a\n\0\0__DEPLOY_VERSION__\0",
+            'src/Thing.php'  => "<?php\n/** @since  __DEPLOY_VERSION__ */\n",
+        ]);
+
+        $findings = (new ArtifactTokenScanner())->scan($archive);
+
+        self::assertCount(1, $findings, 'A NUL-bearing entry is not source and must not be reported.');
+        self::assertSame('pkg.zip!src/Thing.php', $findings[0]['path']);
+    }
+
+    /**
+     * A child that will not open is reported rather than silently dropped:
+     * "one entry was unreadable" must not look identical to "clean".
+     */
+    #[Test]
+    public function reports_an_unopenable_nested_archive(): void
+    {
+        $archive = $this->zip('pkg.zip', [
+            'packages/broken.zip' => 'this is not a zip',
+        ]);
+
+        $findings = (new ArtifactTokenScanner())->scan($archive);
+
+        self::assertCount(1, $findings);
+        self::assertStringContainsString('could not be opened', $findings[0]['text']);
+    }
+
+    #[Test]
+    public function reports_a_missing_archive_rather_than_claiming_it_is_clean(): void
+    {
+        $findings = (new ArtifactTokenScanner())->scan($this->tmpDir . '/nope.zip');
+
+        self::assertCount(1, $findings);
+        self::assertStringContainsString('could not be opened', $findings[0]['text']);
+    }
+
+    // -----------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------
+
+    /**
+     * @param array<string, string> $entries
+     */
+    private function zip(string $name, array $entries): string
+    {
+        $path = $this->tmpDir . '/' . $name;
+        $zip  = new ZipArchive();
+
+        if ($zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            self::fail("Could not create fixture archive $name");
+        }
+
+        foreach ($entries as $entryName => $contents) {
+            $zip->addFromString($entryName, $contents);
+        }
+
+        $zip->close();
+
+        return $path;
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $entry;
+
+            is_dir($path) ? $this->rrmdir($path) : @unlink($path);
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/shell/artifact-tokens.test.sh
+++ b/tests/shell/artifact-tokens.test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/verify-artifact-tokens.php — the release gate that asserts a
+# built artifact carries no unsubstituted placeholder tokens (#85).
+#
+# The scanning itself is covered by tests/Release/ArtifactTokenScannerTest.php.
+# What is tested here is the behaviour release.sh depends on and a unit test
+# cannot express: the exit codes that decide whether a release stops, the
+# opt-in gate, and --warn-only, which is what keeps a dry run from failing on a
+# stale zip left over from the previous release.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+
+VERIFY="${SCRIPT_DIR}/../../scripts/verify-artifact-tokens.php"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+write_config() {
+    # $1 = "opted-in" | "not-opted-in"
+    if [ "$1" = "opted-in" ]; then
+        cat > "${WORK}/cwm-build.config.json" <<'JSON'
+{
+    "extension": { "name": "pkg_thing" },
+    "versionTracking": {
+        "substituteTokens": { "paths": ["src/"] }
+    }
+}
+JSON
+    else
+        cat > "${WORK}/cwm-build.config.json" <<'JSON'
+{ "extension": { "name": "pkg_thing" } }
+JSON
+    fi
+}
+
+# Build a zip containing one file with the given contents.
+make_zip() {
+    local name="$1" entry="$2" contents="$3"
+    rm -rf "${WORK}/stage" && mkdir -p "$(dirname "${WORK}/stage/${entry}")"
+    printf '%s' "$contents" > "${WORK}/stage/${entry}"
+    (cd "${WORK}/stage" && zip -qr "${WORK}/${name}" .)
+}
+
+run_verify() {
+    (cd "$WORK" && php "$VERIFY" "$@" >/dev/null 2>&1; echo $?)
+}
+
+# --- A clean artifact passes -------------------------------------------------
+write_config opted-in
+make_zip clean.zip "src/Thing.php" '<?php /** @since 1.2.3 */'
+assert_equals "0" "$(run_verify -f clean.zip)" "a clean artifact exits 0"
+
+# --- A dirty artifact stops the release --------------------------------------
+# This is the whole point: it must exit non-zero, and it must do so at a moment
+# when nothing has been pushed, tagged or published.
+make_zip dirty.zip "src/Thing.php" '<?php /** @since __DEPLOY_VERSION__ */'
+assert_equals "1" "$(run_verify -f dirty.zip)" "an unsubstituted token exits 1"
+
+# --- --warn-only reports without failing -------------------------------------
+# Used by release.sh under --dry-run, where the artifact on disk is usually the
+# PREVIOUS release: a finding there describes that older zip, not the release
+# being cut, so it must never fail the run.
+assert_equals "0" "$(run_verify -f dirty.zip --warn-only)" "--warn-only exits 0 despite findings"
+
+# --- Opt-in parity with substitute-tokens.php --------------------------------
+write_config not-opted-in
+assert_equals "0" "$(run_verify -f dirty.zip)" \
+    "a project with no substituteTokens block is skipped, not failed"
+
+# The skip is loud rather than silent — a check that says nothing is
+# indistinguishable from a check that passed.
+skip_output="$(cd "$WORK" && php "$VERIFY" -f dirty.zip 2>&1)"
+assert_contains "$skip_output" "Skipped" "the skip is reported, not silent"
+
+# --- Argument and input handling ---------------------------------------------
+write_config opted-in
+assert_equals "1" "$(run_verify)" "a missing -f is a usage error"
+assert_equals "1" "$(run_verify -f does-not-exist.zip)" \
+    "a missing artifact fails rather than reporting clean"
+
+# --- The report names the file and line --------------------------------------
+report="$(cd "$WORK" && php "$VERIFY" -f dirty.zip 2>&1)"
+assert_contains "$report" "src/Thing.php" "the report names the offending entry"
+assert_contains "$report" "dirty.zip!" "the report names the archive path"
+
+finish


### PR DESCRIPTION
Closes #85.

## Why a config check cannot work

`substituteTokens.paths` is hand-maintained and validated against nothing. Three releases shipped the literal token because of it, and no two had the same cause:

| | Cause | Caught by a config check? |
|---|---|---|
| #75 | `package.installer` lives in `build/`, which nobody lists | no — the path was correct *and* the file was missed |
| CWMScriptureLinks#27 | `src/` resolves from the repo root, covering one of three sub-extensions | no — the list looked complete |
| CWMScriptureLinks#29 | vendored `cwm/build-tools` predated #75's fix | no — the config was already right |

The third is the one that settles it: that repo's `paths` were fixed, and it *still* shipped ten literal tags, because the code implementing the fix was two minors behind on disk. Nothing readable from configuration would have caught it.

So this gate reads the artifact instead.

## What it does

Between build and push, `cwm-release` unzips what it is about to publish, recurses into nested zips, and stops if the token survived anywhere.

```
[gate] Scanning build/dist/pkg_cwmscripture-1.2.5.zip for unsubstituted tokens...

Error: 16 unsubstituted __DEPLOY_VERSION__ occurrence(s) in pkg_cwmscripture-1.2.5.zip:

  pkg_cwmscripture-1.2.5.zip!script.install.php:9
      * @since      __DEPLOY_VERSION__
  ...
  pkg_cwmscripture-1.2.5.zip!plg_system_cwmscripture.zip!src/Extension/Cwmscripture.php:53
      * @since  __DEPLOY_VERSION__
  pkg_cwmscripture-1.2.5.zip!plg_content_scripturelinks.zip!script.php:104
      * @since   __DEPLOY_VERSION__
```

That is the **real published 1.2.5 package**: 10 in the installer, 5 in the system plugin, 1 in the content plugin — three files across two nesting levels, in one pass. Assembling the same evidence by hand took three separate commands and I still missed the installer the first time. The library's `lib_cwmscripture-1.1.13.zip` scans clean and exits 0.

## Design decisions worth reviewing

**Placed between build and push.** Nothing is committed, pushed, tagged, released or published yet, so a failure costs a re-run. Thirty lines further down it would cost a cleanup with a live GitHub release attached.

**Ignores `substituteTokens.extensions`.** It defaults to `['php']` — which is exactly why a token in an XML manifest or a JS file ships unnoticed. Filtering the assertion the same way would give it the blind spot it exists to catch. Binary entries are skipped by *content* (NUL byte / invalid UTF-8), not by extension, so an unexpected file type is still read.

**Recurses, and names the whole path.** `outer.zip!inner.zip!path/file.php:12`. `pkg_proclaim.zip` → `packages/pkg_cwmscripture.zip` → `lib_cwmscripture.zip` is three levels; the cap is five, which also refuses a self-nesting archive.

**Reports every occurrence.** All three motivating failures were multi-file; re-cutting to discover the next one is the workflow this replaces.

**`--dry-run` reports but never fails.** No build ran, so the artifact on disk is usually the *previous* release — a finding there describes that zip, not the one being cut. Same reasoning the existing dry-run artifact-selection block already gives.

**Opt-in parity, said out loud.** Skips projects with no `substituteTokens` block, matching `substitute-tokens.php` — but prints `Skipped:` rather than exiting silently. Worth flagging: a project with no block can still ship a hand-typed token, and this check would otherwise catch it. I kept the gate for pipeline consistency; happy to invert it if you'd rather it always run.

**An unopenable nested zip is reported, not skipped** — "one entry was unreadable" must not be indistinguishable from "clean".

## Tests

- `tests/Release/ArtifactTokenScannerTest.php` — 8 tests: three-deep nesting with the full reported path, all-occurrences, the three file types the substituter never rewrites, custom token, binary skip, unopenable child, missing archive.
- `tests/shell/artifact-tokens.test.sh` — 9 assertions on the contract `release.sh` depends on: exit 0 clean, exit 1 dirty, `--warn-only` exit 0, opt-out skip, loud skip, usage errors, report contents.

`composer test` green: 423 PHP / 1006 assertions, 35 Python, 117 shell.

## Follow-on

CWMScriptureLinks#29 is the live instance — that repo needs `composer update cwm/build-tools` regardless of this PR, and once this ships its next release would have been blocked rather than publishing the bad installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ
