### PR TITLE
fix(dev): warn when a consumer's lint:js does not pin its ESLint config

### DIFF
--- a/.github/workflows/joomla-package-ci.yml
+++ b/.github/workflows/joomla-package-ci.yml
@@ -64,7 +64,7 @@ on:
         type: boolean
         default: true
       run-lint-js:
-        description: 'Whether to run npm run lint:js (ESLint). Off by default, unlike the PHP lint inputs: it costs an npm ci of its own, and a project without the script would fail on it. Turn it on per project once lint:js is clean.'
+        description: 'Whether to run npm run lint:js (ESLint). Off by default, unlike the PHP lint inputs: it costs an npm ci of its own, and a project without the script would fail on it. Turn it on per project once lint:js is clean. NOTE: pin the config in that script — "eslint --no-config-lookup -c eslint.config.mjs …" — or ESLint 10 loads the nearest config per file and the shared base ignores stop applying to submodules and vendor/ (build-tools#90).'
         required: false
         type: boolean
         default: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`sync-configs` now warns when a consumer's `lint:js` does not pin its ESLint
+  config.** ESLint 10 resolves the nearest `eslint.config.*` per file rather
+  than using only the root one, so a plain `eslint .` walks into any directory
+  carrying its own config — a git submodule, or this package's own install root
+  under `vendor/` — and lints those files under *that* config. The `ignores` in
+  `templates/eslint.config.base.mjs` never reach them. (#90)
+
+  Both failure modes were seen on Proclaim: a hard `ERR_MODULE_NOT_FOUND` when
+  the nested config imported a base file whose Composer vendor tree was not
+  installed, and, more quietly, files listed under `ignores` being linted
+  anyway — the count dropped 113 → 105 once the config was pinned.
+
+  Advisory only. `package.json` belongs to the consumer and `sync-configs` does
+  not rewrite hand-authored files, so it reports the recommended invocation
+  rather than applying it. The warning recognises `--no-config-lookup`, `-c` and
+  `--config`, which covers every form currently in use across the consuming
+  repos.
+
+  The `ignores` block in the base config and the `run-lint-js` workflow input
+  now both carry the same warning, so it is stated where someone editing either
+  will read it.
+
 ## [1.21.0] - 2026-08-14
 
 ### Fixed

--- a/scripts/sync-configs.php
+++ b/scripts/sync-configs.php
@@ -59,6 +59,7 @@ syncEditorConfig($projectRoot, $templates, $dryRun);
 syncPhpCsFixer($projectRoot, $dryRun);
 syncPhpunit($projectRoot, $templates, $dryRun);
 syncEslint($projectRoot, $templates, $projectConfig, $dryRun);
+checkEslintInvocation($projectRoot);
 checkProfileHints($projectConfig, $toolsRoot);
 
 echo $dryRun ? "(dry-run; no files written)\n" : "Done.\n";
@@ -538,4 +539,61 @@ function checkProfileHints(array $config, string $toolsRoot): void
             echo "cwm-build.config.json: versionTracking block matches profile '{$profile}' defaults — safe to delete.\n";
         }
     }
