### PR TITLE
fix(build): substitute a subBuild child with its own version before packaging

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "enabledPlugins": {
+    "joomla@joomla-bible-study": true,
+    "php-lsp@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true
+  }
+}

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+return (new Config())
+    ->setRiskyAllowed(false)
+    ->setRules([
+        '@auto' => true
+    ])
+    // 💡 by default, Fixer looks for `*.php` files excluding `./vendor/` - here, you can groom this config
+    ->setFinder(
+        (new Finder())
+            // 💡 root folder to check
+            ->in(__DIR__)
+            // 💡 additional files, eg bin entry file
+            // ->append([__DIR__.'/bin-entry-file'])
+            // 💡 folders to exclude, if any
+            // ->exclude([/* ... */])
+            // 💡 path patterns to exclude, if any
+            // ->notPath([/* ... */])
+            // 💡 extra configs
+            // ->ignoreDotFiles(false) // true by default in v3, false in v4 or future mode
+            // ->ignoreVCS(true) // true by default
+    )
+;

--- a/src/Build/ChildTokenSubstitution.php
+++ b/src/Build/ChildTokenSubstitution.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Build;
+
+use CWM\BuildTools\Config\ProfileResolver;
+use CWM\BuildTools\Release\TokenSubstituter;
+
+/**
+ * Substitutes a `subBuild` child's placeholder tokens with the child's OWN
+ * version for the duration of the build, then puts its working tree back.
+ *
+ * Token substitution is a release step: `cwm-release` runs it once, in the
+ * outer repo, over the outer repo's `substituteTokens.paths`. A `subBuild`
+ * runs the child's *build*, never its release — so the child used to be
+ * packaged with whatever placeholders its committed source carried, every
+ * time, with no configuration that could fix it (#89).
+ *
+ * The outer repo cannot cover for it either. When the child is a git
+ * submodule — which is the case this exists for — substituting it from the
+ * parent stamps another repo's source with the parent's version, which is
+ * what Proclaim 10.4.1 did to a plugin (#1704) and what `TokenSubstituter`
+ * has refused to do during descent since 1.16.0.
+ *
+ * So the substitution has to happen here, where the child's own version is
+ * knowable: read from the child's manifest, exactly as the child's own
+ * release would have used.
+ *
+ * ⚠️ This deliberately substitutes a tree whose root is usually a submodule.
+ * That is correct — it is standing in for the child's own release — and it
+ * works because `TokenSubstituter`'s submodule guard is an iterator filter
+ * that only sees entries encountered during descent, never the walk root
+ * itself. `ChildTokenSubstitutionTest::substitutes_a_child_whose_root_is_a_submodule()`
+ * pins that behaviour: if the guard is ever hardened to check the root too,
+ * that test fails loudly rather than this class silently substituting nothing.
+ * A nested submodule *inside* the child is still skipped, as it must be.
+ *
+ * Usage is strictly paired — `apply()` then `restore()` in a `finally`, so a
+ * failed sub-build cannot leave the child rewritten:
+ *
+ *     $sub = new ChildTokenSubstitution($childRoot);
+ *     $sub->apply();
+ *     try { ...build... } finally { $sub->restore(); }
+ */
+final class ChildTokenSubstitution
+{
+    /** @var array<string, string> Absolute path => contents before substitution. */
+    private array $backup = [];
+
+    public function __construct(
+        private readonly string $childRoot,
+    ) {
+    }
+
+    /**
+     * Substitute the child's tree, remembering what to put back.
+     *
+     * A child with no `cwm-build.config.json`, or one that has not opted into
+     * `substituteTokens`, is left alone — same opt-in as the rest of the
+     * pipeline. A child that HAS opted in but whose version cannot be resolved
+     * throws: silently skipping there would reproduce exactly the failure this
+     * class exists to prevent, and do it invisibly.
+     *
+     * @return int Files rewritten.
+     */
+    public function apply(): int
+    {
+        $configFile = $this->childRoot . '/cwm-build.config.json';
+
+        if (!is_file($configFile)) {
+            return 0;
+        }
+
+        $config = json_decode((string) file_get_contents($configFile), true);
+
+        if (!is_array($config)) {
+            return 0;
+        }
+
+        $tracking         = ProfileResolver::resolve($config);
+        $substituteConfig = $tracking['substituteTokens'] ?? null;
+
+        if (!is_array($substituteConfig)) {
+            return 0;
+        }
+
+        $version = $this->childVersion($config);
+
+        // The installer is shipped source but lives in `build/`, which no
+        // project lists under `paths` — and for this child it is where the
+        // failing tokens actually are (#75, CWMScriptureLinks#29).
+        $substituteConfig['paths'] = TokenSubstituter::pathsWithInstaller($substituteConfig, $config);
+
+        $substituter = new TokenSubstituter($this->childRoot, $substituteConfig);
+
+        foreach ($substituter->filesContainingToken() as $file) {
+            $contents = file_get_contents($file);
+
+            if ($contents !== false) {
+                $this->backup[$file] = $contents;
+            }
+        }
+
+        return count($substituter->substitute($version));
+    }
+
+    /**
+     * Put every rewritten file back byte for byte.
+     *
+     * Safe to call when `apply()` did nothing, and safe to call twice — the
+     * caller runs it from a `finally`, which fires on paths where nothing was
+     * substituted at all.
+     */
+    public function restore(): void
+    {
+        foreach ($this->backup as $file => $contents) {
+            file_put_contents($file, $contents);
+        }
+
+        $this->backup = [];
+    }
+
+    /**
+     * The child's own version, from the child's own manifest.
+     *
+     * Never the outer version: the whole point is that a submodule child
+     * releases on its own cadence, so `@since 1.2.5` in the child and
+     * `@since 10.5.8` in the parent are both correct at the same moment.
+     *
+     * @param array<string, mixed> $config
+     */
+    private function childVersion(array $config): string
+    {
+        $candidates = [
+            $config['package']['manifest']    ?? null,
+            $config['manifests']['package']   ?? null,
+            $config['build']['manifest']      ?? null,
+        ];
+
+        foreach ($candidates as $relative) {
+            if (!is_string($relative) || $relative === '') {
+                continue;
+            }
+
+            $absolute = $this->childRoot . '/' . ltrim($relative, '/');
+
+            if (is_file($absolute)) {
+                return (new ManifestReader($absolute))->version();
+            }
+        }
+
+        throw new \RuntimeException(
+            "subBuild child at {$this->childRoot} configures substituteTokens but no readable manifest "
+            . "(package.manifest / manifests.package / build.manifest), so its own version cannot be "
+            . "resolved. Without it the child would be packaged with the literal token in it."
+        );
+    }
+}

