### PR TITLE
feat(dev): add cwm-lint-queries, enforcing createQuery() over getQuery(true) (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`cwm-lint-queries` — enforce `$db->createQuery()` over
+  `$db->getQuery(true)`.** Lifted from Proclaim's `build/lint-queries.sh`, which
+  was the only copy: `lib_cwmscripture` and CWMLivingWord hold the same
+  convention with nothing checking it. (#104)
+
+  A consistency guard rather than a correctness one — both spellings return the
+  same `DatabaseQuery` and neither is deprecated in Joomla 5 or 6. It exists
+  because consistency does not hold on its own. Proclaim reached 666 uses of the
+  old spelling against 9 of the documented one, not by decision but because new
+  code copies what it finds nearby, and that pressure is not specific to one
+  project.
+
+  The no-argument `$db->getQuery()` returns the *current* query rather than a new
+  one. Different operation, never flagged.
+
+  No new scanner: `DeprecationScanner` already takes its ruleset as a
+  constructor argument, so the tree walk, the symlink guard and the exclusion
+  handling are reused and only the rules are new (`Dev\QueryStyleRules`).
+
+  Paths come from `lint.paths[]`, defaulting to the conventional Joomla roots
+  **that exist** — scanning a path that is not there is not an error, but
+  reporting "no findings" for a tree that was never opened is the failure a
+  linter must not have, so the run names what it scanned either way.
+  `lint.excludeDirs[]` covers the submodule case: a separate repository is not
+  this project's standard to enforce.
+
 - **`cwm-baseline` — resolve and fetch the released package an upgrade test
   upgrades *from*.** Both consumers had written this themselves and diverged on
   the part that matters. Proclaim read `versions.json` `current`; CWMLivingWord

--- a/bin/cwm-lint-queries
+++ b/bin/cwm-lint-queries
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# cwm-lint-queries — enforce $db->createQuery() over $db->getQuery(true).
+#
+# A consistency guard, not a correctness one: both spellings return the same
+# DatabaseQuery. It exists because the old spelling grows back on its own —
+# new code copies what it finds nearby.
+#
+# Usage from a consuming project:
+#   composer lint-queries
+#   composer lint-queries -- --warn
+#   composer lint-queries -- --help
+#
+set -euo pipefail
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec php "${TOOLS_DIR}/scripts/lint-queries.php" "$@"

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
         "bin/cwm-joomla-install",
         "bin/cwm-joomla-latest",
         "bin/cwm-joomla-cms-deps",
-        "bin/cwm-baseline"
+        "bin/cwm-baseline",
+        "bin/cwm-lint-queries"
     ],
     "config": {
         "sort-packages": true,

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -67,5 +67,6 @@ ARS endpoint, category, and stream IDs come from the `ars` block in
 
 | Command | What it does |
 |---|---|
+| `cwm-lint-queries` | Enforce `$db->createQuery()` over `$db->getQuery(true)`. A consistency guard, not a correctness one — both return the same `DatabaseQuery`. **Exit 1** on findings; `--warn` to report without failing. The no-argument `$db->getQuery()` is a different operation and is never flagged. |
 | `cwm-lint-deprecations` | Flag Joomla 6/7 upgrade blockers (`bootstrap.modal`, `data-bs-toggle=modal`, iframe modal handlers, `Joomla.Modal`, jQuery globals). **Exit 1** on findings; `--warn` to report without failing. See the [JS guide](javascript-and-joomladialog.md#71-cwm-lint-deprecations-find-j67-blockers). |
 | `cwm-sync-languages` | Sync and translate Joomla language files for the project. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ cwm-init` rather than authoring by hand. Minimal examples live in
 | `ars` | Akeeba Release System target: `endpoint`, `categoryId`, `updateStreamId`, `environments[]`, `tokenItem`, `tokenVault` (1Password). |
 | `github` | `{ owner, repo, releaseBranch }` for release + changelog. |
 | `changelog` | `{ file, url }` — the Joomla changelog XML path and its raw URL. |
+| `lint` | Optional. `{ paths[], excludeDirs[] }` — source roots the lint commands scan, and extra directory basenames to skip on top of `vendor/`, `node_modules/`, `build/`, `dist/` and the VCS directories. A git submodule is a separate repository and not this project's standard to enforce; name it in `excludeDirs`. Defaults to the conventional Joomla roots that exist. |
 | `baseline` | Optional. `{ minimum }` — the oldest release `cwm-baseline` may pick as an upgrade "before" state. For projects whose early packages do not install at all, so choosing one wastes a run on a failure that says nothing about the build. Omit for no floor. |
 | `announcement` | `{ command, bulletsDir }` for the release announcement article. |
 | `versionTracking` | Override layer, deep-merged on top of the profile. `versionsJson`, `packageJson`, `substituteTokens.paths[]`, `sourceFiles[]`. **Lists replace wholesale.** See [source-file version literals](#versiontrackingsourcefiles--version-literals-in-source) below. |

--- a/scripts/lint-queries.php
+++ b/scripts/lint-queries.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Flag `$db->getQuery(true)` in favour of `$db->createQuery()` and exit
+ * non-zero on any finding so CI can gate on it.
+ */
+
+require_once __DIR__ . '/../src/Dev/DeprecationScanner.php';
+require_once __DIR__ . '/../src/Dev/QueryStyleRules.php';
+
+use CWM\BuildTools\Dev\DeprecationScanner;
+use CWM\BuildTools\Dev\QueryStyleRules;
+
+$projectRoot = getcwd() ?: '.';
+
+if (in_array('--help', $argv, true) || in_array('-h', $argv, true)) {
+    echo <<<CWM_HELP
+cwm-lint-queries — enforce \$db->createQuery() over \$db->getQuery(true).
+
+WHAT IT DOES
+  Scans the project's configured source paths for `\$db->getQuery(true)` and
+  reports file:line for each.
+
+  Both spellings return the same DatabaseQuery and neither is deprecated in
+  Joomla 5 or 6, so this is a consistency guard rather than a correctness one.
+  It exists because consistency does not hold on its own: Proclaim reached 666
+  uses of the old spelling against 9 of the documented one, simply because new
+  code copies what it finds nearby.
+
+  The no-argument `\$db->getQuery()` returns the *current* query rather than a
+  new one. That is a different operation and is never flagged.
+
+PREREQUISITES
+  None. With no `lint.paths` configured it scans the conventional Joomla
+  source roots that exist in the project.
+
+USAGE
+  composer lint-queries               # scan, exit 1 on findings
+  composer lint-queries -- --warn     # report but always exit 0
+  composer lint-queries -- path/      # scan a specific subtree
+
+OPTIONS
+  -w, --warn       Report findings but exit 0 (don't fail CI yet).
+  <path>           Scan this directory instead of the configured paths.
+
+CONFIGURATION
+  lint.paths[]        Source roots to scan. Defaults to the conventional
+                      Joomla layout, filtered to those that exist.
+  lint.excludeDirs[]  Extra directory basenames to skip, on top of vendor/,
+                      node_modules/, build/, dist/ and the VCS directories.
+                      A git submodule is a separate repository and not this
+                      project's standard to enforce — name it here.
+
+RELATED
+  composer lint-deprecations   # Joomla 6/7 upgrade blockers
+  composer link-check          # verify dev symlinks
+
+EXIT CODE
+  0  no findings (or --warn)
+  1  one or more findings
+
+CWM_HELP;
+
+    exit(0);
+}
+
+$warnOnly  = false;
+$scanRoots = [];
+
+foreach (array_slice($argv, 1) as $arg) {
+    if ($arg === '-w' || $arg === '--warn') {
+        $warnOnly = true;
+
+        continue;
+    }
+
+    if (!str_starts_with($arg, '-')) {
+        $scanRoots[] = $arg;
+    }
+}
+
+/**
+ * Read a dotted key out of the project's cwm-build.config.json.
+ *
+ * Absent config is not an error — a project that has never configured a lint
+ * block still gets the conventional roots.
+ *
+ * @return mixed The value, or null when the file or the key is absent.
+ */
+$readConfig = static function (string $dotted) use ($projectRoot) {
+    $file = $projectRoot . '/cwm-build.config.json';
+
+    if (!is_file($file)) {
+        return null;
+    }
+
+    $config = json_decode((string) file_get_contents($file), true);
+
+    if (!is_array($config)) {
+        return null;
+    }
+
+    $value = $config;
+
+    foreach (explode('.', $dotted) as $key) {
+        if (!is_array($value) || !array_key_exists($key, $value)) {
+            return null;
+        }
+
+        $value = $value[$key];
+    }
+
+    return $value;
+};
+
+$excludeDirs = $readConfig('lint.excludeDirs');
+$excludeDirs = is_array($excludeDirs) ? array_values(array_filter($excludeDirs, 'is_string')) : [];
+
+if ($scanRoots === []) {
+    $configured = $readConfig('lint.paths');
+
+    if (is_array($configured) && $configured !== []) {
+        $scanRoots = array_values(array_filter($configured, 'is_string'));
+    } else {
+        // Only the conventional roots that actually exist. Scanning a path that
+        // is not there is not an error, but reporting "0 findings" for a tree
+        // that was never opened is the failure mode a linter must not have.
+        $scanRoots = array_values(array_filter(
+            QueryStyleRules::DEFAULT_PATHS,
+            static fn (string $path): bool => is_dir($projectRoot . '/' . $path)
+        ));
+    }
+}
+
+if ($scanRoots === []) {
+    fwrite(STDERR, "No source paths to scan.\n");
+    fwrite(STDERR, "  Set lint.paths[] in cwm-build.config.json, or pass a path.\n");
+
+    exit(1);
+}
+
+$scanner  = new DeprecationScanner(QueryStyleRules::rules());
+$findings = [];
+$scanned  = [];
+
+foreach ($scanRoots as $root) {
+    $absolute = str_starts_with($root, '/') ? $root : $projectRoot . '/' . $root;
+
+    if (!is_dir($absolute)) {
+        fwrite(STDERR, "Path not found: {$root}\n");
+
+        exit(1);
+    }
+
+    $scanned[] = $root;
+    $findings  = array_merge($findings, $scanner->scan($absolute, $excludeDirs === [] ? null : array_merge(
+        ['vendor', 'node_modules', '.git', '.github', '.idea', 'build', 'dist'],
+        $excludeDirs
+    )));
+}
+
+// Name what was scanned even on success. A linter reporting "no findings" over
+// a path list that silently resolved to nothing reads identically to one that
+// did the work — the same shape as a test phase that skips itself and passes.
+echo 'Scanned: ' . implode(', ', $scanned) . "\n";
+
+if ($findings === []) {
+    echo "No \$db->getQuery(true) found.\n";
+
+    exit(0);
+}
+
+foreach ($findings as $finding) {
+    printf("%s:%d\n    %s\n", $finding['file'], $finding['line'], $finding['snippet']);
+}
+
+$count = count($findings);
+
+fwrite(STDERR, "\nFound {$count} use(s) of \$db->getQuery(true).\n");
+fwrite(STDERR, $findings[0]['message'] . "\n");
+
+exit($warnOnly ? 0 : 1);

--- a/src/Dev/DeprecationScanner.php
+++ b/src/Dev/DeprecationScanner.php
@@ -14,11 +14,16 @@ namespace CWM\BuildTools\Dev;
  * replacement is `ModalSelectField` (declarative) or `import JoomlaDialog from
  * 'joomla.dialog'` in a `type="module"` asset.
  *
- * This scanner walks a project's source tree, applies a fixed ruleset of
- * regexes per file type, and returns one finding per match so `cwm-lint-
- * deprecations` can print them and gate CI. Inputs are project-controlled
- * source files (trusted, per the build-tools threat model) — the scanner only
- * reads, never executes.
+ * This scanner walks a project's source tree, applies a ruleset of regexes per
+ * file type, and returns one finding per match so `cwm-lint-deprecations` can
+ * print them and gate CI. Inputs are project-controlled source files (trusted,
+ * per the build-tools threat model) — the scanner only reads, never executes.
+ *
+ * The ruleset is a constructor argument, so this is also the engine for other
+ * source lints: the tree walk, the symlink guard, the minified-bundle skip and
+ * the exclusion handling are the same work whatever is being matched. See
+ * {@see QueryStyleRules}, which `cwm-lint-queries` feeds in. The default
+ * ruleset — the one the class is named for — is the J5 → J6/J7 deprecations.
  */
 final class DeprecationScanner
 {

--- a/src/Dev/QueryStyleRules.php
+++ b/src/Dev/QueryStyleRules.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Dev;
+
+/**
+ * House-style rules for how database queries are constructed.
+ *
+ * Consistency guards rather than correctness ones — nothing here is deprecated
+ * in Joomla 5 or 6, and code that trips these rules works. They exist because
+ * consistency does not hold on its own: Proclaim reached 666 uses of
+ * `$db->getQuery(true)` against 9 of the documented `$db->createQuery()`, not
+ * by decision but because new code copies what it finds nearby. Without a
+ * check, it grows back — which is why this moved out of one project's
+ * `build/lint-queries.sh` and into the shared tooling every CWM extension
+ * already depends on.
+ *
+ * The rules are data for {@see DeprecationScanner}, which is the walking and
+ * matching engine; it takes a ruleset in its constructor precisely so a second
+ * lint can reuse it rather than re-implement the tree walk, the symlink guard
+ * and the exclusion handling.
+ */
+final class QueryStyleRules
+{
+    /**
+     * Conventional Joomla source roots, used when a project configures none.
+     *
+     * Matches the layout `LinkResolver` already assumes. A project whose source
+     * lives elsewhere sets `lint.paths[]`.
+     *
+     * @var list<string>
+     */
+    public const DEFAULT_PATHS = ['admin', 'api', 'site', 'modules', 'plugins', 'components', 'libraries', 'src'];
+
+    /**
+     * The ruleset.
+     *
+     * Only the no-argument form is legal to flag. `$db->getQuery()` without
+     * `true` returns the *current* query rather than a new one — a different
+     * operation, and deliberately untouched. The pattern therefore requires the
+     * literal `true` argument rather than matching the method name.
+     *
+     * @return list<array{id: string, label: string, extensions: list<string>, pattern: string, message: string}>
+     */
+    public static function rules(): array
+    {
+        return [
+            [
+                'id'         => 'get-query-true',
+                'label'      => '$db->getQuery(true)',
+                'extensions' => ['php'],
+                'pattern'    => '/->\s*getQuery\s*\(\s*true\s*\)/',
+                'message'    => 'Build queries with $db->createQuery(). The no-argument $db->getQuery() returns the current query and is a different operation — it is allowed.',
+            ],
+        ];
+    }
+}

--- a/tests/Dev/QueryStyleRulesTest.php
+++ b/tests/Dev/QueryStyleRulesTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Dev;
+
+use CWM\BuildTools\Dev\DeprecationScanner;
+use CWM\BuildTools\Dev\QueryStyleRules;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The query-style ruleset, run through the scanner that consumes it.
+ *
+ * Testing the pattern in isolation would pass on a ruleset the scanner never
+ * applies — the extensions list has to line up with the files being walked, and
+ * that pairing is the part worth pinning.
+ */
+final class QueryStyleRulesTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/cwm-query-lint-tests-' . bin2hex(random_bytes(6));
+        mkdir($this->tmpDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->rrmdir($this->tmpDir);
+    }
+
+    private function scan(?array $excluded = null): array
+    {
+        return (new DeprecationScanner(QueryStyleRules::rules()))->scan($this->tmpDir, $excluded);
+    }
+
+    #[Test]
+    public function flags_get_query_true(): void
+    {
+        $this->write('admin/src/Model/SeriesModel.php', "<?php\n\$query = \$db->getQuery(true);\n");
+
+        $findings = $this->scan();
+
+        self::assertCount(1, $findings);
+        self::assertSame('get-query-true', $findings[0]['rule']);
+        self::assertSame(2, $findings[0]['line']);
+        self::assertStringContainsString('createQuery', $findings[0]['message']);
+    }
+
+    #[Test]
+    public function does_not_flag_the_no_argument_form(): void
+    {
+        // getQuery() returns the CURRENT query rather than a new one. Different
+        // operation, deliberately allowed — flagging it would send people to
+        // rewrite working code into something that does something else.
+        $this->write('admin/src/Model/SeriesModel.php', "<?php\n\$existing = \$db->getQuery();\n");
+
+        self::assertSame([], $this->scan());
+    }
+
+    #[Test]
+    public function does_not_flag_create_query(): void
+    {
+        $this->write('admin/src/Model/SeriesModel.php', "<?php\n\$query = \$db->createQuery();\n");
+
+        self::assertSame([], $this->scan());
+    }
+
+    #[Test]
+    public function tolerates_whitespace_inside_the_call(): void
+    {
+        // Formatting varies across a 600-file sweep; a rule that only matches
+        // the tightest spelling reports a clean tree that is not clean.
+        $this->write('admin/src/Model/A.php', "<?php\n\$q = \$db -> getQuery( true );\n");
+        $this->write('admin/src/Model/B.php', "<?php\n\$q = \$db->getQuery(  true);\n");
+
+        self::assertCount(2, $this->scan());
+    }
+
+    #[Test]
+    public function scans_php_only(): void
+    {
+        // The rule is about PHP query building. A JS file mentioning the string
+        // is not a query and must not be reported.
+        $this->write('media/js/admin.js', "// see getQuery(true) in the model\n");
+
+        self::assertSame([], $this->scan());
+    }
+
+    #[Test]
+    public function excluded_directories_are_not_scanned(): void
+    {
+        // A submodule is a separate repository and not this project's standard
+        // to enforce — the reason Proclaim's original script excluded one.
+        $this->write('plugins/content/scripturelinks/Helper.php', "<?php\n\$q = \$db->getQuery(true);\n");
+        $this->write('admin/src/Model/Clean.php', "<?php\n\$q = \$db->createQuery();\n");
+
+        $findings = $this->scan(['vendor', 'node_modules', '.git', 'build', 'dist', 'scripturelinks']);
+
+        self::assertSame([], $findings);
+    }
+
+    #[Test]
+    public function every_occurrence_is_reported_not_just_the_first(): void
+    {
+        // Reporting one per file turns a 666-hit sweep into 200 runs.
+        $this->write('admin/src/Model/Many.php', "<?php\n\$a = \$db->getQuery(true);\n\$b = \$db->getQuery(true);\n");
+
+        self::assertCount(2, $this->scan());
+    }
+
+    private function write(string $relative, string $contents): void
+    {
+        $path = $this->tmpDir . '/' . $relative;
+
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0o777, true);
+        }
+
+        file_put_contents($path, $contents);
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (array_diff(scandir($dir) ?: [], ['.', '..']) as $entry) {
+            $path = $dir . '/' . $entry;
+            is_dir($path) && !is_link($path) ? $this->rrmdir($path) : unlink($path);
+        }
+
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
Closes #104.

Lifted from Proclaim's `build/lint-queries.sh`, which was the only copy of it. `lib_cwmscripture` and CWMLivingWord hold the same convention with nothing checking it, and the rule is Joomla-wide — the only project-shaped things in the original were a path list and a submodule exclusion, both now config.

## What it is, and is not

A **consistency guard**, not a correctness one. Both spellings return the same `DatabaseQuery` and neither is deprecated in Joomla 5 or 6, so nothing here fixes a bug. It exists because consistency does not hold on its own: Proclaim reached **666** uses of the old spelling against 9 of the documented one, not by decision but because new code copies what it finds nearby.

The no-argument `$db->getQuery()` returns the *current* query rather than a new one — a different operation, never flagged. The pattern requires the literal `true` argument rather than matching the method name, so it cannot drift into flagging it.

## No new scanner

`DeprecationScanner` already takes its ruleset as a constructor argument; that override existed for exactly this. The tree walk, the symlink guard, the minified-bundle skip and the exclusion handling are reused, and only the rules are new (`Dev\QueryStyleRules`). Its docblock now says the ruleset is a parameter, since the class name otherwise reads as though it were fixed.

## The paths behaviour is deliberate

`lint.paths[]`, defaulting to the conventional Joomla roots **filtered to those that exist** — and the run prints what it scanned even on success:

```
Scanned: admin, plugins
No $db->getQuery(true) found.
```

Scanning a path that is not there is not an error, but reporting "no findings" over a path list that silently resolved to nothing reads identically to a run that did the work. That is the same shape as a test phase that skips itself and passes — #101 here, #1866 in Proclaim.

`lint.excludeDirs[]` covers the submodule case: a separate repository is not this project's standard to enforce.

## Tests

`composer test` green — 463 PHPUnit / 1077 assertions, 141 shell assertions.

Seven cases, run **through the scanner that consumes the ruleset** rather than against the pattern alone — a rule whose `extensions` list does not line up with the files being walked passes a pattern test and finds nothing in practice. Covered: the flagged form, the allowed no-argument form, `createQuery`, whitespace variants inside the call, PHP-only scanning, directory exclusion, and every occurrence reported rather than the first per file.

Also exercised end to end against a fixture tree: 2 findings by default, 1 with the submodule excluded, exit 0 under `--warn`.

## Not self-enabled

This repo has no lint runner wired up (CLAUDE.md), and no Joomla queries to lint. Shipping the tool does not turn it on here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)