### PR TITLE
fix(release): skip a submodule named directly in substituteTokens.paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`substituteTokens` no longer writes into a submodule named directly in
+  `paths`.** The 1.16.0 guard is an iterator filter, and a filter never sees
+  the root it was handed — so `paths: ["libraries/lib_thing/"]` walked straight
+  into that submodule and stamped it with the outer repo's version, the exact
+  thing the guard exists to prevent. `libraries/` was safe only because descent
+  found the submodule one level down. (#92)
+
+  Checked on the path root rather than inside the walk, so a *file* path root
+  (`pathsWithInstaller()` adds one) is unaffected. `Build\ChildTokenSubstitution`
+  is also unaffected: it points at paths *inside* a submodule's own tree, which
+  are not themselves submodules — a repo's own release substituting its own
+  paths is always correct, and no opt-in flag was needed.
+
 ## [1.18.1] - 2026-08-13
 
 ### Fixed

--- a/src/Release/TokenSubstituter.php
+++ b/src/Release/TokenSubstituter.php
@@ -115,6 +115,11 @@ final class TokenSubstituter
                 continue;
             }
 
+            if ($this->isSubmoduleRoot($absolute)) {
+                fwrite(STDERR, "Warning: substituteTokens path is a git submodule: $relative (skipped)\n");
+                continue;
+            }
+
             foreach ($this->walkFiles($absolute, $extensions) as $file) {
                 if ($this->replaceInFile($file, $token, $version)) {
                     $touched[] = $file;
@@ -151,7 +156,7 @@ final class TokenSubstituter
         foreach ($paths as $relative) {
             $absolute = $this->projectRoot . '/' . ltrim((string) $relative, '/');
 
-            if (!file_exists($absolute)) {
+            if (!file_exists($absolute) || $this->isSubmoduleRoot($absolute)) {
                 continue;
             }
 
@@ -165,6 +170,31 @@ final class TokenSubstituter
         }
 
         return $found;
+    }
+
+    /**
+     * Is this configured path root itself a submodule (or a nested clone)?
+     *
+     * The descent filter in {@see walkFiles()} skips submodules it *encounters*,
+     * but an iterator filter never sees the root it was handed — so a project
+     * that names a submodule directly in `paths` was substituting it with the
+     * outer version, which is the exact thing the 1.16.0 guard exists to
+     * prevent (#92). `libraries/` was safe only because descent found the
+     * submodule one level down; `libraries/lib_cwmscripture/` was not.
+     *
+     * Checked here rather than inside `walkFiles()` so that a *file* path root
+     * — `pathsWithInstaller()` adds one — is unaffected.
+     *
+     * ⚠️ This is about the path root, not the project root.
+     * `Build\ChildTokenSubstitution` points a substituter at a submodule's own
+     * tree on purpose, with paths like `src/` *inside* it; those roots are not
+     * submodules, so they are untouched by this. A repo's own release
+     * substituting its own paths is always correct — it is only the *outer*
+     * repo reaching in that is wrong.
+     */
+    private function isSubmoduleRoot(string $path): bool
+    {
+        return is_dir($path) && file_exists($path . '/.git');
     }
 
     /**

--- a/tests/Release/TokenSubstituterTest.php
+++ b/tests/Release/TokenSubstituterTest.php
@@ -169,7 +169,19 @@ final class TokenSubstituterTest extends TestCase
         $this->seedFile('src/Model.php',                 "<?php\n// __DEPLOY_VERSION__\n");
         $this->seedFile('src/vendor/dep/Lib.php',        "<?php\n// __DEPLOY_VERSION__\n");
         $this->seedFile('src/node_modules/pkg/index.js', "// __DEPLOY_VERSION__\n");
-        $this->seedFile('src/.git/HEAD',                 "ref: __DEPLOY_VERSION__\n");
+        // Nested one level down rather than at `src/` itself: a `.git` directly
+        // inside the walk root makes that root a repository, and #92's check
+        // now skips such a root wholesale — which would skip everything here.
+        //
+        // Note this line does not pin ALWAYS_SKIP's `.git` entry, and the
+        // original `src/.git/HEAD` fixture did not either: `HEAD` fails the
+        // extension filter anyway. The two rules also overlap — any `.git`
+        // *directory* makes its parent look like a nested repository, so the
+        // submodule filter skips it whether or not `.git` is in ALWAYS_SKIP.
+        // What this asserts is the outcome that matters: nothing under it is
+        // rewritten. Kept as a `.php` file so the extension filter is not
+        // what produces the result.
+        $this->seedFile('src/inner/.git/hooks/pre-commit.php', "<?php\n// __DEPLOY_VERSION__\n");
 
         $touched = $this->runQuiet(fn () => $this->substituter([
             'paths'      => ['src/'],
@@ -241,6 +253,62 @@ final class TokenSubstituterTest extends TestCase
     private function substituter(array $config): TokenSubstituter
     {
         return new TokenSubstituter($this->tmpDir, $config);
+    }
+
+    /**
+     * The 1.16.0 guard is an iterator filter, and a filter never sees the root
+     * it was handed — so naming a submodule *directly* in `paths` walked
+     * straight into it and stamped another repo's source with this repo's
+     * version (#92). `libraries/` was safe only because descent found the
+     * submodule one level down.
+     */
+    #[Test]
+    public function skips_a_submodule_named_directly_in_paths(): void
+    {
+        $this->seedFile('libraries/lib_thing/src/Thing.php', "<?php\n/** @since  __DEPLOY_VERSION__ */\n");
+        file_put_contents($this->tmpDir . '/libraries/lib_thing/.git', "gitdir: ../../.git/modules/lib_thing\n");
+
+        $touched = $this->runQuiet(
+            fn () => $this->substituter(['paths' => ['libraries/lib_thing/']])->substitute('10.5.8')
+        );
+
+        self::assertSame([], $touched, 'A submodule path root must not be substituted.');
+        self::assertStringContainsString(
+            '__DEPLOY_VERSION__',
+            $this->read('libraries/lib_thing/src/Thing.php'),
+            "That placeholder belongs to the submodule's own release."
+        );
+    }
+
+    /** The skip is about submodules, not about deep paths — ordinary roots still work. */
+    #[Test]
+    public function still_substitutes_a_path_root_that_is_not_a_submodule(): void
+    {
+        $this->seedFile('libraries/mine/src/Thing.php', "<?php\n/** @since  __DEPLOY_VERSION__ */\n");
+
+        $touched = $this->runQuiet(
+            fn () => $this->substituter(['paths' => ['libraries/mine/']])->substitute('10.5.8')
+        );
+
+        self::assertCount(1, $touched);
+        self::assertStringContainsString('@since  10.5.8', $this->read('libraries/mine/src/Thing.php'));
+    }
+
+    /**
+     * `pathsWithInstaller()` adds a FILE as a path root. The submodule check
+     * must not swallow it — that file is where #75's tokens live.
+     */
+    #[Test]
+    public function a_file_path_root_is_unaffected_by_the_submodule_check(): void
+    {
+        $this->seedFile('build/script.install.php', "<?php\n/** @since  __DEPLOY_VERSION__ */\n");
+
+        $touched = $this->runQuiet(
+            fn () => $this->substituter(['paths' => ['build/script.install.php']])->substitute('10.5.8')
+        );
+
+        self::assertCount(1, $touched);
+        self::assertStringContainsString('@since  10.5.8', $this->read('build/script.install.php'));
     }
 
     private function runQuiet(callable $fn): mixed


### PR DESCRIPTION
Closes #92.

## The hole

The 1.16.0 guard is a `RecursiveCallbackFilterIterator` callback, and a filter only sees entries encountered **during descent** — never the root it was handed. So:

```
paths: ["libraries/lib_thing/"]     # lib_thing IS a submodule
  → walked straight in, stamped with the OUTER repo's version
```

`libraries/` was safe only because descent found the submodule one level down. `libraries/lib_thing/` was not, and nothing about the config would look wrong.

## No opt-in flag — the issue's proposal was over-engineered

#92 suggested an `allowSubmoduleRoot` flag, on the reasoning that `ChildTokenSubstitution` (#89) deliberately substitutes a submodule and would break.

It doesn't. That class points a substituter at paths **inside** a submodule's own tree — `src/`, `build/script.install.php` — and those roots are not themselves submodules, so they never reach this check. `ChildTokenSubstitutionTest` (9 tests) passes untouched, including `substitutes_a_child_whose_root_is_a_submodule()`.

The rule that falls out is simpler than the flag: **a repo's own release substituting its own paths is always correct; only an outer repo reaching in is wrong.**

Checked on the path root rather than inside `walkFiles()`, so a *file* path root is unaffected — `pathsWithInstaller()` adds one, and that file is where #75's tokens live.

## ⚠️ This changes an existing test fixture

`always_skips_vendor_node_modules_and_git_directories` seeded `src/.git/HEAD`, which incidentally made `src/` a repository root, so the new check skipped the whole walk root and the test failed. Moved one level down to `src/inner/.git/`.

Investigating that turned up something I'd rather record than quietly fix: **that line never pinned `ALWAYS_SKIP`'s `.git` entry.** `HEAD` fails the `['php','js']` extension filter regardless, so the assertion held whether or not `.git` was in the list. The two rules also overlap — any `.git` *directory* makes its parent look like a nested repository, so the submodule filter skips it either way. I tried to strengthen it into a real mutation-detecting assertion and could not, because the rules are genuinely redundant there. The fixture is now a `.php` file so the extension filter isn't what produces the result, and the comment states plainly what it does and does not prove.

## Tests

Three added, all mutation-checked (reverting the guard fails `skips_a_submodule_named_directly_in_paths`):

- a submodule named directly in `paths` is skipped, and keeps its placeholder
- an ordinary path root still substitutes — the skip is about submodules, not deep paths
- a file path root is unaffected

`composer test`: **438 PHP / 1040 assertions**, 35 Python, 117 shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