--- a/src/Build/Packager.php
+++ b/src/Build/Packager.php
@@ -194,6 +194,42 @@ final class Packager
 
         echo "  -> sub-build {$include['outputName']} (in {$include['path']})\n";
 
+        // A subBuild runs the child's BUILD, never its release — so without
+        // this the child is packaged carrying whatever placeholder tokens its
+        // committed source has, and no outer-repo setting can fix it (#89).
+        // Substituted with the child's own version, and reverted in the
+        // `finally` below: the child is usually a submodule checkout, and
+        // leaving it rewritten is the drift `git add -u` silently commits.
+        $substitution = new ChildTokenSubstitution($subDir);
+        $rewritten    = $substitution->apply();
+
+        if ($rewritten > 0) {
+            echo "     substituted the token in $rewritten file(s) at the child's own version\n";
+        }
+
+        try {
+            return $this->runSubBuild($include, $stagedPath, $i, $subDir, $buildScriptAbs);
+        } finally {
+            $substitution->restore();
+        }
+    }
+
+    /**
+     * Run the child's build script and stage the zip it produced.
+     *
+     * Split out of {@see resolveSubBuild} so every exit — a spawn failure, a
+     * non-zero exit, an empty distGlob — unwinds through one `finally` that
+     * restores the child's working tree.
+     *
+     * @param array<string, mixed> $include
+     */
+    private function runSubBuild(
+        array $include,
+        string $stagedPath,
+        int $i,
+        string $subDir,
+        string $buildScriptAbs
+    ): string {
         // Array-form proc_open: no shell, no metachar interpretation. Inherit
         // STDOUT/STDERR so the user sees the sub-build's progress live.
         $cmd = array_merge(['php', $buildScriptAbs], $include['args']);

--- a/src/Release/TokenSubstituter.php
+++ b/src/Release/TokenSubstituter.php
@@ -126,6 +126,48 @@ final class TokenSubstituter
     }
 
     /**
+     * Every file the next `substitute()` call would rewrite.
+     *
+     * Exists so a caller can snapshot those files before substituting and put
+     * them back afterwards. `Build\ChildTokenSubstitution` needs that: it
+     * substitutes a `subBuild` child's working tree so the packaged child does
+     * not ship the literal token, but that tree is usually a submodule
+     * checkout, and leaving it rewritten would show up as another repo's
+     * version staged into it (#1704).
+     *
+     * Silent about missing paths — `substitute()` already warns, and warning
+     * twice for one release reads like two different problems.
+     *
+     * @return list<string>
+     */
+    public function filesContainingToken(): array
+    {
+        $token      = $this->config['token']      ?? self::DEFAULT_TOKEN;
+        $paths      = $this->config['paths']      ?? [];
+        $extensions = $this->config['extensions'] ?? self::DEFAULT_EXTENSIONS;
+
+        $found = [];
+
+        foreach ($paths as $relative) {
+            $absolute = $this->projectRoot . '/' . ltrim((string) $relative, '/');
+
+            if (!file_exists($absolute)) {
+                continue;
+            }
+
+            foreach ($this->walkFiles($absolute, $extensions) as $file) {
+                $contents = file_get_contents($file);
+
+                if ($contents !== false && str_contains($contents, $token)) {
+                    $found[] = $file;
+                }
+            }
+        }
+
+        return $found;
+    }
+
+    /**
      * @param  list<string> $extensions
      * @return iterable<string>
      */

