### PR TITLE
fix(release): stop a pre-release moving versions.json's stable pointers (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed (breaking)
+
+- **A pre-release no longer moves `current.version` or `next.*` in
+  `versions.json`.** `writeVersionsJsonRelease()` wrote `$version` into
+  `current.version` unconditionally, but that field is documented — in its own
+  default description, and in the template this package ships — as the *last
+  stable release*. Releasing `10.4.0-beta1` recorded a pre-release there. (#103)
+
+  It matters because consumers read the field as what its description says.
+  Proclaim's upgrade harness takes `current.version` as the artifact users are
+  on and installs it as the baseline to upgrade from, so a beta recorded there
+  becomes the state of the world for the next upgrade test.
+
+  `next.*` follows for the same reason. It is derived from the last stable
+  release, and after `10.3.2-beta1` the next release is `10.3.2` itself — which
+  is what `next.patch` already held, computed from `10.3.1`. Advancing it to
+  `10.3.3` named a version that skipped the one being stabilised. `_updated`
+  stamps when those pointers last moved, so it stays put too, and the whole
+  write becomes a no-op that says why.
+
+  A malformed version still throws rather than being waved through as "not
+  stable, nothing to do" — `computeNexts()` runs first, as it did before.
+
+  Breaking for any project that releases pre-releases and reads either field.
+  Nothing else in the pipeline changes: the tag, the GitHub release and the
+  changelog all still record that the pre-release happened. `versions.json` was
+  never that record.
+
 ### Fixed
 
 - **`release.sh` now tells the `test:release` gate which version is about to

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -55,7 +55,8 @@ later step see the environment they always did.
     Neither field names the release in progress while the gate is running.
     `active_development.version` is written by `cwm-bump`, which has not run
     yet, so it holds the *previous* bump's value. `current.version` is written
-    by step 8, after publishing, so it holds the *previous* release.
+    by step 8, after publishing, and only for a stable release, so it holds the
+    *previous stable* one.
 
     An upgrade phase that reads either as "the build under test" and compares it
     against a baseline resolved the same way finds them equal, concludes there

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -535,7 +535,11 @@ elif [ "$DRY_RUN" = "1" ]; then
     else
         cwm_skip_in_dry_run "update ${VERSIONS_FILE} on ${RELEASE_BRANCH}, then commit and push it"
     fi
-    echo "  Would set current.version=${VERSION}, recompute next.{patch,minor,major}, refresh _updated."
+    if [ -n "$PRERELEASE_FLAG" ]; then
+        echo "  Would leave ${VERSIONS_FILE} unchanged — current/next track stable releases."
+    else
+        echo "  Would set current.version=${VERSION}, recompute next.{patch,minor,major}, refresh _updated."
+    fi
 elif [ -n "$DEV_BRANCH" ]; then
     # Project uses separate dev branch (versions.json lives there, not on release branch)
     #

--- a/src/Release/VersionTracker.php
+++ b/src/Release/VersionTracker.php
@@ -87,6 +87,10 @@ final class VersionTracker
      * `_updated`. Leaves `active_development` alone — that's the dev-side
      * field, updated by the next cwm-bump.
      *
+     * A pre-release writes nothing. Both fields describe the stable line —
+     * `current` is the last stable release, `next.*` the candidates that follow
+     * it — and a beta advances neither. See writeVersionsJsonRelease().
+     *
      * Called from cwm-release step 7.
      *
      * @return list<string> Files actually rewritten.
@@ -274,7 +278,34 @@ final class VersionTracker
     {
         $data = $this->readJson($path);
 
+        // Computed before the pre-release check so a malformed version still
+        // throws rather than being waved through as "not stable, nothing to do".
         $nexts = $this->computeNexts($version);
+
+        /*
+         * A pre-release advances neither pointer, so it writes nothing.
+         *
+         * `current` is documented as the last stable release, and consumers
+         * read it that way — Proclaim's upgrade harness takes it as the
+         * artifact "users are on" and installs it as the baseline to upgrade
+         * from. Recording 10.4.0-beta1 there hands the next upgrade test a beta
+         * as the state of the world (#103).
+         *
+         * `next.*` follows for the same reason. It is derived from the last
+         * stable release, and after 10.3.2-beta1 the next release is 10.3.2
+         * itself — which is what next.patch already holds, computed from
+         * 10.3.1. Advancing it to 10.3.3 would name a version that skips the
+         * one being stabilised.
+         *
+         * `_updated` stamps when these pointers last moved, so it stays put
+         * too. The GitHub release, the tag and the changelog all still record
+         * that the pre-release happened; this file is not that record.
+         */
+        if (preg_match('/^\d+\.\d+\.\d+-/', $version) === 1) {
+            echo "  $path (unchanged — $version is a pre-release; current/next track stable releases)\n";
+
+            return false;
+        }
 
         $needsWrite = false;
 

--- a/templates/versions.json.tmpl
+++ b/templates/versions.json.tmpl
@@ -3,7 +3,7 @@
     "_updated": "YYYY-MM-DD",
     "current": {
         "version": "0.0.0",
-        "description": "Last stable release (mirrors latest GitHub release tag)"
+        "description": "Last stable release. Pre-releases do not move this, or next.*"
     },
     "next": {
         "patch": "0.0.1",

--- a/tests/Release/VersionTrackerTest.php
+++ b/tests/Release/VersionTrackerTest.php
@@ -78,19 +78,48 @@ final class VersionTrackerTest extends TestCase
     }
 
     #[Test]
-    public function update_for_release_strips_prerelease_suffix_when_computing_nexts(): void
+    public function update_for_release_leaves_every_pointer_alone_for_a_prerelease(): void
     {
-        $this->seedVersionsJson(['current' => ['version' => '10.3.1']]);
+        $this->seedVersionsJson([
+            'current' => ['version' => '10.3.1'],
+            'next'    => ['patch' => '10.3.2', 'minor' => '10.4.0', 'major' => '11.0.0'],
+            '_updated' => '2026-05-01',
+        ]);
 
         $tracker = $this->tracker(['versionsJson' => 'build/versions.json']);
-        $this->runQuiet(fn () => $tracker->updateForRelease('10.3.2-beta1', '2026-05-15'));
+        $touched = $this->runQuiet(fn () => $tracker->updateForRelease('10.3.2-beta1', '2026-05-15'));
 
         $v = $this->readJson('build/versions.json');
 
-        self::assertSame('10.3.2-beta1', $v['current']['version']);
-        self::assertSame('10.3.3', $v['next']['patch']);
+        // current is the last STABLE release — Proclaim's upgrade harness
+        // installs it as the baseline, so a beta recorded here becomes the
+        // state of the world for the next upgrade test (#103).
+        self::assertSame('10.3.1', $v['current']['version']);
+
+        // next.patch is already 10.3.2 — the version 10.3.2-beta1 is
+        // stabilising. Advancing it to 10.3.3 would skip that release.
+        self::assertSame('10.3.2', $v['next']['patch']);
         self::assertSame('10.4.0', $v['next']['minor']);
         self::assertSame('11.0.0', $v['next']['major']);
+
+        self::assertSame('2026-05-01', $v['_updated']);
+        self::assertSame([], $touched, 'nothing was written, so nothing is reported as touched');
+    }
+
+    #[Test]
+    public function update_for_release_strips_a_prerelease_suffix_it_is_stabilising(): void
+    {
+        // 10.3.2 final, released after 10.3.2-beta1: the stable line advances
+        // to it, and the nexts follow from it.
+        $this->seedVersionsJson(['current' => ['version' => '10.3.1']]);
+
+        $tracker = $this->tracker(['versionsJson' => 'build/versions.json']);
+        $this->runQuiet(fn () => $tracker->updateForRelease('10.3.2', '2026-05-15'));
+
+        $v = $this->readJson('build/versions.json');
+
+        self::assertSame('10.3.2', $v['current']['version']);
+        self::assertSame('10.3.3', $v['next']['patch']);
     }
 
     #[Test]


### PR DESCRIPTION
Part of #103 — its premise, landed separately so the `cwm-baseline` extraction is not carrying a behaviour change with it.

## The problem

`writeVersionsJsonRelease()` wrote `$version` into `current.version` unconditionally. That field is documented as the **last stable release** — in its own default description, and in `templates/versions.json.tmpl`, which this package ships to consumers. Releasing `10.4.0-beta1` recorded a pre-release there.

Consumers read it as what it says. Proclaim's upgrade harness takes `current.version` as the artifact users are on and installs it as the baseline to upgrade from, so a beta recorded there becomes the state of the world for the next upgrade test.

## What changed

A pre-release now writes nothing.

`next.*` follows `current` for the same reason: it is derived from the last stable release, and after `10.3.2-beta1` the next release is `10.3.2` itself — which is what `next.patch` already held, computed from `10.3.1`. Advancing it to `10.3.3` named a version that skipped the one being stabilised. `_updated` stamps when those pointers last moved, so it stays put too.

`computeNexts()` still runs first, so a malformed version throws as before rather than being waved through as "contains a hyphen, therefore a pre-release, therefore nothing to do". The existing `not-a-version` test pins that.

## Tests

`composer test`: 456 PHPUnit tests / 1067 assertions, plus 120 shell assertions — green.

The replaced test asserted `current.version == '10.3.2-beta1'`. Its name was about stripping the suffix when computing nexts, and the `current` assertion was incidental — so stripping is now pinned by a stable release following a beta, and the pre-release case asserts every pointer holds still. Mutation-checked: with the guard forced false, the new test fails on `current.version`.

## Breaking

For any project that releases pre-releases and reads either field. Nothing else in the pipeline changes — the tag, the GitHub release and the changelog all still record that the pre-release happened. `versions.json` was never that record.

Two descriptions of the old behaviour updated to match: the dry-run line in `release.sh` step 8, and the field description in the shipped template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)