### PR TITLE
feat(dev): make TestSite driver-aware so it is not silently MySQL-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`Dev\TestSite` reads `dbtype` and speaks both databases.** The primitive
+  every consumer is about to migrate twelve files onto was MySQL-only in four
+  places, silently: a `mysql:` DSN with `charset=utf8mb4`, and `SHOW TABLES` /
+  `SHOW COLUMNS`, which PostgreSQL does not have. Shipping it that way would
+  have replaced twelve scattered MySQL assumptions with one shared one, which is
+  harder to find later, not easier.
+
+  `driver()` and `isPostgres()` expose what the site actually runs, mapped from
+  Joomla's `dbtype` (`mysqli`/`mysql` → `mysql`, `pgsql`/`postgresql` →
+  `pgsql`). An unrecognised value falls back to MySQL rather than throwing —
+  every CWM site is MySQL today, and refusing to connect to guard against a
+  database nobody uses would break working installs — but the fallback is
+  inspectable rather than assumed.
+
+  `hasTable()` and `hasColumn()` now use `information_schema`, which both
+  databases have. They filter on a schema name resolved per driver: the database
+  name for MySQL, `current_schema()` for PostgreSQL, where a database holds many
+  schemas and Joomla's tables are not guaranteed to be in `public`. Without that
+  filter `information_schema` answers about every schema on the server, and a
+  same-named table elsewhere reads as this site's.
+
+  `ExtensionVerifier`'s last `SHOW COLUMNS` — the namespace-column probe — goes
+  through `hasColumn()`, so no MySQL-only introspection remains in `src/`.
+
+  This is the tooling groundwork only. Shipping PostgreSQL support means
+  `install.*.sql`, `uninstall.*.sql`, per-driver `<schemapath>` entries and 37
+  migration files per consumer, which is tracked separately.
+
 - **`Dev\TestSite` — one implementation of "read `configuration.php`, open a
   connection, know the prefix".** That primitive was hand-rolled in twelve files
   across Proclaim and CWMLivingWord, which did not even agree on a driver — six

--- a/src/Dev/ExtensionVerifier.php
+++ b/src/Dev/ExtensionVerifier.php
@@ -70,7 +70,9 @@ final class ExtensionVerifier
         }
 
         $prefix       = $site->prefix();
-        $hasNamespace = $this->hasNamespaceColumn($pdo, $prefix);
+        // Older Joomla schemas have no namespace column. TestSite answers this
+        // portably; SHOW COLUMNS, which this used, is MySQL-only.
+        $hasNamespace = $site->hasColumn('#__extensions', 'namespace');
         $expected     = array_merge($this->expectedExtensions(), $this->expectedFromPackages($packages));
 
         $ok     = 0;
@@ -813,13 +815,6 @@ final class ExtensionVerifier
         }
 
         return 'added';
-    }
-
-    private function hasNamespaceColumn(\PDO $pdo, string $prefix): bool
-    {
-        $stmt = $pdo->query("SHOW COLUMNS FROM {$prefix}extensions LIKE 'namespace'");
-
-        return $stmt instanceof \PDOStatement && $stmt->rowCount() > 0;
     }
 
     /**

--- a/src/Dev/TestSite.php
+++ b/src/Dev/TestSite.php
@@ -49,9 +49,12 @@ final class TestSite
 {
     private ?PDO $pdo = null;
 
+    /** Resolved lazily; see {@see schemaName()}. */
+    private ?string $schemaName = null;
+
     /**
      * @param  string  $path    Absolute path to the Joomla document root.
-     * @param  array{host: string, user: string, password: string, db: string, dbprefix: string}  $config
+     * @param  array{host: string, user: string, password: string, db: string, dbprefix: string, driver: string}  $config
      *         Parsed connection values from that install's configuration.php.
      */
     private function __construct(
@@ -114,6 +117,7 @@ final class TestSite
             'password' => '',
             'db'       => '',
             'dbprefix' => $prefix,
+            'driver'   => (string) $pdo->getAttribute(PDO::ATTR_DRIVER_NAME),
         ]);
 
         $site->pdo = $pdo;
@@ -136,6 +140,83 @@ final class TestSite
     public function database(): string
     {
         return $this->config['db'];
+    }
+
+    /**
+     * The PDO driver this site uses: `mysql` or `pgsql`.
+     *
+     * Read from `dbtype` in configuration.php. Callers running SQL that is not
+     * portable — and most schema DDL is not — should branch on this rather than
+     * assume, which is the assumption every hand-rolled copy made silently.
+     */
+    public function driver(): string
+    {
+        return $this->config['driver'];
+    }
+
+    /** Whether this site runs on PostgreSQL. */
+    public function isPostgres(): bool
+    {
+        return $this->driver() === 'pgsql';
+    }
+
+    /**
+     * The DSN for this site's driver.
+     *
+     * `charset=utf8mb4` is MySQL-only; PostgreSQL takes the encoding from the
+     * database itself, and passing an unknown DSN parameter to it is an error
+     * rather than something ignored.
+     */
+    private function dsn(): string
+    {
+        $host = $this->config['host'];
+        $db   = $this->config['db'];
+
+        if ($this->driver() === 'pgsql') {
+            // Joomla writes host:port into the same field for both drivers.
+            [$hostname, $port] = array_pad(explode(':', $host, 2), 2, null);
+
+            return 'pgsql:host=' . $hostname
+                . ($port !== null ? ';port=' . $port : '')
+                . ';dbname=' . $db;
+        }
+
+        return 'mysql:host=' . $host . ';dbname=' . $db . ';charset=utf8mb4';
+    }
+
+    /**
+     * The schema name `information_schema` queries should filter on.
+     *
+     * The two databases disagree about what a "schema" is. In MySQL it is the
+     * database, so the database name is the filter. In PostgreSQL a database
+     * holds many schemas and Joomla's tables live in whichever is first on the
+     * search path — usually `public`, but not necessarily, so it is asked
+     * rather than assumed.
+     *
+     * Filtering matters: without it, `information_schema` answers about every
+     * schema on the server, and a table of the same name in another database
+     * reads as this site's.
+     */
+    private function schemaName(): string
+    {
+        if ($this->schemaName !== null) {
+            return $this->schemaName;
+        }
+
+        if ($this->driver() === 'pgsql') {
+            $current = $this->db()->query('SELECT current_schema()')?->fetchColumn();
+
+            return $this->schemaName = is_string($current) ? $current : 'public';
+        }
+
+        // fromPdo() carries no database name; ask the connection instead.
+        if ($this->config['db'] !== '') {
+            return $this->schemaName = $this->config['db'];
+        }
+
+        $current = $this->db()->query('SELECT DATABASE()')?->fetchColumn();
+
+        return $this->schemaName = is_string($current) ? $current : '';
     }
 
     /**
@@ -168,7 +249,7 @@ final class TestSite
 
         try {
             $this->pdo = new PDO(
-                'mysql:host=' . $this->config['host'] . ';dbname=' . $this->config['db'] . ';charset=utf8mb4',
+                $this->dsn(),
                 $this->config['user'],
                 $this->config['password'],
                 [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION],
@@ -194,8 +275,10 @@ final class TestSite
      */
     public function hasTable(string $token): bool
     {
-        $stmt = $this->db()->prepare('SHOW TABLES LIKE ?');
-        $stmt->execute([$this->table($token)]);
+        $stmt = $this->db()->prepare(
+            'SELECT 1 FROM information_schema.tables WHERE table_schema = ? AND table_name = ?'
+        );
+        $stmt->execute([$this->schemaName(), $this->table($token)]);
 
         return $stmt->fetchColumn() !== false;
     }
@@ -209,8 +292,11 @@ final class TestSite
      */
     public function hasColumn(string $token, string $column): bool
     {
-        $stmt = $this->db()->prepare('SHOW COLUMNS FROM ' . $this->table($token) . ' LIKE ?');
-        $stmt->execute([$column]);
+        $stmt = $this->db()->prepare(
+            'SELECT 1 FROM information_schema.columns '
+            . 'WHERE table_schema = ? AND table_name = ? AND column_name = ?'
+        );
+        $stmt->execute([$this->schemaName(), $this->table($token), $column]);
 
         return $stmt->fetchColumn() !== false;
     }
@@ -221,7 +307,7 @@ final class TestSite
      * Pure: it takes a path and returns values, so it is tested against fixture
      * files rather than a live install.
      *
-     * @return array{host: string, user: string, password: string, db: string, dbprefix: string}|null
+     * @return array{host: string, user: string, password: string, db: string, dbprefix: string, driver: string}|null
      *         Null when the file is absent, unreadable, or names no database.
      */
     public static function readConfig(string $joomlaPath): ?array
@@ -260,7 +346,29 @@ final class TestSite
             'password' => $values['password'] ?? '',
             'db'       => $values['db'],
             'dbprefix' => $values['dbprefix'] ?? 'jos_',
+            'driver'   => self::normaliseDriver($values['dbtype'] ?? 'mysqli'),
         ];