--- a/tests/Build/ChildTokenSubstitutionTest.php
+++ b/tests/Build/ChildTokenSubstitutionTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Build;
+
+use CWM\BuildTools\Build\ChildTokenSubstitution;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ChildTokenSubstitutionTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/cwm-child-subst-' . bin2hex(random_bytes(6));
+        mkdir($this->tmpDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->rrmdir($this->tmpDir);
+    }
+
+    // -----------------------------------------------------------------
+    // the case this exists for
+    // -----------------------------------------------------------------
+
+    /**
+     * The child is a submodule, so its root carries a `.git` FILE. Substituting
+     * it is correct here — this stands in for the child's own release, which is
+     * the only thing that knows the child's version.
+     *
+     * It works because `TokenSubstituter`'s submodule guard is an iterator
+     * filter: it sees entries encountered during descent, never the walk root.
+     * If that is ever hardened to check the root as well, this test fails —
+     * which is the point. Without it, hardening would make
+     * `ChildTokenSubstitution` silently substitute nothing and every other test
+     * here would still pass, because a non-submodule fixture cannot tell the
+     * difference.
+     */
+    #[Test]
+    public function substitutes_a_child_whose_root_is_a_submodule(): void
+    {
+        $this->seedChild(version: '1.2.5');
+        file_put_contents($this->tmpDir . '/.git', "gitdir: ../../.git/modules/child\n");
+
+        $rewritten = $this->runQuiet(fn () => (new ChildTokenSubstitution($this->tmpDir))->apply());
+
+        self::assertGreaterThan(0, $rewritten, 'A submodule child must still be substituted.');
+        self::assertStringContainsString('@since 1.2.5', $this->read('src/Thing.php'));
+    }
+
+    /**
+     * The child releases on its own cadence, so it gets ITS version — not the
+     * wrapper's. Proclaim 10.4.1 stamping 10.4.1 into a plugin whose own version
+     * was 1.1.5 is the bug on the other side of this line (#1704).
+     */
+    #[Test]
+    public function uses_the_childs_own_version_not_the_parents(): void
+    {
+        $this->seedChild(version: '1.2.5');
+
+        $this->runQuiet(fn () => (new ChildTokenSubstitution($this->tmpDir))->apply());
+
+        self::assertStringContainsString('@since 1.2.5', $this->read('src/Thing.php'));
+        self::assertStringNotContainsString('__DEPLOY_VERSION__', $this->read('src/Thing.php'));
+    }
+
+    /**
+     * The 10 occurrences that actually failed in pkg_cwmscripture 1.2.5 were in
+     * `build/script.install.php`, which is not in `paths` — it is folded in from
+     * `package.installer` (#75). Substituting only the declared paths would fix
+     * nothing that mattered.
+     */
+    #[Test]
+    public function covers_the_package_installer_which_is_not_in_paths(): void
+    {
+        $this->seedChild(version: '1.2.5');
+
+        $this->runQuiet(fn () => (new ChildTokenSubstitution($this->tmpDir))->apply());
+
+        self::assertStringContainsString('@since 1.2.5', $this->read('build/script.install.php'));
+    }
+
+    /** A submodule nested inside the child is that repo's business, not ours. */
+    #[Test]
+    public function leaves_a_submodule_nested_inside_the_child_alone(): void
+    {
+        $this->seedChild(version: '1.2.5');
+        mkdir($this->tmpDir . '/src/libraries/inner', 0o777, true);
+        file_put_contents($this->tmpDir . '/src/libraries/inner/.git', "gitdir: elsewhere\n");
+        file_put_contents(
+            $this->tmpDir . '/src/libraries/inner/Deep.php',
+            "<?php\n/** @since __DEPLOY_VERSION__ */\n"
+        );
+
+        $this->runQuiet(fn () => (new ChildTokenSubstitution($this->tmpDir))->apply());
+
+        self::assertStringContainsString(
+            '__DEPLOY_VERSION__',
+            $this->read('src/libraries/inner/Deep.php'),
+            "A nested submodule's placeholder belongs to its own release."
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // restore — the child is a submodule, so leaving it dirty is drift
+    // -----------------------------------------------------------------
+
+    #[Test]
+    public function restores_every_file_byte_for_byte(): void
+    {
+        $this->seedChild(version: '1.2.5');
+
+        $before = [
+            'src/Thing.php'           => $this->read('src/Thing.php'),
+            'build/script.install.php' => $this->read('build/script.install.php'),
+        ];
+
+        $subst = new ChildTokenSubstitution($this->tmpDir);
+        $this->runQuiet(fn () => $subst->apply());
+        self::assertStringNotContainsString('__DEPLOY_VERSION__', $this->read('src/Thing.php'));
+
+        $subst->restore();
+
+        foreach ($before as $rel => $contents) {
+            self::assertSame($contents, $this->read($rel), "$rel was not restored exactly.");
+        }
+    }
+
+    /**
+     * `Packager::resolveSubBuild()` restores from a `finally`, which fires on
+     * paths where nothing was substituted — a child that never opted in, or one
+     * whose build blew up before anything happened.
+     */
+    #[Test]
+    public function restore_is_safe_when_nothing_was_substituted(): void
+    {
+        $subst = new ChildTokenSubstitution($this->tmpDir);
+
+        $subst->restore();
+        $subst->restore();
+
+        self::assertTrue(true, 'restore() must be callable with no apply() and callable twice.');
+    }
+
+    // -----------------------------------------------------------------
+    // opt-in and failure modes
+    // -----------------------------------------------------------------
+
+    #[Test]
+    public function a_child_with_no_config_is_left_alone(): void
+    {
+        file_put_contents($this->tmpDir . '/whatever.php', "<?php\n// __DEPLOY_VERSION__\n");
+
+        self::assertSame(0, $this->runQuiet(fn () => (new ChildTokenSubstitution($this->tmpDir))->apply()));
+        self::assertStringContainsString('__DEPLOY_VERSION__', $this->read('whatever.php'));
+    }
+
+    #[Test]
+    public function a_child_that_has_not_opted_into_substitution_is_left_alone(): void
+    {
+        $this->seedChild(version: '1.2.5');
+        file_put_contents(
+            $this->tmpDir . '/cwm-build.config.json',
+            json_encode(['package' => ['manifest' => 'build/manifest.xml']])
+        );
+
+        self::assertSame(0, $this->runQuiet(fn () => (new ChildTokenSubstitution($this->tmpDir))->apply()));
+        self::assertStringContainsString('__DEPLOY_VERSION__', $this->read('src/Thing.php'));
+    }
+
+    /**
+     * Opted in but unresolvable: throwing is the point. Skipping quietly would
+     * reproduce the exact bug this class exists to prevent, invisibly.
+     */
+    #[Test]
+    public function throws_when_an_opted_in_child_has_no_readable_manifest(): void
+    {
+        $this->seedChild(version: '1.2.5');
+        unlink($this->tmpDir . '/build/manifest.xml');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/own version cannot be resolved/');
+
+        $this->runQuiet(fn () => (new ChildTokenSubstitution($this->tmpDir))->apply());
+    }
+
+    // -----------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------
+
+    private function seedChild(string $version): void
+    {
+        mkdir($this->tmpDir . '/src', 0o777, true);
+        mkdir($this->tmpDir . '/build', 0o777, true);
+
+        file_put_contents($this->tmpDir . '/src/Thing.php', "<?php\n/** @since __DEPLOY_VERSION__ */\n");
+        file_put_contents(
+            $this->tmpDir . '/build/script.install.php',
+            "<?php\n/** @since __DEPLOY_VERSION__ */\n"
+        );
+        file_put_contents(
+            $this->tmpDir . '/build/manifest.xml',
+            "<?xml version=\"1.0\"?>\n<extension><version>$version</version></extension>\n"
+        );
+        file_put_contents($this->tmpDir . '/cwm-build.config.json', json_encode([
+            'package' => [
+                'manifest'  => 'build/manifest.xml',
+                'installer' => 'build/script.install.php',
+            ],
+            'versionTracking' => [
+                'substituteTokens' => ['paths' => ['src/'], 'extensions' => ['php']],
+            ],
+        ]));
+    }
+
+    private function runQuiet(callable $fn): mixed
+    {
+        ob_start();
+
+        try {
+            return $fn();
+        } finally {
+            ob_end_clean();
+        }
+    }
+
+    private function read(string $relative): string
+    {
+        return (string) file_get_contents($this->tmpDir . '/' . $relative);
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $entry;
+
+            is_dir($path) ? $this->rrmdir($path) : @unlink($path);
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/Build/PackagerTest.php
+++ b/tests/Build/PackagerTest.php
@@ -202,6 +202,82 @@ PHP);
         $packager->package();
     }
 
+    /**
+     * A subBuild runs the child's BUILD, never its release, so without
+     * substitution the packaged child ships whatever placeholders its source
+     * carries — and no outer-repo setting can fix it, because substituting a
+     * submodule from the parent stamps the wrong version (#89).
+     */
+    #[Test]
+    public function subBuildSubstitutesTheChildWithItsOwnVersion(): void
+    {
+        $this->writeManifest('build/pkg.xml', '10.5.8');
+        $this->seedSubstitutingChild('1.2.5');
+
+        $config = $this->makePackageConfig([
+            'includes' => [[
+                'type'        => 'subBuild',
+                'path'        => 'lib',
+                'buildScript' => 'build.php',
+                'distGlob'    => 'dist/lib-*.zip',
+                'outputName'  => 'lib.zip',
+            ]],
+        ]);
+
+        $this->expectOutputRegex('/sub-build lib\.zip/');
+        $outer = (new Packager($config, null, $this->tmpDir))->package();
+
+        // The child was packaged at ITS version, not the wrapper's 10.5.8.
+        $staged = $this->nestedEntryContents($outer, 'lib.zip', 'src/Thing.php');
+        $this->assertStringContainsString('@since 1.2.5', $staged);
+        $this->assertStringNotContainsString('__DEPLOY_VERSION__', $staged);
+        $this->assertStringNotContainsString('10.5.8', $staged);
+
+        // ...and the child's working tree is exactly as it was found. It is a
+        // submodule checkout in the real case, and release.sh step 4's
+        // `git add -A` is waiting downstream (#1704).
+        $this->assertStringContainsString(
+            '__DEPLOY_VERSION__',
+            file_get_contents($this->tmpDir . '/lib/src/Thing.php')
+        );
+    }
+
+    /** Restore runs from a `finally`, so a blown-up build must not leave the child rewritten. */
+    #[Test]
+    public function subBuildRestoresTheChildEvenWhenTheBuildFails(): void
+    {
+        $this->writeManifest('build/pkg.xml', '10.5.8');
+        $this->seedSubstitutingChild('1.2.5');
+        file_put_contents($this->tmpDir . '/lib/build.php', "<?php exit(3);\n");
+
+        $before = file_get_contents($this->tmpDir . '/lib/src/Thing.php');
+
+        $config = $this->makePackageConfig([
+            'includes' => [[
+                'type'        => 'subBuild',
+                'path'        => 'lib',
+                'buildScript' => 'build.php',
+                'distGlob'    => 'dist/*.zip',
+                'outputName'  => 'lib.zip',
+            ]],
+        ]);
+
+        $this->expectOutputRegex('/sub-build/');
+
+        try {
+            (new Packager($config, null, $this->tmpDir))->package();
+            $this->fail('The failing sub-build should have thrown.');
+        } catch (\RuntimeException) {
+            // expected
+        }
+
+        $this->assertSame(
+            $before,
+            file_get_contents($this->tmpDir . '/lib/src/Thing.php'),
+            'A failed sub-build must still leave the child byte-identical.'
+        );
+    }
+
     #[Test]
     public function subBuildPassesArgsToScript(): void
     {
@@ -719,5 +795,56 @@ XML;
         }
 
         @rmdir($dir);
+    }
+
+    /**
+     * A subBuild child that opts into substitution: its own manifest, its own
+     * config, a placeholder in source, and a build script that zips the tree.
+     */
+    private function seedSubstitutingChild(string $childVersion): void
+    {
+        mkdir($this->tmpDir . '/lib/src', 0o777, true);
+        mkdir($this->tmpDir . '/lib/dist', 0o777, true);
+        mkdir($this->tmpDir . '/lib/build', 0o777, true);
+
+        file_put_contents($this->tmpDir . '/lib/src/Thing.php', "<?php\n/** @since __DEPLOY_VERSION__ */\n");
+        file_put_contents(
+            $this->tmpDir . '/lib/build/manifest.xml',
+            "<?xml version=\"1.0\"?>\n<extension><version>$childVersion</version></extension>\n"
+        );
+        file_put_contents($this->tmpDir . '/lib/cwm-build.config.json', json_encode([
+            'package'         => ['manifest' => 'build/manifest.xml'],
+            'versionTracking' => ['substituteTokens' => ['paths' => ['src/'], 'extensions' => ['php']]],
+        ]));
+
+        file_put_contents($this->tmpDir . '/lib/build.php', <<<'PHP'
+<?php
+$out = __DIR__ . '/dist/lib-1.2.5.zip';
+$zip = new ZipArchive();
+$zip->open($out, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+$zip->addFile(__DIR__ . '/src/Thing.php', 'src/Thing.php');
+$zip->close();
+echo "  produced $out\n";
+PHP);
+    }
+
+    /** Contents of one entry inside a zip nested in the outer package. */
+    private function nestedEntryContents(string $outerZip, string $childName, string $entry): string
+    {
+        $outer = new \ZipArchive();
+        $outer->open($outerZip);
+        $childBytes = $outer->getFromName($childName);
+        $outer->close();
+
+        $tmp = tempnam(sys_get_temp_dir(), 'cwm-nested-');
+        file_put_contents($tmp, $childBytes);
+
+        $child = new \ZipArchive();
+        $child->open($tmp);
+        $contents = (string) $child->getFromName($entry);
+        $child->close();
+        @unlink($tmp);
+
+        return $contents;
     }
 }


