### PR TITLE
fix(release): hand the test:release gate the version about to ship (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`release.sh` now tells the `test:release` gate which version is about to
+  ship.** The gate runs before the bump, deliberately — it verifies the commit
+  being released, not the commit that results from bumping it — but that means
+  nothing on disk names the target version while it runs. A project whose
+  upgrade phase resolved "the build under test" from `versions.json` therefore
+  read a stale pointer: `active_development.version` still holds the previous
+  bump's value, and `current.version` the previous release's. Compared against a
+  baseline resolved the same way, the two match, and the phase stands down. (#101)
+
+  CWMLivingWord 5.7.0 released that way. Clean install, accessibility and API
+  acceptance all ran; the upgrade path — the one every existing site takes, and
+  where install-scriptfile postflight repairs live — was never exercised, on a
+  release whose headline fix was exactly such a repair. The gate passed, because
+  a phase reporting itself not-applicable is not a failure.
+
+  Version resolution now happens immediately before the gate rather than after
+  it, and the gate is invoked as `CWM_RELEASE_VERSION=<target> composer
+  test:release`. The reorder is read-only — the argument or prompt, a manifest
+  read for the prompt hint, and `cwm_validate_release_version` — so the gate's
+  "nothing has been mutated yet" property is unchanged. As a side effect the two
+  version strings the pipeline refuses outright, empty and `-dev`, now cost a
+  second instead of a full acceptance suite. The variable is set as a command
+  prefix, not exported, so no later step's environment changes.
+
+  Consumers have to read it for this to do anything. `docs/releasing.md` covers
+  the contract and why the baseline belongs in published artifacts — the newest
+  stable release older than the target — rather than in a file the pipeline has
+  not written yet.
+
 ## [1.22.0] - 2026-08-14
 
 ### Fixed

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -29,6 +29,66 @@ composer cwm-release
 6. **Finish** — update `versions.json` and push the release commit/tag to
    `github.releaseBranch`.
 
+## The release gate
+
+If the project's `composer.json` defines a `test:release` script, `cwm-release`
+runs it as a pre-flight gate and stops before touching anything if it fails.
+This is opt-in by presence — a project with no `test:release` script is released
+exactly as before. Pass `--skip-tests` to release anyway; `--dry-run` still runs
+the gate for real, since it verifies rather than writes.
+
+The gate runs **before the version bump**, so it verifies the commit about to be
+released rather than the commit that results from bumping it. That ordering is
+deliberate and worth keeping, but it has a consequence: at the moment the gate
+runs, nothing on disk names the version about to ship.
+
+`cwm-release` therefore hands the gate that version in the environment:
+
+```bash
+CWM_RELEASE_VERSION=1.2.3 composer test:release
+```
+
+It is set for that one command, not exported — the bump, the build and every
+later step see the environment they always did.
+
+!!! warning "Don't resolve the version under test from `versions.json`"
+    Neither field names the release in progress while the gate is running.
+    `active_development.version` is written by `cwm-bump`, which has not run
+    yet, so it holds the *previous* bump's value. `current.version` is written
+    by step 8, after publishing, so it holds the *previous* release.
+
+    An upgrade phase that reads either as "the build under test" and compares it
+    against a baseline resolved the same way finds them equal, concludes there
+    is nothing to upgrade to, and reports itself not-applicable. The gate then
+    passes. A CWMLivingWord 5.7.0 release went out that way with the upgrade
+    path — the one every existing site takes, and where install-scriptfile
+    postflight repairs live — never exercised, on a release whose headline fix
+    was exactly such a repair (#101).
+
+    Read `CWM_RELEASE_VERSION` for the target, and resolve the baseline from
+    published artifacts — the newest stable GitHub release older than the target
+    — rather than from a file the pipeline has not updated yet.
+
+The variable's presence is itself the signal, because `test:release` runs in two
+situations and the right answer differs between them:
+
+| `CWM_RELEASE_VERSION` | Situation | The build under test is |
+|---|---|---|
+| set | a release is in progress; the bump has not run | the variable |
+| unset | nightly, PR or manual run; no release in flight | `active_development.version` |
+
+Outside a release that file is correct — `cwm-bump` wrote it and nothing is
+mid-flight — so the fallback is not a workaround, it is the other half of the
+contract. Read the variable when it is set and fall back when it is not:
+
+```bash
+TARGET="${CWM_RELEASE_VERSION:-$(jq -r .active_development.version versions.json)}"
+```
+
+A gate phase that genuinely has nothing to do should still say so loudly enough
+to be read as a finding. "Not applicable" printed next to a passing gate is
+indistinguishable from "covered", which is what made the above quiet.
+
 ## The token gate
 
 Step 2 substitutes across `substituteTokens.paths`. That list is hand-maintained
@@ -62,13 +122,6 @@ If it fires, the usual causes are a shipped directory missing from `paths`
 is not covered by a bare `src/` entry) or a vendored `cwm/build-tools` older than
 the fix for the file in question — `composer.lock` is not evidence the installed
 tree is current.
-
-Before any of that, if the project's `composer.json` defines a `test:release`
-script, `cwm-release` runs it as a pre-flight gate and stops before touching
-anything if it fails. This is opt-in by presence — a project with no
-`test:release` script is released exactly as before. Pass `--skip-tests` to
-release anyway; `--dry-run` still runs the gate for real, since it verifies
-rather than writes.
 
 Always check `--help` for the current flags and any dry-run option:
 

--- a/scripts/lib/testgate.sh
+++ b/scripts/lib/testgate.sh
@@ -37,3 +37,31 @@ cwm_has_test_release_script() {
         exit(isset($c["scripts"]["test:release"]) ? 0 : 1);
     ' "$composer_json" 2>/dev/null
 }
+
+# Run the project's test:release script with the release target in scope.
+#
+# The gate runs before the bump, by design — it verifies the commit about to
+# be released, not the commit that results from bumping it. The cost is that
+# nothing on disk yet names the version about to ship: versions.json carries
+# `active_development.version` from the *previous* bump and `current.version`
+# from the *previous* release, so an upgrade phase that derives "the build
+# under test" from either compares a version against itself, concludes there
+# is nothing to upgrade to, and stands down. A CWMLivingWord 5.7.0 release
+# passed its gate that way with the upgrade path never exercised — on a
+# release whose headline fix lived in install-scriptfile postflight (#101).
+#
+# CWM_RELEASE_VERSION is that missing fact. It is set as a command prefix
+# rather than exported, so it reaches the gate and nothing else: the bump, the
+# build, the publish and every other subprocess keep the environment they had.
+#
+# Arguments:
+#   $1  The version about to be released (already validated by the caller).
+#
+# Returns:
+#   composer's exit status, unchanged — release.sh branches on it three ways
+#   (pass, dry-run warning, hard stop).
+cwm_run_test_release() {
+    local version="$1"
+
+    CWM_RELEASE_VERSION="$version" composer test:release
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -49,6 +49,12 @@
 #   so that's a deliberate, visible choice rather than a reason to touch this
 #   script. See lib/testgate.sh.
 #
+#   The gate is handed CWM_RELEASE_VERSION — the version about to ship. It
+#   runs before the bump, so nothing on disk names that version yet, and a
+#   test phase that derives it from versions.json instead reads a stale
+#   pointer and can quietly decide it has nothing to do (#101). Read the
+#   variable, not the file.
+#
 # Prerequisites:
 #   - Clean working tree, on the configured release branch (default: main)
 #   - gh CLI authenticated
@@ -223,29 +229,15 @@ if [ -f .gitmodules ]; then
 fi
 echo ""
 
-# --- Pre-flight: release gate (composer test:release) ---
-# Verifies the commit about to be released, not the commit that results from
-# bumping/building it — so this runs before step 1, against what's on disk
-# right now. See lib/testgate.sh for why this exists at all.
-if [ "$SKIP_TESTS" = "1" ]; then
-    echo "[pre-flight] Skipping composer test:release (--skip-tests)."
-elif ! cwm_has_test_release_script "${PROJECT_ROOT}/composer.json"; then
-    echo "[pre-flight] No composer test:release script — skipping pre-release verification."
-else
-    echo "[pre-flight] Running composer test:release..."
-    if composer test:release; then
-        echo "  test:release passed."
-    elif [ "$DRY_RUN" = "1" ]; then
-        echo "  WARNING: test:release failed. A real run would stop here."
-    else
-        echo ""
-        echo "Error: composer test:release failed. Fix the failure, or pass --skip-tests to release anyway."
-        exit 1
-    fi
-fi
-echo ""
-
 # --- Get version ---
+#
+# Resolved before the gate below, not after, so the gate can be told which
+# version is about to ship (#101). Everything here reads — the manifest for the
+# prompt hint, the argument or the terminal for the answer, lib/version.sh to
+# validate it — so the gate's "nothing has been mutated yet" property survives
+# the move intact. It also means the two version strings the pipeline refuses
+# outright (empty, and -dev) now cost a second rather than a full acceptance
+# suite.
 if [ -n "${1:-}" ]; then
     VERSION="$1"
 else
@@ -255,6 +247,10 @@ else
     fi
     printf "Enter new version (e.g., 1.2.3): "
     read -r VERSION
+    # Separate the prompt from the gate's output below. Only on this path —
+    # when the version came in as an argument this block prints nothing, and
+    # the preceding pre-flight already left a blank line.
+    echo ""
 fi
 
 # Validation, tag and pre-release derivation live in lib/version.sh so
@@ -263,6 +259,28 @@ cwm_validate_release_version "$VERSION" || exit 1
 
 TAG=$(cwm_tag_for_version "$VERSION")
 PRERELEASE_FLAG=$(cwm_prerelease_flag "$VERSION")
+
+# --- Pre-flight: release gate (composer test:release) ---
+# Verifies the commit about to be released, not the commit that results from
+# bumping/building it — so this runs before step 1, against what's on disk
+# right now. The version above is handed to it as CWM_RELEASE_VERSION, since
+# nothing on disk names it yet. See lib/testgate.sh for both.
+if [ "$SKIP_TESTS" = "1" ]; then
+    echo "[pre-flight] Skipping composer test:release (--skip-tests)."
+elif ! cwm_has_test_release_script "${PROJECT_ROOT}/composer.json"; then
+    echo "[pre-flight] No composer test:release script — skipping pre-release verification."
+else
+    echo "[pre-flight] Running composer test:release (CWM_RELEASE_VERSION=${VERSION})..."
+    if cwm_run_test_release "$VERSION"; then
+        echo "  test:release passed."
+    elif [ "$DRY_RUN" = "1" ]; then
+        echo "  WARNING: test:release failed. A real run would stop here."
+    else
+        echo ""
+        echo "Error: composer test:release failed. Fix the failure, or pass --skip-tests to release anyway."
+        exit 1
+    fi
+fi
 
 echo ""
 echo "=== ${PKG_NAME} Release ${VERSION} ==="

--- a/tests/shell/testgate.test.sh
+++ b/tests/shell/testgate.test.sh
@@ -79,4 +79,41 @@ else
     PASS=$((PASS + 1))
 fi
 
+# --- Invoking the gate (#101) -------------------------------------------------
+# A stub `composer` on PATH, not the real one — the header's "running composer
+# for real isn't something a unit test should do" still holds. What is under
+# test is the environment the gate is handed and the status it returns, and
+# neither needs a real composer process to observe.
+mkdir -p "${WORK}/bin"
+cat > "${WORK}/bin/composer" <<'STUB'
+#!/usr/bin/env bash
+echo "args=$* version=${CWM_RELEASE_VERSION-<unset>}"
+exit "${STUB_EXIT:-0}"
+STUB
+chmod +x "${WORK}/bin/composer"
+PATH="${WORK}/bin:${PATH}"
+
+# The release target reaches the gate. Without it the gate has no way to know
+# which version is about to ship — the bump hasn't happened yet — and an
+# upgrade phase resolving it from versions.json compares a version to itself.
+assert_equals \
+    "args=test:release version=1.2.3" \
+    "$(cwm_run_test_release '1.2.3')" \
+    "the gate runs test:release with CWM_RELEASE_VERSION set to the target"
+
+# Scoped to that one command, not exported: the bump, the build and every
+# later step must keep the environment they had.
+assert_equals \
+    "<unset>" \
+    "${CWM_RELEASE_VERSION-<unset>}" \
+    "CWM_RELEASE_VERSION does not leak into the caller's environment"
+
+# release.sh branches three ways on this status (pass / dry-run warning / hard
+# stop), so it has to arrive unchanged rather than swallowed by the wrapper.
+export STUB_EXIT=7
+cwm_run_test_release '1.2.3' > /dev/null
+GATE_STATUS=$?
+unset STUB_EXIT
+assert_equals "7" "$GATE_STATUS" "composer's exit status reaches the caller unchanged"
+
 finish


### PR DESCRIPTION
Closes #101.

## The problem

The `test:release` gate runs before the bump — deliberately, so a failure leaves nothing
mutated — which means nothing on disk names the version about to ship while it is running.
`versions.json` carries `active_development.version` from the *previous* bump and
`current.version` from the *previous* release, so a project resolving "the build under
test" from either compares a version against itself, and its upgrade phase concludes there
is nothing to upgrade to.

CWMLivingWord 5.7.0 released that way. Clean install, accessibility and API acceptance all
ran; the upgrade path — the one every existing site takes, and where install-scriptfile
postflight repairs live — was never exercised, on a release whose headline fix was exactly
such a repair. The gate passed, because a phase reporting itself not-applicable is not a
failure.

## One correction to the issue's option ranking

#101 offered option 2 (export the target version) as *"cheapest, and keeps the current
ordering intact."* It was not quite that. The gate block ended at `release.sh:246` and
`# --- Get version ---` did not start until `:248`, so `$VERSION` did not exist yet when
the gate ran.

So version resolution moves above the gate. That turned out to be favourable: everything in
that block reads — the argument or the prompt, a manifest read for the prompt hint,
`cwm_validate_release_version` — so the "nothing mutated before tests pass" property
survives the move intact, and the two version strings the pipeline refuses outright
(empty and `-dev`) now cost a second instead of a full acceptance suite.

## What changed

| file | |
|---|---|
| `scripts/release.sh` | version resolution hoisted above the gate; gate calls `cwm_run_test_release "$VERSION"` |
| `scripts/lib/testgate.sh` | new `cwm_run_test_release()` |
| `tests/shell/testgate.test.sh` | three regression assertions |
| `docs/releasing.md` | the gate gets its own section, and the consumer contract |
| `CHANGELOG.md` | under `[Unreleased]` → `Fixed` |

`CWM_RELEASE_VERSION` is set as a **command prefix, not an export**, so the bump, the
build, the publish and every other subprocess keep the environment they had. The
invocation is extracted to `lib/testgate.sh` for the same reason
`cwm_has_test_release_script()` lives there — `release.sh` itself is not reachable from a
unit test. The three-way branch on the gate's result (pass / dry-run warning / hard stop)
depends on composer's status arriving unchanged, so the function returns it bare.

## Testing

`composer test` green: 455 PHPUnit tests / 1063 assertions, and 120 shell assertions
across 8 files.

The new coverage uses a **stub `composer` on PATH**, not a real one — what is under test is
the environment the gate is handed, which needs no composer process to observe, so
`testgate.sh`'s "running composer for real isn't something a unit test should do" still
holds. Three assertions: the target reaches the gate, the variable does not leak to the
caller, and a non-zero status propagates. Mutation-checked — with the prefix dropped from
the function, the first fails:

```
FAIL: the gate runs test:release with CWM_RELEASE_VERSION set to the target
      expected: args=test:release version=1.2.3
      actual:   args=test:release version=<unset>
```

Also driven end to end against a throwaway project with a local origin, covering the
argument path, the prompt path, `--skip-tests`, the no-`test:release`-script path, and
`-dev` now being rejected before the gate rather than after it:

```
[pre-flight] Running composer test:release (CWM_RELEASE_VERSION=1.2.3)...
GATE SAW CWM_RELEASE_VERSION=1.2.3
  test:release passed.
```

`mkdocs` is not installed locally, so `--strict` was not run. The docs change adds no links
or nav entries, and nothing linked into the moved paragraph's old anchor.

## Consumers have to read it

Option 2 does nothing on its own, so option 3 came with it. `docs/releasing.md` states the
contract in both directions:

| `CWM_RELEASE_VERSION` | situation | the build under test is |
|---|---|---|
| set | a release is in progress; the bump has not run | the variable |
| unset | nightly, PR or manual run | `active_development.version` |

A consumer reading `${CWM_RELEASE_VERSION}` unguarded would break their own CI, which is
why the fallback is documented as the other half of the contract rather than as a
workaround. Adoption is tracked in Joomla-Bible-Study/Proclaim#1871 and
Joomla-Bible-Study/CWMLivingWord#152.

The other end of an upgrade test — resolving the released artifact to upgrade *from* — is
#103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