+}
+
+/**
+ * Warn when a consumer's `lint:js` script does not pin the config file.
+ *
+ * ESLint 10 resolves the nearest `eslint.config.*` per file rather than using
+ * only the root one. A plain `eslint .` therefore walks into any directory
+ * carrying its own config -- a git submodule, or this package's own install
+ * root under vendor/ -- and lints those files under *that* config, which means
+ * the `ignores` in templates/eslint.config.base.mjs never apply to them.
+ *
+ * Two ways that shows up, both seen on Proclaim (issue #90):
+ *
+ *   - A hard failure, when the nested config imports a base file whose Composer
+ *     vendor tree is not installed: "Cannot find module ...eslint.config.base.mjs".
+ *   - Silently linting more than intended. Proclaim's root config listed the
+ *     submodule paths under `ignores` and they were linted regardless; the file
+ *     count dropped 113 -> 105 once the config was pinned.
+ *
+ * Advisory only. package.json belongs to the consumer, and sync-configs does
+ * not rewrite hand-authored files -- the same reason checkProfileHints() below
+ * reports rather than edits.
+ */
+function checkEslintInvocation(string $projectRoot): void
+{
+    $packageJson = $projectRoot . '/package.json';
+
+    if (!is_file($packageJson)) {
+        return;
+    }
+
+    try {
+        $package = json_decode((string) file_get_contents($packageJson), true, 512, JSON_THROW_ON_ERROR);
+    } catch (\JsonException) {
+        // A malformed package.json is not this handler's problem to report.
+        return;
+    }
+
+    $script = $package['scripts']['lint:js'] ?? null;
+
+    if (!is_string($script) || $script === '') {
+        return;
+    }
+
+    // Either form pins the config: --no-config-lookup stops the per-file search
+    // outright, and -c/--config names the file to use.
+    if (str_contains($script, '--no-config-lookup')
+        || str_contains($script, '--config ')
+        || preg_match('/(^|\s)-c\s/', $script) === 1) {
+        return;
+    }
+
+    echo "package.json: lint:js does not pin an ESLint config.\n"
+        . "  ESLint 10 loads the nearest eslint.config.* per file, so the ignores in\n"
+        . "  the shared base config are advisory for any directory that has its own\n"
+        . "  (a submodule, or vendor/). Consider:\n"
+        . "    \"lint:js\": \"eslint --no-config-lookup -c eslint.config.mjs --max-warnings=0 .\"\n";
 }

--- a/templates/eslint.config.base.mjs
+++ b/templates/eslint.config.base.mjs
@@ -33,6 +33,24 @@ import globals from 'globals';
 
 export default defineConfig([
     {
+        // ⚠️ These are advisory unless the consumer's lint:js pins this config.
+        //
+        // ESLint 10 resolves the nearest eslint.config.* per file rather than
+        // using only the root one, so a plain `eslint .` walks into any
+        // directory carrying its own config — a git submodule, or this package's
+        // own install root under vendor/ — and lints those files under *that*
+        // config. These ignores never reach them.
+        //
+        // Seen both ways on Proclaim (build-tools#90): a hard
+        // ERR_MODULE_NOT_FOUND when the nested config imported a base file whose
+        // vendor tree was not installed, and, more quietly, files listed here
+        // being linted regardless — the count dropped 113 → 105 once the config
+        // was pinned.
+        //
+        // The invocation that holds:
+        //   eslint --no-config-lookup -c eslint.config.mjs --max-warnings=0 .
+        //
+        // `composer sync-configs` warns when lint:js omits it.
         ignores: ['**/vendor/', '**/node_modules/', '**/dist/', '**/reports/', 'media/'],
     },
 

--- a/tests/Cli/SyncConfigsEslintInvocationTest.php
+++ b/tests/Cli/SyncConfigsEslintInvocationTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Cli;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * sync-configs warns when a consumer's lint:js does not pin its ESLint config.
+ *
+ * Run through the real CLI rather than by calling the function: scripts/ has no
+ * autoloader and loads everything by path, which is the gap PackageCliTest
+ * exists to cover. A handler that is never reached from main() would pass any
+ * unit test and still do nothing.
+ *
+ * Always with --dry-run: the script writes .gitignore and friends, and a test
+ * that mutates its own fixture tells you less each time it runs.
+ */
+final class SyncConfigsEslintInvocationTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/cwm-sync-eslint-' . bin2hex(random_bytes(6));
+        mkdir($this->tmpDir, 0o777, true);
+
+        // Minimal project: the script needs a config file to run at all.
+        file_put_contents(
+            $this->tmpDir . '/cwm-build.config.json',
+            json_encode(['extension' => ['type' => 'component', 'name' => 'com_example']]),
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->tmpDir . '/*') ?: [] as $f) {
+            @unlink($f);
+        }
+
+        @rmdir($this->tmpDir);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: bool}>
+     */
+    public static function scripts(): array
+    {
+        return [
+            // The three forms actually in use across the consuming repos.
+            'unpinned (CWMLivingWord)'   => ['eslint --max-warnings=0 .', true],
+            'no-config-lookup (Proclaim)' => ['eslint --no-config-lookup -c eslint.config.mjs --max-warnings=0 .', false],
+            '-c (lib_cwmscripture)'      => ['eslint -c build/eslint.config.mjs --max-warnings=0 .', false],
+            // --config is the long form of -c and pins just as well.
+            'long --config'              => ['eslint --config eslint.config.mjs .', false],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('scripts')]
+    public function warns_only_when_the_config_is_not_pinned(string $lintScript, bool $expectWarning): void
+    {
+        file_put_contents(
+            $this->tmpDir . '/package.json',
+            json_encode(['name' => 'example', 'scripts' => ['lint:js' => $lintScript]]),
+        );
+
+        $output = $this->runSync();
+
+        if ($expectWarning) {
+            self::assertStringContainsString('lint:js does not pin an ESLint config', $output);
+            // The warning is only useful if it says what to write instead.
+            self::assertStringContainsString('--no-config-lookup', $output);
+        } else {
+            self::assertStringNotContainsString('lint:js does not pin', $output);
+        }
+    }
+
+    #[Test]
+    public function stays_quiet_when_the_project_has_no_package_json(): void
+    {
+        self::assertStringNotContainsString('lint:js', $this->runSync());
+    }
+
+    #[Test]
+    public function stays_quiet_when_package_json_is_malformed(): void
+    {
+        // A broken package.json is another handler's problem to report, and a
+        // crash here would take the whole sync down with it.
+        file_put_contents($this->tmpDir . '/package.json', '{ not json');
+
+        $output = $this->runSync();
+
+        self::assertStringNotContainsString('lint:js', $output);
+        self::assertStringNotContainsString('Fatal error', $output);
+    }
+
+    private function runSync(): string
+    {
+        $script = \dirname(__DIR__, 2) . '/scripts/sync-configs.php';
+        $cmd    = 'cd ' . escapeshellarg($this->tmpDir)
+            . ' && php ' . escapeshellarg($script) . ' --dry-run 2>&1';
+
+        return (string) shell_exec($cmd);
+    }
+}