### PR DESCRIPTION
Closes #89.

## The gap

Token substitution is a *release* step: `cwm-release` runs it once, in the outer repo, over the outer repo's `substituteTokens.paths`. A `subBuild` runs the child's **build**, never its release — so the child was packaged with whatever placeholders its committed source carried, every time.

The outer repo cannot cover for it. When the child is a submodule, substituting it from the parent stamps another repo's source with the parent's version — Proclaim 10.4.1 did exactly that to a plugin (#1704), and `TokenSubstituter` has refused to do it during descent since 1.16.0.

So no configuration fixed this, and **1.17.0's artifact gate turned it from invisible into blocking**: Proclaim could not cut a release at all, because `pkg_cwmscripture` contributed ten literal tags from its install script and nothing in Proclaim could remove them.

## The fix

`ChildTokenSubstitution` reads the child's own `cwm-build.config.json` and its own manifest, substitutes with the **child's** version, and restores the tree byte for byte. `Packager::resolveSubBuild()` runs it around the build in a `try/finally`.

Verified against the real `plugins/content/scripturelinks`:

```
child version from its manifest        1.2.5
rewritten                              1 file
installer tokens after substitution    0        (10 × "@since 1.2.5")
installer tokens after restore         10
```

## Two things it has to get right — both regression-tested

**`pathsWithInstaller()` is applied.** The failing tokens live in `build/script.install.php`, which is in no project's `paths` — it is folded in from `package.installer` (#75). Substituting only the declared paths would have fixed nothing that mattered, while looking like it worked.

**The child's root is usually a submodule, and substituting it is correct here.** That works because `TokenSubstituter`'s submodule guard is an iterator filter over entries found during *descent*, never the walk root itself. `substitutes_a_child_whose_root_is_a_submodule()` pins that: harden the guard without adding an opt-in and the test fails loudly, instead of this class silently substituting nothing while every non-submodule fixture still passes.

A submodule nested *inside* the child is still skipped — that placeholder belongs to its own release.

## Restore survives failure

`resolveSubBuild()` throws on a spawn failure, a non-zero exit and an empty `distGlob`. The build moved into `runSubBuild()` so all three unwind through one `finally`. `subBuildRestoresTheChildEvenWhenTheBuildFails()` forces `exit(3)` and asserts the child is byte-identical afterwards — a child left rewritten is the drift `release.sh` step 4's `git add -A` silently commits.

## Tests

- `tests/Build/ChildTokenSubstitutionTest.php` — 9: submodule root, child's-own-version, installer coverage, nested-submodule skip, byte-exact restore, restore-without-apply, both opt-out paths, and the throw when an opted-in child has no resolvable manifest.
- `tests/Build/PackagerTest.php` — 2 added: the packaged child carries the child's version and not the wrapper's, and restore-after-failure.

`composer test`: **434 PHP / 1029 assertions**, 35 Python, 117 shell — all green.

## Deliberately not done

Bundling the child's *released* artifact via an exact-version `prebuilt` — resolving `*-<version>.zip` the way `cwm_select_artifact_for_version()` already does for the outer artifact — would ship the bytes that were actually published and tested, rather than rebuilding from source. `prebuilt` was rejected earlier on the mtime bug (CWMScriptureLinks#23), but that was the *selection* logic, not the concept. Recording it as the alternative rather than pretending it isn't one; it is a bigger change and out of scope here.

## Follow-on

Unblocks Proclaim#1770. Also worth noting separately: a submodule named **directly** in `paths` (rather than reached by descent) is still substituted, because the guard never sees the walk root. `libraries/` is safe; `libraries/lib_cwmscripture/` would not be. Not fixed here — this PR depends on that exact behaviour — but it deserves its own issue and an explicit opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ
