### PR TITLE
feat(release): add cwm-baseline, the released artifact an upgrade test upgrades from (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`cwm-baseline` — resolve and fetch the released package an upgrade test
+  upgrades *from*.** Both consumers had written this themselves and diverged on
+  the part that matters. Proclaim read `versions.json` `current`; CWMLivingWord
+  resolved it from the releases that exist, after `current` made the phase skip
+  itself during the 5.7.0 release. Each implementation had something the other
+  lacked — a floor below which no release installs, a `gh`-presence check, a
+  not-applicable path — and neither was going to acquire the other's half. (#103)
+
+  Resolution: the newest release strictly older than the target, at or above
+  `baseline.minimum`, preferring stable and falling back to a pre-release only
+  when nothing stable qualifies. The target is `CWM_RELEASE_VERSION` when a
+  release is in flight (#101), `--target`, or the manifest — in that order — so
+  the baseline is chosen relative to the version being shipped rather than the
+  manifest the pre-bump gate has not touched yet.
+
+  The artifact name and its directory come from `build.outputGlob`, the one
+  artifact-naming key present in every project shape, with the version
+  substituted for its `*`. A glob that cannot name exactly one asset is refused
+  rather than guessed at: a wrong name reports "not found on the release", which
+  sends the reader after the wrong problem.
+
+  **Exit 3 is "no usable baseline"** — a first release, or every candidate below
+  the floor — kept distinct from both success and failure. Treating it as fatal
+  blocks the first release of every new project; treating it as success reports
+  an upgrade test that never ran.
+
+  Selection lives in `scripts/lib/baseline.sh`, free of network calls, so it is
+  tested against release-list fixtures rather than by reading.
+
 ### Changed (breaking)
 
 - **A pre-release no longer moves `current.version` or `next.*` in

--- a/bin/cwm-baseline
+++ b/bin/cwm-baseline
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# cwm-baseline — fetch the released package an upgrade test upgrades from.
+#
+# Resolves the newest release older than the version under test (preferring
+# stable, honouring baseline.minimum) and downloads its artifact into the
+# project's build output directory.
+#
+# Usage from a consuming project:
+#   composer cwm-baseline
+#   composer cwm-baseline -- --target 5.7.1
+#   composer cwm-baseline -- --print
+#   composer cwm-baseline -- --help
+#
+set -euo pipefail
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec bash "${TOOLS_DIR}/scripts/baseline.sh" "$@"

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,8 @@
         "bin/cwm-install-zip",
         "bin/cwm-joomla-install",
         "bin/cwm-joomla-latest",
-        "bin/cwm-joomla-cms-deps"
+        "bin/cwm-joomla-cms-deps",
+        "bin/cwm-baseline"
     ],
     "config": {
         "sort-packages": true,

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -32,6 +32,7 @@ matching Composer script (`composer cwm-init` → `vendor/bin/cwm-init`).
 | `cwm-clean` | Remove every dev symlink `cwm-link` created. |
 | `cwm-verify` | Confirm each install has every project sub-extension registered in `#__extensions`; detects `manifest_cache` drift. **Exit non-zero** on mismatch. |
 | `cwm-install-zip` | Install the built dist zip into every Joomla install. |
+| `cwm-baseline` | Download the released package an upgrade test should upgrade *from* — the newest release older than the version under test, preferring stable. **Exit 3** when no usable baseline exists (a first release), which is a status, not a failure. See [the release gate](releasing.md#the-release-gate). |
 
 See [How to use → everyday commands](how-to-use.md#3-everyday-commands) for the
 typical day-to-day loop.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ cwm-init` rather than authoring by hand. Minimal examples live in
 | `ars` | Akeeba Release System target: `endpoint`, `categoryId`, `updateStreamId`, `environments[]`, `tokenItem`, `tokenVault` (1Password). |
 | `github` | `{ owner, repo, releaseBranch }` for release + changelog. |
 | `changelog` | `{ file, url }` — the Joomla changelog XML path and its raw URL. |
+| `baseline` | Optional. `{ minimum }` — the oldest release `cwm-baseline` may pick as an upgrade "before" state. For projects whose early packages do not install at all, so choosing one wastes a run on a failure that says nothing about the build. Omit for no floor. |
 | `announcement` | `{ command, bulletsDir }` for the release announcement article. |
 | `versionTracking` | Override layer, deep-merged on top of the profile. `versionsJson`, `packageJson`, `substituteTokens.paths[]`, `sourceFiles[]`. **Lists replace wholesale.** See [source-file version literals](#versiontrackingsourcefiles--version-literals-in-source) below. |
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -90,6 +90,34 @@ A gate phase that genuinely has nothing to do should still say so loudly enough
 to be read as a finding. "Not applicable" printed next to a passing gate is
 indistinguishable from "covered", which is what made the above quiet.
 
+### The other end: which release to upgrade *from*
+
+An upgrade phase also needs a "before" state, and `cwm-baseline` resolves and
+fetches it:
+
+```bash
+composer cwm-baseline            # newest release older than the version under test
+composer cwm-baseline -- --print # just say which, download nothing
+```
+
+It reads `CWM_RELEASE_VERSION` when a release is in flight, so the baseline is
+chosen relative to the version being shipped rather than the stale manifest.
+Stable releases are preferred; a pre-release is only chosen when no stable one
+qualifies. `baseline.minimum` excludes early releases that cannot install.
+
+It downloads the **released artifact**, not a rebuild of an old tree — the
+released zip carries the old `install.sql`, without the newer migrations, so
+installing the new build over it genuinely exercises the `ADD COLUMN` /
+`CREATE TABLE` update SQL.
+
+!!! note "Exit 3 means *not applicable*, and the caller decides"
+    A project's first release has nothing to upgrade from, and neither does one
+    whose every candidate sits below `baseline.minimum`. That is not a failure.
+    It exits **3** rather than 0 or 1 so the caller can tell it apart from both:
+    treating it as fatal blocks the first release of every new project, and
+    treating it as success reports an upgrade test that never ran. #101 is the
+    story of that distinction being made silently, in the wrong place.
+
 ## The token gate
 
 Step 2 substitutes across `substituteTokens.paths`. That list is hand-maintained

--- a/scripts/baseline.sh
+++ b/scripts/baseline.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# Fetch the released artifact an upgrade test should upgrade FROM.
+#
+# Reads cwm-build.config.json from the current working directory. The release
+# list comes from the project's GitHub repo; selection lives in
+# lib/baseline.sh so it can be tested without a network.
+#
+# Why the baseline is a released artifact rather than a rebuild of an old tree:
+# the released zip carries the old install.sql, without the newer migrations,
+# so installing the new build over it genuinely exercises the ADD COLUMN /
+# CREATE TABLE update SQL. A rebuild of an old checkout with today's build
+# tooling does not reliably reproduce that.
+#
+# Usage:
+#   cwm-baseline                # resolve and fetch, target from the manifest
+#   cwm-baseline --target 5.7.1 # resolve relative to a specific version
+#   cwm-baseline --version 5.6.2 # skip resolution, fetch this release
+#   cwm-baseline --print        # print the resolved version, download nothing
+#
+# Exit codes are the point of this script's interface — see EXIT CODE in --help.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=lib/baseline.sh
+source "${SCRIPT_DIR}/lib/baseline.sh"
+# shellcheck source=lib/version.sh
+source "${SCRIPT_DIR}/lib/version.sh"
+
+PROJECT_ROOT="$(pwd)"
+CONFIG_FILE="${PROJECT_ROOT}/cwm-build.config.json"
+
+usage() {
+    cat <<'CWM_HELP'
+cwm-baseline — fetch the released package an upgrade test upgrades from.
+
+WHAT IT DOES
+  Resolves which released version is the right "before" state, then downloads
+  that release's artifact into the project's build output directory.
+
+  Resolution picks the newest release strictly older than the target that is
+  at or above the configured floor, preferring stable releases and falling
+  back to pre-releases only when no stable one qualifies.
+
+  Already-downloaded baselines are left alone, so re-running is cheap.
+
+PREREQUISITES
+  - cwm-build.config.json with github.owner, github.repo and build.outputGlob
+  - gh CLI, authenticated against that repo
+
+USAGE
+  composer cwm-baseline                     # resolve and fetch
+  composer cwm-baseline -- --target 5.7.1   # resolve relative to this version
+  composer cwm-baseline -- --version 5.6.2  # fetch this release, no resolution
+  composer cwm-baseline -- --print          # print the resolution, fetch nothing
+
+OPTIONS
+  --target <ver>   Resolve relative to this version instead of the manifest's.
+                   During a release, CWM_RELEASE_VERSION is used automatically.
+  --version <ver>  Use this baseline verbatim. Skips resolution entirely.
+  --print          Print the resolved version and exit without downloading.
+  -h, --help       Show this and exit.
+
+CONFIGURATION
+  github.owner / github.repo   Which repo's releases to read.
+  build.outputGlob             Names the artifact and the directory it lands
+                               in. Must contain exactly one '*'.
+  baseline.minimum             Optional. Releases older than this are never
+                               chosen — for projects whose early packages do
+                               not install at all.
+
+EXIT CODE
+  0  a baseline is present in the output directory
+  1  an error: bad config, gh missing or failing, asset not on the release
+  3  no usable baseline exists — the first release of a project, or every
+     candidate below the floor. NOT a failure. A caller that treats this as
+     fatal blocks the first release of every new project; one that treats it
+     as success reports an upgrade test that never ran.
+
+RELATED
+  composer cwm-release      # runs the test:release gate before bumping
+  composer cwm-install-zip  # install a built or downloaded zip
+CWM_HELP
+}
+
+TARGET=""
+EXPLICIT_VERSION=""
+PRINT_ONLY=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+        --print)   PRINT_ONLY=1; shift ;;
+        --target)  TARGET="${2:-}"; shift 2 ;;
+        --version) EXPLICIT_VERSION="${2:-}"; shift 2 ;;
+        *)
+            echo "Error: unknown option '$1'." >&2
+            echo >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "Error: $CONFIG_FILE not found" >&2
+    exit 1
+fi
+
+read_config() {
+    php -r "\$c = json_decode(file_get_contents('${CONFIG_FILE}'), true); \$keys = explode('.', '$1'); \$v = \$c; foreach (\$keys as \$k) { \$v = \$v[\$k] ?? null; if (\$v === null) break; } echo \$v ?? '';"
+}
+
+GH_OWNER=$(read_config "github.owner")
+GH_REPO=$(read_config "github.repo")
+OUTPUT_GLOB=$(read_config "build.outputGlob")
+FLOOR=$(read_config "baseline.minimum")
+
+if [ -z "$GH_OWNER" ] || [ -z "$GH_REPO" ]; then
+    echo "Error: github.owner and github.repo must be set in cwm-build.config.json" >&2
+    exit 1
+fi
+
+if [ -z "$OUTPUT_GLOB" ]; then
+    echo "Error: build.outputGlob must be set in cwm-build.config.json" >&2
+    exit 1
+fi
+
+REPO="${GH_OWNER}/${GH_REPO}"
+DIST="$(cwm_baseline_dir_from_glob "$OUTPUT_GLOB")"
+
+# --- Resolve the baseline version ---
+if [ -n "$EXPLICIT_VERSION" ]; then
+    BASEVER="$EXPLICIT_VERSION"
+    echo "Baseline named explicitly: ${BASEVER}"
+else
+    # The target: an explicit --target, else the version cwm-release is about
+    # to ship, else the manifest. CWM_RELEASE_VERSION matters because the gate
+    # runs before the bump, so during a release the manifest still carries the
+    # previous cycle's version and resolving against it selects a baseline one
+    # release too old (#101).
+    if [ -z "$TARGET" ]; then
+        TARGET="${CWM_RELEASE_VERSION:-}"
+    fi
+
+    if [ -z "$TARGET" ]; then
+        PKG_MANIFEST=$(read_config "manifests.package")
+
+        if [ -n "$PKG_MANIFEST" ]; then
+            TARGET=$(cwm_version_from_manifest "$PKG_MANIFEST" || true)
+        fi
+    fi
+
+    if [ -z "$TARGET" ]; then
+        echo "Error: could not determine the target version." >&2
+        echo "       Pass --target <ver>, or set manifests.package in cwm-build.config.json." >&2
+        exit 1
+    fi
+
+    if ! command -v gh > /dev/null 2>&1; then
+        echo "Error: gh CLI not found — needed to list ${REPO} releases." >&2
+        echo "       Install it, or pass --version <ver> to name a baseline directly." >&2
+        exit 1
+    fi
+
+    RELEASES="$(gh release list --repo "$REPO" --limit 100 \
+        --json tagName,isPrerelease \
+        --jq '.[] | [.tagName, (.isPrerelease | tostring)] | @tsv' 2>/dev/null || true)"
+
+    if [ -z "$RELEASES" ]; then
+        echo "NOT APPLICABLE: ${REPO} has no releases to use as a baseline." >&2
+        echo "                GitHub must also be reachable to resolve one." >&2
+        exit 3
+    fi
+
+    if ! BASEVER="$(cwm_select_baseline_version "$TARGET" "$FLOOR" "$RELEASES")"; then
+        echo "NOT APPLICABLE: no released package older than ${TARGET} is usable as a baseline." >&2
+
+        if [ -n "$FLOOR" ]; then
+            echo "                Releases below baseline.minimum (${FLOOR}) are excluded." >&2
+        fi
+
+        echo "                To name one explicitly: cwm-baseline --version <ver>" >&2
+        exit 3
+    fi
+
+    echo "Baseline for ${TARGET}: ${BASEVER}"
+fi
+
+if [ "$PRINT_ONLY" = "1" ]; then
+    printf '%s\n' "$BASEVER"
+    exit 0
+fi
+
+# --- Fetch it ---
+ASSET="$(cwm_baseline_asset_from_glob "$OUTPUT_GLOB" "$BASEVER")" || exit 1
+TAG="$(cwm_tag_for_version "$BASEVER")"
+OUT="${DIST}/${ASSET}"
+
+mkdir -p "$DIST"
+
+if [ -f "$OUT" ]; then
+    echo "Already present: ${OUT}"
+    exit 0
+fi
+
+if ! command -v gh > /dev/null 2>&1; then
+    echo "Error: gh CLI not found — needed to download the ${TAG} release asset." >&2
+    exit 1
+fi
+
+echo "Downloading ${ASSET} from release ${TAG}..."
+
+if ! gh release download "$TAG" --repo "$REPO" --pattern "$ASSET" --dir "$DIST" --clobber; then
+    echo "Error: could not download ${ASSET} from ${TAG}." >&2
+    echo "       Check the release's assets: gh release view ${TAG} --repo ${REPO}" >&2
+    exit 1
+fi
+
+if [ ! -f "$OUT" ]; then
+    echo "Error: ${ASSET} is not attached to release ${TAG}." >&2
+    echo "       Check the release's assets: gh release view ${TAG} --repo ${REPO}" >&2
+    exit 1
+fi
+
+echo "Baseline ready: ${OUT}"

--- a/scripts/lib/baseline.sh
+++ b/scripts/lib/baseline.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# Baseline selection for the upgrade test.
+#
+# An upgrade test needs a "before" state: the released artifact users are
+# actually on, installed first so the new build lands on top of it and Joomla
+# routes the second install to update(). Which release that should be is a
+# decision both consumers were making independently, and differently.
+#
+# Proclaim read versions.json `current`. CWMLivingWord resolved it from the
+# releases that exist, after `current` made the phase skip itself during the
+# 5.7.0 release — the gate runs before the bump, so the file describes the
+# previous cycle (Joomla-Bible-Study/cwm-build-tools#101). LivingWord's
+# strategy is the one that survives contact with a release, so it is the one
+# here.
+#
+# Selection is split from the `gh` call for the same reason lib/artifacts.sh
+# and lib/version.sh exist: the entry points in scripts/ run on invocation and
+# cannot be reached from a test, which is why every bug in them was found by
+# reading. Functions here must stay free of network calls and of writes outside
+# a path they were handed.
+
+# Choose the newest usable baseline from a list of releases.
+#
+# "Usable" is three conditions, and each one exists because a run hit it:
+#
+#   - strictly older than the target, or the upgrade path never fires;
+#   - at or above the floor, because a project's early releases may not
+#     install at all (CWMLivingWord#95 — packages before 5.6.0-beta2 assembled
+#     their inner extensions into a folder the manifest never pointed at, so
+#     Joomla refused them, and such a release cannot serve as a "before"
+#     state);
+#   - stable, when any stable release qualifies. Most sites are on a stable
+#     release, and resolving to a prerelease was the specific shape of the
+#     #101 failure. Prereleases are used only when nothing stable qualifies,
+#     because a project that has only ever shipped betas still deserves the
+#     phase to run.
+#
+# Comparison is delegated to PHP's version_compare, which orders prerelease
+# suffixes correctly (5.7.0-beta4 < 5.7.0). Sorting these as strings puts
+# 10.3.10 before 10.3.2 and 5.7.0 before 5.7.0-beta4, both wrong.
+#
+# Arguments:
+#   $1  Target version the baseline must be older than, e.g. 5.7.1.
+#   $2  Floor version, or empty for no floor.
+#   $3  Releases, one per line, as "<tag><TAB><true|false>" where the second
+#       field is whether the release is a prerelease. Tags may carry a leading
+#       v; it is stripped.
+#
+# Outputs:
+#   The chosen version on stdout, without a leading v. Nothing when none
+#   qualifies.
+#
+# Returns:
+#   0 when a baseline was chosen, 1 when none qualifies.
+cwm_select_baseline_version() {
+    local target="$1"
+    local floor="$2"
+    local releases="$3"
+    local chosen
+
+    chosen="$(printf '%s\n' "$releases" | php -r '
+        $target = $argv[1];
+        $floor  = $argv[2];
+        $stable = [];
+        $any    = [];
+
+        while (($line = fgets(STDIN)) !== false) {
+            [$tag, $prerelease] = array_pad(explode("\t", trim($line)), 2, "");
+
+            if ($tag === "") {
+                continue;
+            }
+
+            $version = ltrim($tag, "v");
+
+            if (version_compare($version, $target, ">=")) {
+                continue;
+            }
+
+            if ($floor !== "" && version_compare($version, $floor, "<")) {
+                continue;
+            }
+
+            $any[] = $version;
+
+            if ($prerelease !== "true") {
+                $stable[] = $version;
+            }
+        }
+
+        $pool = $stable !== [] ? $stable : $any;
+
+        if ($pool === []) {
+            exit(1);
+        }
+
+        usort($pool, "version_compare");
+
+        echo end($pool);
+    ' "$target" "$floor")" || return 1
+
+    [ -n "$chosen" ] || return 1
+
+    printf '%s\n' "$chosen"
+}
+
+# Derive the released asset's filename for a version from the output glob.
+#
+# `build.outputGlob` is the one artifact-naming key present in every project
+# shape — the package example carries no `outputName` — and it is already the
+# source of truth for finding a built artifact (lib/artifacts.sh). A released
+# asset is the same file under the same name, so the glob answers this too.
+#
+# Exactly one `*` is required. A glob with none has no version to substitute,
+# and one with several is ambiguous about which position the version occupies;
+# guessing would name a file that does not exist and report it as "not found on
+# the release", sending the reader after the wrong problem.
+#
+# Arguments:
+#   $1  The glob, e.g. build/dist/pkg_proclaim-*.zip
+#   $2  The version to substitute.
+#
+# Outputs:
+#   The asset filename (basename only) on stdout.
+#
+# Returns:
+#   0 on success, 1 when the glob does not carry exactly one `*`.
+cwm_baseline_asset_from_glob() {
+    local glob="$1"
+    local version="$2"
+    local base stars
+
+    base="$(basename "$glob")"
+    stars="${base//[^\*]/}"
+
+    if [ "${#stars}" -ne 1 ]; then
+        echo "Error: build.outputGlob basename must contain exactly one '*' to name a baseline asset (got '${base}')." >&2
+
+        return 1
+    fi
+
+    printf '%s\n' "${base/\*/$version}"
+}
+
+# The directory a baseline should be downloaded into, from the same glob.
+#
+# Arguments:
+#   $1  The glob, e.g. build/dist/pkg_proclaim-*.zip
+#
+# Outputs:
+#   The directory on stdout, e.g. build/dist. "." when the glob has no path.
+cwm_baseline_dir_from_glob() {
+    dirname "$1"
+}

--- a/tests/shell/baseline.test.sh
+++ b/tests/shell/baseline.test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/lib/baseline.sh.
+#
+# Selection only. Downloading the chosen release is a `gh` call and belongs to
+# scripts/baseline.sh; what decides whether an upgrade test exercises the right
+# transition is which version comes out of here, and that needs no network to
+# check.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+# shellcheck source=../../scripts/lib/baseline.sh
+source "${SCRIPT_DIR}/../../scripts/lib/baseline.sh"
+
+# A release history shaped like CWMLivingWord's at the 5.7.1 release.
+RELEASES="$(printf '%s\n' \
+    "v5.7.0-beta4	true" \
+    "v5.7.0	false" \
+    "v5.6.2	false" \
+    "v5.6.0	false" \
+    "v5.5.0	false")"
+
+# --- The release target picks the release immediately before it ---------------
+assert_equals "5.7.0" "$(cwm_select_baseline_version '5.7.1' '' "$RELEASES")" \
+    "the newest stable release older than the target is chosen"
+
+# --- The bug this exists to stop (#101) ---------------------------------------
+# Resolving against the development pointer instead of the release target skips
+# a whole release: every migration 5.7.0 shipped goes unexercised by the phase
+# whose job is to exercise migrations.
+assert_equals "5.6.2" "$(cwm_select_baseline_version '5.7.0-beta4' '' "$RELEASES")" \
+    "resolving against a stale pointer selects an older baseline (the #101 shape)"
+
+# --- Prereleases are skipped when a stable release qualifies ------------------
+assert_equals "5.7.0" "$(cwm_select_baseline_version '5.7.1' '' "$RELEASES")" \
+    "v5.7.0-beta4 is not chosen over v5.7.0"
+
+# --- ...but used when nothing stable does -------------------------------------
+BETAS_ONLY="$(printf '%s\n' "v1.0.0-beta2	true" "v1.0.0-beta1	true")"
+assert_equals "1.0.0-beta2" "$(cwm_select_baseline_version '1.0.0' '' "$BETAS_ONLY")" \
+    "a project that has only ever shipped betas still gets a baseline"
+
+# --- Version ordering is numeric, not lexical ---------------------------------
+# 10.3.10 sorts before 10.3.2 as a string; that is how a release picked a stale
+# artifact before lib/artifacts.sh started matching on the version.
+TENS="$(printf '%s\n' "v10.3.2	false" "v10.3.10	false" "v10.3.9	false")"
+assert_equals "10.3.10" "$(cwm_select_baseline_version '10.4.0' '' "$TENS")" \
+    "10.3.10 is newer than 10.3.9 and 10.3.2"
+
+# --- The floor excludes releases that cannot install --------------------------
+assert_equals "5.6.2" "$(cwm_select_baseline_version '5.7.0' '5.6.1' "$RELEASES")" \
+    "a floor keeps unusable early releases out of the pool"
+
+assert_equals "" "$(cwm_select_baseline_version '5.6.0' '5.6.1' "$RELEASES")" \
+    "nothing qualifies when the floor excludes everything older than the target"
+
+# --- Strictly older -----------------------------------------------------------
+# Equal is not a baseline: installing a release over itself does not route
+# Joomla to update(), which is the whole point of the phase.
+assert_equals "5.6.2" "$(cwm_select_baseline_version '5.7.0' '' "$RELEASES")" \
+    "the target's own release is not chosen as its baseline"
+
+# --- No usable baseline is a status, not a crash ------------------------------
+# The first release of a project has nothing to upgrade from. The caller decides
+# whether that is fatal; #101 is the story of that decision being made silently
+# in the wrong place.
+if cwm_select_baseline_version '5.0.0' '' "$RELEASES" > /dev/null; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: no release older than the target returns non-zero"
+else
+    PASS=$((PASS + 1))
+fi
+
+if cwm_select_baseline_version '5.7.1' '' '' > /dev/null; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: an empty release list returns non-zero"
+else
+    PASS=$((PASS + 1))
+fi
+
+# --- Asset naming from the output glob ----------------------------------------
+assert_equals "pkg_proclaim-10.3.2.zip" \
+    "$(cwm_baseline_asset_from_glob 'build/dist/pkg_proclaim-*.zip' '10.3.2')" \
+    "the asset name is the glob with the version substituted"
+
+assert_equals "build/dist" \
+    "$(cwm_baseline_dir_from_glob 'build/dist/pkg_proclaim-*.zip')" \
+    "the download directory is the glob's directory"
+
+# A glob that cannot name one asset is refused rather than guessed at: a wrong
+# name reports "not found on the release", which sends the reader after the
+# wrong problem.
+if cwm_baseline_asset_from_glob 'build/dist/pkg_proclaim.zip' '10.3.2' 2>/dev/null; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: a glob with no '*' is refused"
+else
+    PASS=$((PASS + 1))
+fi
+
+if cwm_baseline_asset_from_glob 'build/dist/*-proclaim-*.zip' '10.3.2' 2>/dev/null; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: a glob with two '*' is refused"
+else
+    PASS=$((PASS + 1))
+fi
+
+# --- The CLI, against a stub gh -----------------------------------------------
+# The selection above is the interesting logic, but it reaches nobody unless the
+# script wires config -> gh -> selection -> download. A stub on PATH exercises
+# that wiring without a network.
+#
+# It also pins --help. The first version of this script used <<'USAGE' as its
+# heredoc delimiter while the help text carries a USAGE heading — the shape
+# CLAUDE.md prescribes for every command — so the heredoc closed early and the
+# remaining help lines ran as shell commands. `--help` printed two thirds of
+# itself, invoked composer, and exited 1.
+BASELINE_SH="${SCRIPT_DIR}/../../scripts/baseline.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "${WORK}/bin"
+cat > "${WORK}/cwm-build.config.json" <<'JSON'
+{
+    "manifests": { "package": "pkg_smoke.xml" },
+    "build":     { "outputGlob": "build/dist/pkg_smoke-*.zip" },
+    "github":    { "owner": "acme", "repo": "smoke" },
+    "baseline":  { "minimum": "1.0.0" }
+}
+JSON
+cat > "${WORK}/pkg_smoke.xml" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<extension type="package"><name>pkg_smoke</name><version>1.3.0</version></extension>
+XML
+cat > "${WORK}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$1 $2" in
+    "release list")
+        printf 'v1.3.0-beta1\ttrue\nv1.2.0\tfalse\nv1.1.0\tfalse\nv0.9.0\tfalse\n' ;;
+    "release download")
+        for a in "$@"; do
+            case "$prev" in --dir) d="$a" ;; --pattern) p="$a" ;; esac
+            prev="$a"
+        done
+        mkdir -p "$d"; echo stub-zip > "$d/$p" ;;
+esac
+STUB
+chmod +x "${WORK}/bin/gh"
+
+run_baseline() {
+    (cd "$WORK" && PATH="${WORK}/bin:$PATH" bash "$BASELINE_SH" "$@" 2>&1)
+}
+
+# --help must render in full and exit 0. Checking the last section catches the
+# truncation the heredoc bug caused; the earlier sections printed fine.
+HELP="$(run_baseline --help)"
+HELP_STATUS=$?
+assert_equals "0" "$HELP_STATUS" "--help exits 0"
+assert_contains "$HELP" "cwm-install-zip" "--help renders through to its last section"
+
+# The target defaults to the manifest version (1.3.0) -> newest stable below it.
+assert_equals "1.2.0" "$(run_baseline --print | tail -1)" \
+    "the CLI resolves a baseline from the manifest version"
+
+# A release in flight overrides the manifest, which is stale before the bump.
+assert_equals "1.1.0" "$(cd "$WORK" && PATH="${WORK}/bin:$PATH" CWM_RELEASE_VERSION=1.1.5 bash "$BASELINE_SH" --print 2>/dev/null | tail -1)" \
+    "CWM_RELEASE_VERSION takes precedence over the manifest"
+
+run_baseline > /dev/null
+if [ -f "${WORK}/build/dist/pkg_smoke-1.2.0.zip" ]; then
+    PASS=$((PASS + 1))
+else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: the resolved baseline is downloaded into the output directory"
+fi
+
+assert_contains "$(run_baseline)" "Already present" \
+    "a second run does not re-download"
+
+# Exit 3, not 1: no usable baseline is a status the caller interprets.
+run_baseline --target 0.5.0 --print > /dev/null
+assert_equals "3" "$?" "no usable baseline exits 3"
+
+finish


### PR DESCRIPTION
Closes #103. Follows #108, which fixed this issue's premise (a pre-release no longer records itself as the last stable release).

## Why

An upgrade test needs a "before" state: the released package users are on, installed first so the new build lands on top of it and Joomla routes the second install to `update()`. Both consumers wrote that themselves and diverged on the part that matters.

| | Proclaim `build-baseline.sh` | CWMLivingWord, inlined in `test-upgrade.sh` |
|---|---|---|
| resolution | `versions.json` `current.version` | newest release older than the target, preferring stable |
| floor | none | `MIN_BASELINE` — older packages cannot install (CWMLivingWord#95) |
| `gh` missing | explicit error | not checked |
| no usable baseline | error | `NOT APPLICABLE` |
| standalone | yes | no |

Each has something the other lacks, and neither acquires it by accident — the shape #102 describes.

## What landed

`cwm-baseline`, with the union of both:

- newest release **strictly older** than the target, at or above `baseline.minimum`, **preferring stable** and falling back to a pre-release only when nothing stable qualifies;
- target from `CWM_RELEASE_VERSION` → `--target` → the manifest. That order is the point: during a release the manifest still carries the previous cycle, so resolving against it picks a baseline one release too old and every migration the skipped release shipped goes unexercised (#101);
- artifact name and directory from `build.outputGlob` — the one artifact-naming key present in every project shape — with the version substituted for its `*`. A glob that cannot name exactly one asset is refused rather than guessed at;
- `--print` to resolve without downloading, `--version` to skip resolution, and an already-present check so re-running is free.

Comparison is delegated to PHP's `version_compare`: string sorting puts `5.7.0` before `5.7.0-beta4` and `10.3.10` before `10.3.2`, and the second already shipped a release against the wrong artifact once (see `lib/artifacts.sh`).

### Exit 3

`no usable baseline` — a first release, or every candidate below the floor — is kept distinct from both success and failure. Treating it as fatal blocks the first release of every new project; treating it as success reports an upgrade test that never ran. It is in the `EXIT CODE` section of `--help` rather than left to be inferred.

## Tests

`composer test` green — 456 PHPUnit / 1067 assertions, 141 shell assertions including 21 new.

Selection lives in `scripts/lib/baseline.sh` with no network calls, tested against release-list fixtures: the #101 shape (target vs stale pointer selecting **5.7.0** vs **5.6.2** from the same history), prerelease preference and its fallback, numeric ordering, the floor, strictly-older, and both no-baseline cases.

The CLI is covered with a stub `gh` on PATH — and that immediately earned itself. The help heredoc used `<<'USAGE'` while the help text carries a `USAGE` heading, which is the shape CLAUDE.md prescribes for every command. The heredoc closed early, the remaining help lines **ran as shell**, and `--help` printed two thirds of itself, invoked composer and exited 1. Mutation-checked: restoring the old delimiter fails both help assertions.

Worth knowing when adding the next command from that template.

## Follow-on

Consumers can migrate to it independently; nothing here changes their behaviour until they do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)