### PR DESCRIPTION
Closes #90.

## The problem

ESLint 10 resolves the nearest `eslint.config.*` **per file** rather than using only the root one. A plain `eslint .` therefore walks into any directory carrying its own config — a git submodule, or this package's own install root under `vendor/` — and lints those files under *that* config. The `ignores` shipped in `templates/eslint.config.base.mjs` never reach them.

Both failure modes were seen on Proclaim:

- **Loud:** `ERR_MODULE_NOT_FOUND`, because the nested config imported a base file whose Composer vendor tree wasn't installed in that CI job.
- **Quiet:** paths listed under `ignores` being linted anyway — visible only as a file count dropping **113 → 105** once the config was pinned.

## The approach: warn, don't rewrite

`package.json` belongs to the consumer, and `sync-configs` does not rewrite hand-authored files — the same reason `checkProfileHints()` reports rather than edits. So this adds an advisory check in that mould.

It recognises `--no-config-lookup`, `-c` and `--config`, which between them cover every form currently in use:

| repo | `lint:js` | result |
|---|---|---|
| Proclaim | `eslint --no-config-lookup -c … .` | silent ✅ |
| lib_cwmscripture | `eslint -c build/eslint.config.mjs … .` | silent ✅ |
| CWMLivingWord | `eslint --max-warnings=0 .` | **warns** ✅ |

All three were run through the real script against their actual checkouts (`--dry-run`) to confirm it fires for exactly the third.

## Said in the places people will read it

The invocation and the `ignores` it protects get edited by different people at different times, so the warning is now in three places: the check itself, the header of the `ignores` block, and the `run-lint-js` input description in the reusable workflow — since turning that input on is when a repo finds out.

## Tests

Through the **CLI**, not by calling the function. `scripts/` has no autoloader and loads everything by path, so a handler `main()` never reaches would pass a unit test and still do nothing — which is exactly how 1.18.0 shipped a fatal in `cwm-package` with a green suite (`PackageCliTest` exists for that reason).

Six cases: the three real-world forms plus `--config`, no `package.json`, and a malformed one (which must stay quiet and must not take the whole sync down). **Mutation-checked** — with the handler stashed, the unpinned case fails.

Full suite green: PHPUnit 455 / 1063, Python 35, all 8 shell suites, `codespell`, `php -l`, `shellcheck`.

Changelog entry is under `[Unreleased]`; no release cut here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
