### PR TITLE
fix(dev): prefer declared signals over inference in link resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The `joomlaLinks` `manifest` key is no longer dropped during validation.**
+  `LinkResolver` has read it since packages were first supported, and the class
+  docblock advertises it, but `InstalledPackageReader::validateLink()`
+  normalises each tuple through a `name`/`group`/`element`/`client` whitelist —
+  so the key never arrived and the `?? <name>.xml` fallback always won. A
+  package declaring it was ignored silently. (#97)
+
+  This also gives `derivePackageComponent()` the declared signal it lacked: it
+  had to resolve a component's media layout by probing for `media/<name>`, the
+  inference #95 removed elsewhere by reading the manifest. When a tuple names
+  its manifest, the declared `<media folder="">` now settles the layout and a
+  stray empty `media/<name>/` cannot mislead it. `<media folder="">` resolves
+  relative to the manifest's own directory, which need not be the package root.
+
+  No installed package declares `manifest` today, so nothing changes behaviour
+  until one does.
+
+- **An explicit `dev.links[]` entry now overrides the auto-derived pair for the
+  same target.** Derived pairs were emitted first and deduplication kept the
+  first writer, so an explicit entry for a target the deriver also produced was
+  discarded without a word. That left `dev.deriveLinks: false` — hand-write
+  every link for the project — as the only way to correct a single wrong pair,
+  and made inference bugs like #95 unworkaroundable for anyone hitting one.
+  (#98)
+
+  Explicit configuration beats inference; that is the point of it being
+  explicit. The override takes the derived pair's position, so emitted order is
+  unchanged.
+
 ## [1.20.0] - 2026-08-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - **An explicit `dev.links[]` entry now overrides the auto-derived pair for the
   same target.** Derived pairs were emitted first and deduplication kept the
-  first writer, so an explicit entry for a target the deriver also produced was
+  first writer, so an explicit entry for a target auto-derivation also produced was
   discarded without a word. That left `dev.deriveLinks: false` — hand-write
   every link for the project — as the only way to correct a single wrong pair,
   and made inference bugs like #95 unworkaroundable for anyone hitting one.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,7 +74,7 @@ That is deliberate. A rewrite that silently does nothing is precisely how the
 version drifted in the first place, so a misconfigured entry has to stop the
 bump rather than let a stale literal ship.
 | `assets` | Source-tree asset staging (`images`, `vendorMediaSource`, `packages[]`). Source paths, not install paths. |
-| `dev` | Optional dev-link overrides — `deriveLinks`, `links[]`, `internalLinks[]`, `cwmSiblings`. |
+| `dev` | Optional dev-link overrides — `deriveLinks`, `links[]`, `internalLinks[]`, `cwmSiblings`. A `links[]` entry whose target matches an auto-derived one replaces it, so a single wrong pair can be corrected without setting `deriveLinks: false` and hand-writing them all. |
 | `gitignore` | `{ outputPaths[], mediaPaths[] }` feeding the managed `.gitignore` block. |
 | `vendors` | Bundled npm libraries `vendor:check` reports on — `[{ npm, label?, notes? }]`. |
 | `security` | Optional `vendor:check` audit tuning. See [security block](#the-security-block). |

--- a/src/Config/CwmPackage.php
+++ b/src/Config/CwmPackage.php
@@ -17,7 +17,8 @@ namespace CWM\BuildTools\Config;
  *     name?: string,
  *     group?: string,
  *     element?: string,
- *     client?: 'site'|'administrator'
+ *     client?: 'site'|'administrator',
+ *     manifest?: string
  * }
  */
 final class CwmPackage

--- a/src/Config/InstalledPackageReader.php
+++ b/src/Config/InstalledPackageReader.php
@@ -189,7 +189,11 @@ final class InstalledPackageReader
 
         $out = ['type' => $type];
 
-        foreach (['name', 'group', 'element', 'client'] as $key) {
+        // 'manifest' is optional and advertised by LinkResolver for library and
+        // component links. Omitting it here dropped it during validation, so the
+        // key never reached the resolver and its `?? <name>.xml` fallback always
+        // won (#97).
+        foreach (['name', 'group', 'element', 'client', 'manifest'] as $key) {
             if (isset($entry[$key]) && is_string($entry[$key]) && $entry[$key] !== '') {
                 $out[$key] = $entry[$key];
             }

--- a/src/Dev/LinkResolver.php
+++ b/src/Dev/LinkResolver.php
@@ -227,11 +227,17 @@ final class LinkResolver
     {
         $name = $link['name'];
 
+        // A package that names its component manifest gets the layout read from
+        // it, the same way deriveComponent() does. Without one there is nothing
+        // to read, so the probe stands (#97).
+        $media = $this->packageMediaSource($pkgRoot, $name, $link['manifest'] ?? null)
+            ?? $this->componentMediaSource($pkgRoot . '/media', $name);
+
         foreach (['admin' => "/administrator/components/{$name}",
                   'site'  => "/components/{$name}",
                   'media' => "/media/{$name}"] as $sub => $tail) {
             $src = $sub === 'media'
-                ? $this->componentMediaSource($pkgRoot . '/media', $name)
+                ? $media
                 : $pkgRoot . '/' . $sub;
 
             if (is_dir($src)) {
@@ -338,6 +344,35 @@ final class LinkResolver
         $namespaced = $mediaDir . '/' . $name;
 
         return is_dir($namespaced) ? $namespaced : $mediaDir;
+    }
+
+    /**
+     * Resolve a package component's media source from the manifest its
+     * joomlaLinks tuple names, if it names one and the file parses.
+     *
+     * Unlike deriveComponent(), nothing here guarantees a manifest exists — the
+     * tuple's `manifest` key is optional — so this returns null whenever the
+     * declared layout cannot be read, and the caller falls back to the probe.
+     *
+     * @param  string|null $manifestFile  Tuple-relative manifest path, if declared.
+     * @return string|null
+     */
+    private function packageMediaSource(string $pkgRoot, string $name, ?string $manifestFile): ?string
+    {
+        if ($manifestFile === null || $manifestFile === '') {
+            return null;
+        }
+
+        $manifestPath = $pkgRoot . '/' . ltrim($manifestFile, '/');
+        $xml          = $this->loadManifest($manifestPath);
+
+        if ($xml === null) {
+            return null;
+        }
+
+        // <media folder=""> is relative to the manifest, which need not sit at
+        // the package root even though admin/ and site/ are resolved from there.
+        return $this->mediaSourceFromManifest($xml, \dirname($manifestPath));
     }
 
     /**

--- a/src/Dev/LinkResolver.php
+++ b/src/Dev/LinkResolver.php
@@ -578,23 +578,34 @@ final class LinkResolver
     }
 
     /**
+     * Collapse to one pair per target, keeping the last writer.
+     *
+     * externalLinks() appends the explicit dev.links[] entries after the
+     * auto-derived ones, so last-wins is what lets a project correct a single
+     * pair the deriver got wrong. Keeping the first instead silently discarded
+     * the explicit entry, leaving `dev.deriveLinks: false` — hand-write every
+     * link for the project — as the only way to override anything (#98).
+     *
+     * Position is the derived pair's, so the emitted order stays stable.
+     *
      * @param  list<LinkPair>  $links
      * @return list<LinkPair>
      */
     private function dedupe(array $links): array
     {
-        $seen = [];
-        $out  = [];
+        $at  = [];
+        $out = [];
 
         foreach ($links as $pair) {
             $key = $pair['target'];
 
-            if (isset($seen[$key])) {
+            if (isset($at[$key])) {
+                $out[$at[$key]] = $pair;
                 continue;
             }
 
-            $seen[$key] = true;
-            $out[]      = $pair;
+            $at[$key] = \count($out);
+            $out[]    = $pair;
         }
 
         return $out;

--- a/src/Dev/LinkResolver.php
+++ b/src/Dev/LinkResolver.php
@@ -582,7 +582,7 @@ final class LinkResolver
      *
      * externalLinks() appends the explicit dev.links[] entries after the
      * auto-derived ones, so last-wins is what lets a project correct a single
-     * pair the deriver got wrong. Keeping the first instead silently discarded
+     * pair auto-derivation got wrong. Keeping the first instead silently discarded
      * the explicit entry, leaving `dev.deriveLinks: false` — hand-write every
      * link for the project — as the only way to override anything (#98).
      *

--- a/tests/Config/InstalledPackageReaderTest.php
+++ b/tests/Config/InstalledPackageReaderTest.php
@@ -130,6 +130,48 @@ final class InstalledPackageReaderTest extends TestCase
     }
 
     #[Test]
+    public function optional_manifest_key_survives_validation(): void
+    {
+        // LinkResolver advertises and reads joomlaLinks[].manifest, but the key
+        // whitelist here used to drop it, so the resolver's `?? <name>.xml`
+        // fallback always won and the declared value never arrived (#97).
+        $tmpRoot = sys_get_temp_dir() . '/cwm-installed-reader-' . bin2hex(random_bytes(6));
+        mkdir($tmpRoot . '/vendor/composer', 0o777, true);
+
+        try {
+            file_put_contents(
+                $tmpRoot . '/vendor/composer/installed.json',
+                json_encode([
+                    'packages' => [[
+                        'name'               => 'cwm/declaresmanifest',
+                        'version'            => '1.0.0',
+                        'version_normalized' => '1.0.0.0',
+                        'dist'               => ['type' => 'zip', 'url' => 'x', 'reference' => 'z', 'shasum' => ''],
+                        'type'               => 'library',
+                        'install-path'       => '../cwm/declaresmanifest',
+                        'extra'              => [
+                            'cwm-build-tools' => [
+                                'joomlaLinks' => [
+                                    ['type' => 'component', 'name' => 'com_x', 'manifest' => 'custom/x.xml'],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ]),
+            );
+
+            $packages = (new InstalledPackageReader($tmpRoot))->cwmPackages();
+
+            self::assertSame('custom/x.xml', $packages[0]->joomlaLinks[0]['manifest'] ?? null);
+        } finally {
+            @unlink($tmpRoot . '/vendor/composer/installed.json');
+            @rmdir($tmpRoot . '/vendor/composer');
+            @rmdir($tmpRoot . '/vendor');
+            @rmdir($tmpRoot);
+        }
+    }
+
+    #[Test]
     public function throws_when_module_client_is_not_site_or_administrator(): void
     {
         $tmpRoot = sys_get_temp_dir() . '/cwm-installed-reader-' . bin2hex(random_bytes(6));

--- a/tests/Dev/LinkResolverPackagesTest.php
+++ b/tests/Dev/LinkResolverPackagesTest.php
@@ -282,6 +282,106 @@ final class LinkResolverPackagesTest extends TestCase
         );
     }
 
+    #[Test]
+    public function declared_manifest_beats_a_stray_media_name_dir(): void
+    {
+        // Same shape that broke Proclaim (#95): a flat-layout component with an
+        // empty media/<name>/ lying around. Here the tuple names the manifest,
+        // so the declared layout settles it instead of the probe.
+        $pkgRoot = $this->tmpDir . '/vendor/cwm/flat';
+        mkdir($pkgRoot . '/media/com_flat', 0o777, true);
+        file_put_contents(
+            $pkgRoot . '/flat.xml',
+            '<extension type="component"><name>com_flat</name>'
+            . '<media destination="com_flat" folder="media"/></extension>',
+        );
+
+        $pkg = $this->package(
+            $pkgRoot,
+            [['type' => 'component', 'name' => 'com_flat', 'manifest' => 'flat.xml']],
+        );
+
+        $links = (new LinkResolver($this->tmpDir, []))->externalLinksForPackages('/joomla', [$pkg]);
+
+        self::assertSame($pkgRoot . '/media', $this->sourceFor($links, '/joomla/media/com_flat'));
+    }
+
+    #[Test]
+    public function declared_manifest_resolves_a_namespaced_media_folder(): void
+    {
+        $pkgRoot = $this->tmpDir . '/vendor/cwm/nested';
+        mkdir($pkgRoot . '/media/com_nested', 0o777, true);
+        file_put_contents(
+            $pkgRoot . '/nested.xml',
+            '<extension type="component"><name>com_nested</name>'
+            . '<media destination="com_nested" folder="media/com_nested"/></extension>',
+        );
+
+        $pkg = $this->package(
+            $pkgRoot,
+            [['type' => 'component', 'name' => 'com_nested', 'manifest' => 'nested.xml']],
+        );
+
+        $links = (new LinkResolver($this->tmpDir, []))->externalLinksForPackages('/joomla', [$pkg]);
+
+        self::assertSame(
+            $pkgRoot . '/media/com_nested',
+            $this->sourceFor($links, '/joomla/media/com_nested'),
+        );
+    }
+
+    #[Test]
+    public function media_folder_is_relative_to_a_nested_manifest_not_the_package_root(): void
+    {
+        $pkgRoot = $this->tmpDir . '/vendor/cwm/deep';
+        mkdir($pkgRoot . '/pkg/media', 0o777, true);
+        mkdir($pkgRoot . '/media', 0o777, true);
+        file_put_contents(
+            $pkgRoot . '/pkg/deep.xml',
+            '<extension type="component"><name>com_deep</name>'
+            . '<media destination="com_deep" folder="media"/></extension>',
+        );
+
+        $pkg = $this->package(
+            $pkgRoot,
+            [['type' => 'component', 'name' => 'com_deep', 'manifest' => 'pkg/deep.xml']],
+        );
+
+        $links = (new LinkResolver($this->tmpDir, []))->externalLinksForPackages('/joomla', [$pkg]);
+
+        self::assertSame($pkgRoot . '/pkg/media', $this->sourceFor($links, '/joomla/media/com_deep'));
+    }
+
+    #[Test]
+    public function an_unreadable_declared_manifest_falls_back_to_the_probe(): void
+    {
+        $pkgRoot = $this->tmpDir . '/vendor/cwm/broken';
+        mkdir($pkgRoot . '/media', 0o777, true);
+        // Named but absent — nothing to read, so the probe stands.
+        $pkg = $this->package(
+            $pkgRoot,
+            [['type' => 'component', 'name' => 'com_broken', 'manifest' => 'nope.xml']],
+        );
+
+        $links = (new LinkResolver($this->tmpDir, []))->externalLinksForPackages('/joomla', [$pkg]);
+
+        self::assertSame($pkgRoot . '/media', $this->sourceFor($links, '/joomla/media/com_broken'));
+    }
+
+    /**
+     * @param  list<array{source: string, target: string, package: string}>  $links
+     */
+    private function sourceFor(array $links, string $target): string
+    {
+        foreach ($links as $link) {
+            if ($link['target'] === $target) {
+                return $link['source'];
+            }
+        }
+
+        self::fail("No link found for target {$target}");
+    }
+
     private function rrmdir(string $path): void
     {
         if (!is_dir($path) && !is_link($path)) {

--- a/tests/Dev/LinkResolverTest.php
+++ b/tests/Dev/LinkResolverTest.php
@@ -258,6 +258,59 @@ final class LinkResolverTest extends TestCase
     }
 
     #[Test]
+    public function an_explicit_link_overrides_the_auto_derived_pair_for_the_same_target(): void
+    {
+        // Without this, dev.deriveLinks:false -- hand-write every link for the
+        // project -- was the only way to correct a single derived pair.
+        $projectRoot = realpath(__DIR__ . '/../fixtures/project-component-toplevel');
+        self::assertNotFalse($projectRoot);
+
+        $config = [
+            'extension' => ['type' => 'component', 'name' => 'com_example'],
+            'manifests' => ['extensions' => []],
+            'dev'       => ['links' => [
+                ['source' => 'media/somewhere-else', 'target' => '{joomlaPath}/media/com_example'],
+            ]],
+        ];
+
+        $links  = (new LinkResolver($projectRoot, $config))->externalLinks('/var/www/joomla');
+        $source = self::mediaSourceFor($links, '/var/www/joomla/media/com_example');
+
+        self::assertSame($projectRoot . '/media/somewhere-else', $source);
+        self::assertCount(
+            3,
+            $links,
+            'the override replaces the derived pair rather than adding a second one',
+        );
+    }
+
+    #[Test]
+    public function an_overriding_link_keeps_the_derived_pair_position(): void
+    {
+        $projectRoot = realpath(__DIR__ . '/../fixtures/project-component-toplevel');
+        self::assertNotFalse($projectRoot);
+
+        $config = [
+            'extension' => ['type' => 'component', 'name' => 'com_example'],
+            'manifests' => ['extensions' => []],
+            'dev'       => ['links' => [
+                ['source' => 'media/somewhere-else', 'target' => '{joomlaPath}/media/com_example'],
+            ]],
+        ];
+
+        $links = (new LinkResolver($projectRoot, $config))->externalLinks('/var/www/joomla');
+
+        self::assertSame(
+            [
+                '/var/www/joomla/administrator/components/com_example',
+                '/var/www/joomla/components/com_example',
+                '/var/www/joomla/media/com_example',
+            ],
+            array_column($links, 'target'),
+        );
+    }
+
+    #[Test]
     public function stray_media_name_dir_does_not_override_a_manifest_declaring_the_flat_layout(): void
     {
         // The regression this class of bug produces: an empty media/<name>/


### PR DESCRIPTION
Closes #97, closes #98.

Follow-up to #95, which fixed the `is_dir()` media-layout inference at `deriveComponent()` and left the other two call sites on the probe for want of anything better to read. Two commits, independently reviewable.

## 1. The `joomlaLinks` `manifest` key was dead (#97)

`LinkResolver` has read an optional per-link manifest name since packages were first supported — `derivePackageLibrary()` does `$link['manifest'] ?? ($name . '.xml')`, and the class docblock advertises `<pkgRoot>/<manifest|<name>.xml>`. It never arrived: `InstalledPackageReader::validateLink()` normalises each tuple through a `name`/`group`/`element`/`client` whitelist, so the key was dropped and the fallback always won. Silently — no error, no warning.

Adding it to the whitelist makes the advertised option work **and** hands `derivePackageComponent()` the declared signal it lacked. When a tuple names its manifest, `<media folder="">` settles the layout and a stray empty `media/<name>/` cannot mislead it. Without one, nothing is knowable and the probe stands.

`<media folder="">` resolves relative to the manifest's own directory, not the package root — a manifest need not sit at the root even though `admin/` and `site/` are resolved from there.

**Rejected alternative:** scanning `<pkgRoot>/*.xml` for something that parses as this component's manifest. "Zero or many matches falls back" makes behaviour depend on which files happen to be lying around — the same class of defect as `is_dir()`, one layer up.

**No installed package declares `manifest` today**, so this changes no current behaviour; it makes an advertised option start working.

## 2. Explicit `dev.links[]` could not override a derived pair (#98)

Derived pairs are emitted first and `dedupe()` kept the *first* writer, so an explicit entry for a target the deriver also produced was silently discarded. Demonstrated against the shipped `project-component-toplevel` fixture before the change:

```
surviving source: …/project-component-toplevel/media   ← the derived pair; the explicit entry lost
```

That left `dev.deriveLinks: false` — hand-write every link for the project — as the only way to correct one wrong pair. It is also what made #95 unworkaroundable: a project could see the bad link, know the right answer, and have no way to say so.

Now the last writer wins, at the first writer's position so emitted order is unchanged.

## What still probes, and why

`deriveFromTopLevel()` keeps `is_dir()`. Unlike the other two sites it has **no** declared signal to replace it with: the config block driving it names only a type and a name, and the `manifests.extensions[]` component entry it might otherwise borrow is deliberately suppressed in that shape and resolved against a base that need not match the project root. Resurrecting it with a directory guard as the only thing standing between correct and silently-wrong links is worse than an honest probe. #98 is the answer for that site — a project hitting it can now override the single pair.

## Verification

- **#97:** 3 of the 4 new resolver tests fail against the previous code — the ones where the declared manifest and the probe disagree. The other two are guards.
- **#98:** the override test fails against the previous `dedupe()`; a second test pins emitted order so the change can't silently reshuffle links.
- The pre-existing `external_links_dedupe_by_target` test still passes unchanged; its explicit and derived sources resolve to the same path, so last-wins doesn't alter its meaning.
- Full suite green: PHPUnit 449 tests / 1055 assertions, Python 35 tests, all 8 shell suites, `php -l` across `src scripts tests`.

Changelog entries are under `[Unreleased]`; no release cut here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
