### PR TITLE
fix(build): require ChildTokenSubstitution in the package CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.18.1] - 2026-08-13
+
+### Fixed
+
+- **`cwm-package` fataled on any project with a `subBuild` include.** 1.18.0
+  wired `ChildTokenSubstitution` into `Packager::resolveSubBuild()` but never
+  required it in `scripts/package.php`, which has no autoloader and loads every
+  class by path. Result: `Class "CWM\BuildTools\Build\ChildTokenSubstitution"
+  not found`, and the build stopped.
+
+  The unit suite stayed green throughout, because it runs under Composer's
+  autoloader — the one thing the CLI does not have. `tests/Cli/PackageCliTest.php`
+  now runs `scripts/package.php` as a real subprocess against a project with a
+  `subBuild` child, and asserts both that it exits 0 and that the child was
+  actually substituted; it reproduces the fatal exactly when the requires are
+  removed.
+
+  Every other autoload-less entry point under `scripts/` was swept for the same
+  shape; this was the only one.
+
 ## [1.18.0] - 2026-08-13
 
 ### Fixed

--- a/scripts/package.php
+++ b/scripts/package.php
@@ -13,11 +13,21 @@ declare(strict_types=1);
  * language files, and an opt-in self-verify step.
  */
 
+// This entry point has no autoloader — every class Packager can reach at
+// runtime has to be required here, including the ones it only touches on
+// some paths. ChildTokenSubstitution and its two dependencies were missed
+// when subBuild substitution landed in 1.18.0, so `cwm-package` fataled on
+// any project with a subBuild include while the unit tests stayed green:
+// they run under Composer's autoloader, which this does not have.
+// `tests/Cli/PackageCliTest.php` runs this file for real to catch that.
 require_once __DIR__ . '/../src/Build/BuildConfig.php';
 require_once __DIR__ . '/../src/Build/ManifestReader.php';
 require_once __DIR__ . '/../src/Build/Prompt.php';
 require_once __DIR__ . '/../src/Build/PackageBuilder.php';
 require_once __DIR__ . '/../src/Build/PackageConfig.php';
+require_once __DIR__ . '/../src/Config/ProfileResolver.php';
+require_once __DIR__ . '/../src/Release/TokenSubstituter.php';
+require_once __DIR__ . '/../src/Build/ChildTokenSubstitution.php';
 require_once __DIR__ . '/../src/Build/Packager.php';
 
 use CWM\BuildTools\Build\BuildConfig;