+    }
+
+    /**
+     * Map Joomla's `dbtype` onto a PDO driver name.
+     *
+     * Joomla writes `mysqli` (and historically `mysql`) for MySQL and MariaDB,
+     * and `pgsql` (sometimes spelled `postgresql`) for PostgreSQL. PDO knows
+     * `mysql` and `pgsql`.
+     *
+     * An unrecognised value falls back to `mysql` rather than throwing: every
+     * CWM site is MySQL today, and refusing to open a connection over a dbtype
+     * this mapping has not seen would break working installs to guard against a
+     * database nobody is using. The fallback is visible via {@see driver()} so a
+     * caller that cares can check.
+     */
+    private static function normaliseDriver(string $dbtype): string
+    {
+        return match (strtolower($dbtype)) {
+            'pgsql', 'postgresql' => 'pgsql',
+            default               => 'mysql',
+        };
     }
 
     /**

--- a/tests/Dev/TestSiteTest.php
+++ b/tests/Dev/TestSiteTest.php
@@ -122,6 +122,31 @@ final class TestSiteTest extends TestCase
     }
 
     #[Test]
+    public function reads_the_driver_from_dbtype(): void
+    {
+        self::assertSame('mysql', TestSite::fromPath($this->fixture('standard'))->driver());
+        self::assertFalse(TestSite::fromPath($this->fixture('standard'))->isPostgres());
+
+        self::assertSame('pgsql', TestSite::fromPath($this->fixture('postgres'))->driver());
+        self::assertTrue(TestSite::fromPath($this->fixture('postgres'))->isPostgres());
+    }
+
+    #[Test]
+    public function an_unknown_dbtype_falls_back_to_mysql(): void
+    {
+        /*
+         * Every CWM site is MySQL today. Refusing to open a connection over a
+         * dbtype this mapping has not seen would break working installs to
+         * guard against a database nobody is using — so it falls back, and
+         * driver() makes the assumption inspectable.
+         */
+        $config = TestSite::readConfig($this->fixture('escapes'));
+
+        self::assertNotNull($config);
+        self::assertSame('mysql', $config['driver'], 'a configuration.php with no dbtype reads as MySQL');
+    }
+
+    #[Test]
     public function an_install_config_contributes_its_path_only(): void
     {
         /*

--- a/tests/fixtures/joomla/postgres/configuration.php
+++ b/tests/fixtures/joomla/postgres/configuration.php
@@ -1,0 +1,10 @@
+<?php
+class JConfig
+{
+	public $db = 'cwm_pg';
+	public $dbtype = 'pgsql';
+	public $host = 'localhost:5432';
+	public $user = 'cwmdev';
+	public $password = 'sekrit';
+	public $dbprefix = 'pg_';
+}


### PR DESCRIPTION
Groundwork for PostgreSQL support. Does **not** add PostgreSQL support — see the tracking issue for what that actually costs.

## Why now

`TestSite` (#102, merged in #112) is about to become the primitive twelve files across two consumers migrate onto. It was MySQL-only in four places and said so nowhere:

| | |
|---|---|
| `TestSite::db()` | `mysql:host=…;charset=utf8mb4` |
| `TestSite::hasTable()` | `SHOW TABLES LIKE` |
| `TestSite::hasColumn()` | `SHOW COLUMNS FROM … LIKE` |
| `ExtensionVerifier::hasNamespaceColumn()` | `SHOW COLUMNS … LIKE 'namespace'` |

Migrating onto it as-is would replace twelve scattered MySQL assumptions with one shared one — fewer, but harder to find later, and baked into the layer everything else sits on. It is also unreleased, so this is the cheapest moment it will ever be.

## What changed

`readConfig()` already parsed `configuration.php` and **threw `dbtype` away**. It now keeps it, mapped to a PDO driver: `mysqli`/`mysql` → `mysql`, `pgsql`/`postgresql` → `pgsql`, exposed as `driver()` and `isPostgres()`.

An unrecognised `dbtype` falls back to MySQL rather than throwing. Every CWM site is MySQL today, and refusing to connect to guard against a database nobody uses would break working installs — but the fallback is now *inspectable* rather than implicit, which was the actual defect.

The DSN is built per driver: `charset=utf8mb4` is MySQL-only, and PostgreSQL rejects unknown DSN parameters rather than ignoring them. Joomla writes `host:port` into one field for both, so the pgsql branch splits it.

`hasTable()` / `hasColumn()` move to `information_schema`, which both databases have, filtered on a schema name resolved per driver — the database name for MySQL, `current_schema()` for PostgreSQL, where a database holds many schemas and Joomla's tables are not guaranteed to sit in `public`.

**That filter is load-bearing.** Without it `information_schema` answers about every schema on the server and a same-named table elsewhere reads as this site's. It is also a real improvement on MySQL: `SHOW COLUMNS` *throws* on a missing table, where this returns false.

`ExtensionVerifier::hasNamespaceColumn()` is deleted; the caller asks `TestSite`. No MySQL-only introspection remains in `src/` or `scripts/`.

## Tests

`composer test` green — 502 PHPUnit / 1146 assertions, 141 shell assertions.

New committed fixture `tests/fixtures/joomla/postgres/configuration.php` (`dbtype = 'pgsql'`, `host:port`), plus coverage that a `configuration.php` with no `dbtype` reads as MySQL.

The connection paths themselves still need a live server and are not executed here.

## Scope

Tooling only. Actual PostgreSQL support means `install.*.sql`, `uninstall.*.sql`, per-driver `<schemapath>` entries and 37 migration files in Proclaim alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)