--- a/tests/Cli/PackageCliTest.php
+++ b/tests/Cli/PackageCliTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Cli;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ZipArchive;
+
+/**
+ * Runs `scripts/package.php` as a real subprocess.
+ *
+ * Every other test in this suite loads classes through Composer's autoloader.
+ * The CLI entry points do not have one — they `require_once` each class by
+ * path — so a class the packager reaches only on some code path can be missing
+ * from that list and nothing fails until a user runs the command.
+ *
+ * That is not hypothetical: 1.18.0 shipped `ChildTokenSubstitution` wired into
+ * `Packager::resolveSubBuild()` but never required in `scripts/package.php`, so
+ * `cwm-package` fataled with "Class ... not found" on every project with a
+ * subBuild include, while the unit suite stayed entirely green.
+ */
+final class PackageCliTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/cwm-package-cli-' . bin2hex(random_bytes(6));
+        mkdir($this->tmpDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->rrmdir($this->tmpDir);
+    }
+
+    /**
+     * The subBuild path is the one that regressed, and it is the one that
+     * reaches the most classes — so it is the shape worth running for real.
+     */
+    #[Test]
+    public function packages_a_project_with_a_subbuild_child_through_the_real_cli(): void
+    {
+        $this->seedOuter();
+        $this->seedChild('1.2.5');
+
+        [$exit, $output] = $this->runCli();
+
+        self::assertSame(0, $exit, "cwm-package failed:\n$output");
+        self::assertFileExists($this->tmpDir . '/dist/pkg-1.0.0.zip', $output);
+
+        // The child was substituted with its own version on the way through —
+        // proving ChildTokenSubstitution actually loaded, not just that the
+        // command exited 0.
+        $staged = $this->nestedEntry($this->tmpDir . '/dist/pkg-1.0.0.zip', 'lib.zip', 'src/Thing.php');
+        self::assertStringContainsString('@since 1.2.5', $staged);
+        self::assertStringNotContainsString('__DEPLOY_VERSION__', $staged);
+
+        // ...and the child's tree was put back.
+        self::assertStringContainsString(
+            '__DEPLOY_VERSION__',
+            (string) file_get_contents($this->tmpDir . '/lib/src/Thing.php')
+        );
+    }
+
+    /**
+     * @return array{0: int, 1: string}
+     */
+    private function runCli(): array
+    {
+        $script = dirname(__DIR__, 2) . '/scripts/package.php';
+
+        $proc = proc_open(
+            ['php', $script],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+            $this->tmpDir
+        );
+
+        if (!is_resource($proc)) {
+            self::fail('Could not spawn scripts/package.php');
+        }
+
+        $output = stream_get_contents($pipes[1]) . stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        return [proc_close($proc), (string) $output];
+    }
+
+    private function seedOuter(): void
+    {
+        mkdir($this->tmpDir . '/build', 0o777, true);
+
+        file_put_contents(
+            $this->tmpDir . '/build/pkg.xml',
+            "<?xml version=\"1.0\"?>\n<extension><version>1.0.0</version></extension>\n"
+        );
+
+        file_put_contents($this->tmpDir . '/cwm-build.config.json', json_encode([
+            'extension' => ['name' => 'pkg'],
+            'package'   => [
+                'manifest'   => 'build/pkg.xml',
+                'outputDir'  => 'dist',
+                'outputName' => 'pkg-{version}.zip',
+                'includes'   => [[
+                    'type'        => 'subBuild',
+                    'path'        => 'lib',
+                    'buildScript' => 'build.php',
+                    'distGlob'    => 'dist/lib-*.zip',
+                    'outputName'  => 'lib.zip',
+                ]],
+            ],
+        ], JSON_PRETTY_PRINT));
+    }
+
+    private function seedChild(string $version): void
+    {
+        mkdir($this->tmpDir . '/lib/src', 0o777, true);
+        mkdir($this->tmpDir . '/lib/dist', 0o777, true);
+        mkdir($this->tmpDir . '/lib/build', 0o777, true);
+
+        file_put_contents($this->tmpDir . '/lib/src/Thing.php', "<?php\n/** @since __DEPLOY_VERSION__ */\n");
+        file_put_contents(
+            $this->tmpDir . '/lib/build/manifest.xml',
+            "<?xml version=\"1.0\"?>\n<extension><version>$version</version></extension>\n"
+        );
+        file_put_contents($this->tmpDir . '/lib/cwm-build.config.json', json_encode([
+            'package'         => ['manifest' => 'build/manifest.xml'],
+            'versionTracking' => ['substituteTokens' => ['paths' => ['src/'], 'extensions' => ['php']]],
+        ]));
+
+        file_put_contents($this->tmpDir . '/lib/build.php', <<<'PHP'
+<?php
+$out = __DIR__ . '/dist/lib-1.2.5.zip';
+$zip = new ZipArchive();
+$zip->open($out, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+$zip->addFile(__DIR__ . '/src/Thing.php', 'src/Thing.php');
+$zip->close();
+echo "  produced $out\n";
+PHP);
+    }
+
+    private function nestedEntry(string $outerZip, string $childName, string $entry): string
+    {
+        $outer = new ZipArchive();
+        $outer->open($outerZip);
+        $childBytes = $outer->getFromName($childName);
+        $outer->close();
+
+        $tmp = tempnam(sys_get_temp_dir(), 'cwm-cli-nested-');
+        file_put_contents($tmp, $childBytes);
+
+        $child = new ZipArchive();
+        $child->open($tmp);
+        $contents = (string) $child->getFromName($entry);
+        $child->close();
+        @unlink($tmp);
+
+        return $contents;
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $entry;
+
+            is_dir($path) ? $this->rrmdir($path) : @unlink($path);
+        }
+
+        @rmdir($dir);
+    }
+}


### PR DESCRIPTION
1.18.0 wired `ChildTokenSubstitution` into `Packager::resolveSubBuild()` but never required it in `scripts/package.php`, which has **no autoloader** and loads every class by path.

```
Error: package failed — Class "CWM\BuildTools\Build\ChildTokenSubstitution" not found
```

So `cwm-package` fataled on **any project with a `subBuild` include**. CWMScriptureLinks CI caught it within minutes of the release.

## Why nothing caught it first

The unit suite runs under Composer's autoloader — the one thing the CLI does not have. My own pre-release verification missed it for the same reason: every probe `require`d the class explicitly. Nothing exercised the real entry point.

`tests/Cli/PackageCliTest.php` now runs `scripts/package.php` as a real subprocess against a project with a `subBuild` child. It asserts a zero exit **and** that the child was actually substituted — exiting 0 alone would not prove the class loaded. Removing the three requires reproduces the fatal exactly.

Swept every other autoload-less script under `scripts/` for the same shape; this was the only one.

`composer test`: 435 PHP / 1034 assertions, 35 Python, 117 shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