### PR TITLE
feat(release): verify the published update stream, from a post-publish step (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`cwm-verify-update-stream`, and a post-publish step in `release.sh` to run
+  it from.** The pipeline had nine steps and no verification after publishing,
+  so the one class of failure that only exists post-publish had nowhere to be
+  caught: the release goes out, the feed stays valid, and some population of
+  sites is never offered the update. Null ARS environments mis-shipped three
+  Proclaim releases that way — published fine, offered to nobody. (#106)
+
+  It asserts an `<update>` entry exists at the released version and carries
+  `php_minimum` and `targetplatform`, reading the stream URL from the package
+  manifest's `<updateservers>` so a manifest pointing at the wrong stream is
+  caught by the same check.
+
+  **It reports and never fails the release.** Nothing it finds can be undone by
+  exiting non-zero at that point — the tag is pushed, the GitHub release is out,
+  ARS has the item. A red pipeline would imply the release did not happen, and
+  would teach people to ignore the one check that runs after it did.
+
+  Project-specific assertions stay with the project. Proclaim's legacy
+  `com_proclaim` entry and its required sort order encode one extension's
+  migration history, so `entriesFor()` returns the parsed entries in document
+  order with their positions — position being what decides a tie, since Joomla
+  keeps one `$latest` per feed and replaces it only on a strictly greater
+  version — and a project asserts on top rather than forking the fetcher.
+
+  Parsing is split from fetching and tested against committed feeds, including
+  wrong ones. A post-publish check only ever run against a healthy production
+  stream is a check nobody knows can fail.
+
 - **`cwm-reset-testsite` — remove an extension family from every `role = test`
   install.** Both consumers had written this and their copies had drifted 356
   differing lines apart. A repeatable install test has to begin from a known

--- a/bin/cwm-verify-update-stream
+++ b/bin/cwm-verify-update-stream
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# cwm-verify-update-stream — check a published release is reachable by sites.
+#
+# Runs AFTER publish: everything else in the release pipeline runs before it
+# and cannot see what the update stream serves. Asserts the released version
+# has an entry carrying php_minimum and targetplatform — each of which fails
+# silently in production, leaving the release published and offered to nobody.
+#
+# Usage from a consuming project:
+#   composer cwm-verify-update-stream
+#   composer cwm-verify-update-stream -- 1.3.0
+#   composer cwm-verify-update-stream -- --help
+#
+set -euo pipefail
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec php "${TOOLS_DIR}/scripts/verify-update-stream.php" "$@"

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
         "bin/cwm-baseline",
         "bin/cwm-lint-queries",
         "bin/cwm-lint-comments",
-        "bin/cwm-reset-testsite"
+        "bin/cwm-reset-testsite",
+        "bin/cwm-verify-update-stream"
     ],
     "config": {
         "sort-packages": true,

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -46,6 +46,7 @@ typical day-to-day loop.
 | `cwm-build` | Build one installable extension zip from the `build` block. Runs the `preBuild` hook and the optional [`verifyAssets`](javascript-and-joomladialog.md#72-buildverifyassets-fail-loudly-if-an-asset-didnt-build) check first. |
 | `cwm-package` | Assemble a multi-extension Joomla **package** zip from child extension zips. |
 | `cwm-release` | Full release pipeline: bump → substitute tokens → build → ARS publish → `versions.json` + git push. |
+| `cwm-verify-update-stream` | **After** a release: fetch the update stream the package manifest declares and assert the released version is served with `php_minimum` and `targetplatform`. Each of those fails silently in production — published fine, offered to nobody. `cwm-release` runs it as a post-flight step and reports rather than fails. |
 | `cwm-changelog` | Generate a Joomla changelog XML entry from a GitHub release. |
 | `cwm-article` | Post a "&lt;Extension&gt; X.Y.Z Released" announcement article. |
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -158,6 +158,43 @@ Always check `--help` for the current flags and any dry-run option:
 composer cwm-release -- --help
 ```
 
+## After the release: is it reachable?
+
+Everything above runs **before** publish, so none of it can see what the update
+stream serves afterwards. That failure is silent by construction — valid XML, a
+clean release, and some population of sites is simply never offered the update.
+Null ARS environments mis-shipped three Proclaim releases exactly that way.
+
+`cwm-release` therefore ends with a post-flight check:
+
+```
+[post-flight] Verifying the published update stream...
+=== update stream check — 1.3.0 ===
+  entries at 1.3.0: 1
+    #1   pkg_example    php_minimum=8.1   targetplatform=5\.[0-9]+
+  OK: the released version is served and usable.
+```
+
+It asserts an `<update>` entry exists at the released version and carries
+`php_minimum` and `targetplatform`. The stream URL comes from the package
+manifest's `<updateservers>`, so a manifest pointing at the wrong stream is
+caught by the same check.
+
+!!! note "It reports; it never fails the release"
+    Nothing it finds can be undone by exiting non-zero at that point — the tag
+    is pushed, the GitHub release is out, ARS has the item. A red pipeline would
+    imply the release did not happen, and would teach people to ignore the one
+    check that runs after it did. Re-run it by hand once ARS has caught up:
+
+    ```bash
+    composer cwm-verify-update-stream -- 1.3.0
+    ```
+
+Project-specific assertions — a legacy component entry, a required sort order —
+stay in the project. `UpdateStreamVerifier::entriesFor()` returns the parsed
+entries in document order with their positions, so a project asserts on top
+rather than forking the fetcher.
+
 ## Step-by-step (when you don't want the full pipeline)
 
 | Step | Command |

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -590,6 +590,37 @@ else
 fi
 echo ""
 
+# --- Post-flight: is the published release actually reachable? ---
+#
+# Every other check in this pipeline runs before publish and so cannot see what
+# the update stream serves afterwards. The failure is silent by construction:
+# valid XML, a clean release, and some population of sites is never offered the
+# update again. Null ARS environments mis-shipped three Proclaim releases that
+# way — published fine, offered to nobody.
+#
+# It REPORTS and never fails the run. Nothing it finds can be undone by exiting
+# non-zero at this point: the tag is pushed, the GitHub release is out and ARS
+# has the item. A red pipeline here would imply the release did not happen, and
+# would teach people to ignore the one check that runs after it did. The whole
+# subject of #101 is a check whose result was easy to misread.
+#
+# Skipped under --dry-run: nothing was published, so the stream still describes
+# the previous release and checking it would report on the wrong version.
+if [ "$DRY_RUN" != "1" ] && [ -n "$PKG_MANIFEST" ]; then
+    echo "[post-flight] Verifying the published update stream..."
+
+    if php "${TOOLS_DIR}/scripts/verify-update-stream.php" "$VERSION"; then
+        :
+    else
+        echo ""
+        echo "  WARNING: the update stream does not serve ${VERSION} usably."
+        echo "           The release IS published — this is about whether sites will see it."
+        echo "           Re-check once ARS has caught up:"
+        echo "             composer cwm-verify-update-stream -- ${VERSION}"
+    fi
+    echo ""
+fi
+
 if [ "$DRY_RUN" = "1" ]; then
     echo "=== DRY RUN complete — nothing was changed ==="
     echo "  Re-run without --dry-run to release ${VERSION}."

--- a/scripts/verify-update-stream.php
+++ b/scripts/verify-update-stream.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Post-release check: can the published update stream actually reach sites?
+ */
+
+require_once __DIR__ . '/../src/Release/UpdateStreamVerifier.php';
+
+use CWM\BuildTools\Release\UpdateStreamVerifier;
+
+$projectRoot = getcwd() ?: '.';
+
+if (in_array('--help', $argv, true) || in_array('-h', $argv, true)) {
+    echo <<<CWM_HELP
+cwm-verify-update-stream — check that a published release is reachable.
+
+WHAT IT DOES
+  Fetches the update stream declared by the package manifest and asserts that
+  the released version is there and usable:
+
+    - an <update> entry exists at that exact version;
+    - it carries <php_minimum>;
+    - it carries <targetplatform version="...">.
+
+  Every one of those fails silently in production. The release publishes, the
+  feed stays valid, and some population of sites is simply never offered the
+  update — which is how null ARS environments mis-shipped three Proclaim
+  releases in a row.
+
+  Runs AFTER publish, because everything else in the release pipeline runs
+  before it and cannot see what the stream serves.
+
+PREREQUISITES
+  - manifests.package in cwm-build.config.json, declaring <updateservers>
+  - the release already published to ARS
+
+USAGE
+  composer cwm-verify-update-stream            # version from the manifest
+  composer cwm-verify-update-stream -- 1.3.0
+  composer cwm-verify-update-stream -- --url https://staging.test/updates.xml
+
+OPTIONS
+  --url <url>    Check this stream instead of the manifest's. For a staging
+                 stream, or for exercising the check against a fixture —
+                 without it the assertions could only ever run against
+                 production, which is no way to know they can fail.
+  -h, --help     Show this and exit.
+
+PROJECT-SPECIFIC ASSERTIONS
+  A feed can carry entries only one extension cares about — a legacy component
+  entry, a required sort order. That is the project's knowledge, so it is not
+  checked here. Use CWM\\BuildTools\\Release\\UpdateStreamVerifier::entriesFor()
+  to get the parsed rows, in document order with their positions, and assert on
+  top rather than forking the fetcher.
+
+EXIT CODE
+  0  the released version is served and usable
+  1  it is not, or the stream could not be fetched or parsed
+
+  cwm-release runs this after publishing and REPORTS the result without
+  failing: nothing it finds can be undone by exiting non-zero, and a release
+  that already published to ARS and GitHub should not end in a red pipeline
+  that implies otherwise.
+
+RELATED
+  composer cwm-ars-publish    # publish the release to ARS
+  composer cwm-ars-list       # inspect ARS categories and streams
+
+CWM_HELP;
+
+    exit(0);
+}
+
+$version = null;
+$url     = null;
+$args    = array_slice($argv, 1);
+
+for ($i = 0; $i < count($args); $i++) {
+    if ($args[$i] === '--url') {
+        $url = $args[++$i] ?? null;
+
+        continue;
+    }
+
+    if (!str_starts_with($args[$i], '-')) {
+        $version = $args[$i];
+    }
+}
+
+$configFile = $projectRoot . '/cwm-build.config.json';
+$config     = is_file($configFile) ? json_decode((string) file_get_contents($configFile), true) : null;
+$manifest   = is_array($config) ? ($config['manifests']['package'] ?? null) : null;
+
+if ($version === null && is_string($manifest) && is_file($projectRoot . '/' . $manifest)) {
+    $doc = new DOMDocument();
+
+    if (@$doc->load($projectRoot . '/' . $manifest)) {
+        $node    = (new DOMXPath($doc))->query('/extension/version')?->item(0);
+        $version = $node === null ? null : trim($node->textContent);
+    }
+}
+
+if ($version === null || $version === '') {
+    fwrite(STDERR, "Could not determine which version to check. Pass one as an argument.\n");
+
+    exit(1);
+}
+
+if ($url === null) {
+    if (!is_string($manifest)) {
+        fwrite(STDERR, "No manifests.package in cwm-build.config.json, and no --url given.\n");
+
+        exit(1);
+    }
+
+    $url = UpdateStreamVerifier::streamUrlFromManifest($projectRoot . '/' . $manifest);
+
+    if ($url === null) {
+        fwrite(STDERR, "No <updateservers><server> in {$manifest} — the package cannot self-update.\n");
+
+        exit(1);
+    }
+}
+
+echo "=== update stream check — {$version} ===\n";
+echo "  stream: {$url}\n";
+
+$context = stream_context_create(['http' => ['timeout' => 30], 'https' => ['timeout' => 30]]);
+$body    = @file_get_contents($url, false, $context);
+
+if ($body === false || $body === '') {
+    fwrite(STDERR, "  FAIL: could not fetch the update stream.\n");
+
+    exit(1);
+}
+
+$entries  = UpdateStreamVerifier::entriesFor($body, $version);
+$findings = UpdateStreamVerifier::findings($entries, $version);
+
+echo '  entries at ' . $version . ': ' . count($entries) . "\n";
+
+foreach ($entries as $entry) {
+    printf(
+        "    #%-3d %-20s php_minimum=%-8s targetplatform=%s\n",
+        $entry['position'],
+        $entry['element'] === '' ? '(no element)' : $entry['element'],
+        $entry['php_minimum'] === '' ? '(none)' : $entry['php_minimum'],
+        $entry['targetplatform'] === '' ? '(none)' : $entry['targetplatform']
+    );
+}
+
+if ($findings === []) {
+    echo "  OK: the released version is served and usable.\n";
+
+    exit(0);
+}
+
+foreach ($findings as $finding) {
+    fwrite(STDERR, '  ' . strtoupper($finding['level']) . ': ' . $finding['message'] . "\n");
+}
+
+exit(1);

--- a/src/Release/UpdateStreamVerifier.php
+++ b/src/Release/UpdateStreamVerifier.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Release;
+
+use DOMDocument;
+use DOMXPath;
+
+/**
+ * Checks that a published update stream can actually reach sites.
+ *
+ * Everything else in the release pipeline runs before publish and therefore
+ * cannot see what the stream serves afterwards. The failure this catches is
+ * silent by construction: valid XML, a clean release, and some population of
+ * sites simply never sees an update again. Null ARS environments mis-shipped
+ * three Proclaim releases that way — published fine, offered to nobody.
+ *
+ * ## Parsing is separate from fetching
+ *
+ * {@see entriesFor()} takes XML and returns rows; {@see findings()} takes rows
+ * and returns problems. Neither touches the network, so both are tested against
+ * committed fixture feeds — including feeds that are *wrong*, which is the only
+ * way to know the assertions can fail. Fetching lives in the CLI.
+ *
+ * ## Project-specific assertions belong to the project
+ *
+ * A feed can carry entries that only one extension cares about. Proclaim serves
+ * a legacy `com_proclaim` entry for sites installed before it shipped a package,
+ * and requires it to sort *before* the package entry of the same version,
+ * because Joomla keeps a single `$latest` per feed and replaces it only on a
+ * strictly greater version — so at equal versions the first block parsed wins.
+ *
+ * That is one extension's migration history, and it does not belong in an
+ * extension-agnostic build tool. So `entriesFor()` returns the parsed rows,
+ * in document order with their positions, and a project asserts whatever else
+ * it needs on top rather than forking the fetcher to get at them.
+ *
+ * Feeds are semi-trusted (TLS), and parsed with the default libxml options —
+ * external entities are disabled by default on libxml ≥ 2.9, and nothing here
+ * passes `LIBXML_NOENT` or `LIBXML_DTDLOAD`.
+ */
+final class UpdateStreamVerifier
+{
+    /**
+     * The update-server URL declared by a package manifest.
+     *
+     * Read from the manifest rather than configured separately, so a manifest
+     * pointing at the wrong stream is caught by the same check — that is a real
+     * failure mode, and a separately configured URL would verify a stream the
+     * shipped package never consults.
+     *
+     * @return string|null Null when the file is unreadable, unparseable, or
+     *                     declares no update server at all — which means the
+     *                     package cannot self-update.
+     */
+    public static function streamUrlFromManifest(string $manifestPath): ?string
+    {
+        if (!is_file($manifestPath)) {
+            return null;
+        }
+
+        $doc = new DOMDocument();
+
+        if (!@$doc->load($manifestPath)) {
+            return null;
+        }
+
+        $node = (new DOMXPath($doc))->query('/extension/updateservers/server')?->item(0);
+
+        if ($node === null) {
+            return null;
+        }
+
+        $url = trim($node->textContent);
+
+        return $url === '' ? null : $url;
+    }
+
+    /**
+     * Every `<update>` entry in the feed carrying this exact version.
+     *
+     * `position` is the entry's 1-based index across the whole feed, in document
+     * order. It is kept because document order is what decides a tie between two
+     * entries at the same version, so a project asserting on ordering needs it
+     * and cannot recover it afterwards.
+     *
+     * @return list<array{element: string, type: string, version: string, position: int, php_minimum: string, targetplatform: string}>
+     */
+    public static function entriesFor(string $xml, string $version): array
+    {
+        $doc = new DOMDocument();
+
+        if ($xml === '' || !@$doc->loadXML($xml)) {
+            return [];
+        }
+
+        $xpath    = new DOMXPath($doc);
+        $matching = [];
+        $position = 0;
+
+        foreach ($xpath->query('//update') ?: [] as $update) {
+            $position++;
+            $versionNode = $xpath->query('version', $update)?->item(0);
+
+            if ($versionNode === null || trim($versionNode->textContent) !== $version) {
+                continue;
+            }
+
+            $platformNode = $xpath->query('targetplatform', $update)?->item(0);
+
+            $matching[] = [
+                'element'        => self::text($xpath, $update, 'element'),
+                'type'           => self::text($xpath, $update, 'type'),
+                'version'        => $version,
+                'position'       => $position,
+                'php_minimum'    => self::text($xpath, $update, 'php_minimum'),
+                'targetplatform' => $platformNode === null ? '' : trim($platformNode->getAttribute('version')),
+            ];
+        }
+
+        return $matching;
+    }
+
+    /**
+     * Generic problems with a released version's entries.
+     *
+     * Three assertions, each of which fails silently in production if broken:
+     *
+     *   - an entry exists at all. Without one the release is published and no
+     *     site is ever offered it, which no pre-publish check can see;
+     *   - `php_minimum` is present. Joomla filters entries by it, and an absent
+     *     value is not "any version" on every code path;
+     *   - `targetplatform` is present. Same shape — the entry is served and
+     *     matches nobody.
+     *
+     * @param  list<array{element: string, type: string, version: string, position: int, php_minimum: string, targetplatform: string}>  $entries
+     *
+     * @return list<array{level: string, message: string}> Empty when the feed is sound.
+     */
+    public static function findings(array $entries, string $version): array
+    {
+        if ($entries === []) {
+            return [[
+                'level'   => 'fail',
+                'message' => "No <update> entry at version {$version}. The release is published and no site will be offered it.",
+            ]];
+        }
+
+        $findings = [];
+
+        foreach ($entries as $entry) {
+            $name = $entry['element'] === '' ? '(no element)' : $entry['element'];
+
+            if ($entry['php_minimum'] === '') {
+                $findings[] = [
+                    'level'   => 'fail',
+                    'message' => "Entry '{$name}' at {$version} has no <php_minimum>. Joomla filters on it, and an absent value is not 'any version' everywhere.",
+                ];
+            }
+
+            if ($entry['targetplatform'] === '') {
+                $findings[] = [
+                    'level'   => 'fail',
+                    'message' => "Entry '{$name}' at {$version} has no <targetplatform version=\"...\">. It will be served and match no site.",
+                ];
+            }
+        }
+
+        return $findings;
+    }
+
+    /** Trimmed text of a child element, or '' when absent. */
+    private static function text(DOMXPath $xpath, \DOMNode $context, string $child): string
+    {
+        $node = $xpath->query($child, $context)?->item(0);
+
+        return $node === null ? '' : trim($node->textContent);
+    }
+}

--- a/tests/Release/UpdateStreamVerifierTest.php
+++ b/tests/Release/UpdateStreamVerifierTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Release;
+
+use CWM\BuildTools\Release\UpdateStreamVerifier;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Parsing and assertion, against committed feeds — including wrong ones.
+ *
+ * A post-publish check that has only ever been run against a healthy
+ * production stream is a check nobody knows can fail. The fixtures here include
+ * a feed missing the metadata Joomla filters on, which is the exact shape that
+ * shipped three Proclaim releases to nobody.
+ */
+final class UpdateStreamVerifierTest extends TestCase
+{
+    private function feed(string $name): string
+    {
+        return (string) file_get_contents(__DIR__ . '/../fixtures/updates/' . $name);
+    }
+
+    #[Test]
+    public function finds_the_entry_for_the_released_version(): void
+    {
+        $entries = UpdateStreamVerifier::entriesFor($this->feed('sound.xml'), '1.3.0');
+
+        self::assertCount(1, $entries);
+        self::assertSame('pkg_example', $entries[0]['element']);
+        self::assertSame('8.1', $entries[0]['php_minimum']);
+        self::assertSame('5\\.[0-9]+', $entries[0]['targetplatform']);
+    }
+
+    #[Test]
+    public function a_sound_feed_yields_no_findings(): void
+    {
+        $entries = UpdateStreamVerifier::entriesFor($this->feed('sound.xml'), '1.3.0');
+
+        self::assertSame([], UpdateStreamVerifier::findings($entries, '1.3.0'));
+    }
+
+    #[Test]
+    public function a_version_with_no_entry_is_the_headline_failure(): void
+    {
+        // Published, and offered to nobody. No pre-publish check can see this.
+        $entries = UpdateStreamVerifier::entriesFor($this->feed('sound.xml'), '9.9.9');
+
+        self::assertSame([], $entries);
+
+        $findings = UpdateStreamVerifier::findings($entries, '9.9.9');
+
+        self::assertCount(1, $findings);
+        self::assertSame('fail', $findings[0]['level']);
+        self::assertStringContainsString('no site will be offered it', $findings[0]['message']);
+    }
+
+    #[Test]
+    public function missing_php_minimum_and_targetplatform_are_both_reported(): void
+    {
+        // The null-ARS-environment shape: the entry exists, the release looks
+        // clean, and Joomla filters it out at every site.
+        $entries  = UpdateStreamVerifier::entriesFor($this->feed('missing-metadata.xml'), '1.3.0');
+        $findings = UpdateStreamVerifier::findings($entries, '1.3.0');
+
+        self::assertCount(2, $findings);
+        self::assertStringContainsString('php_minimum', $findings[0]['message']);
+        self::assertStringContainsString('targetplatform', $findings[1]['message']);
+    }
+
+    #[Test]
+    public function entries_keep_their_document_position(): void
+    {
+        /*
+         * Document order decides a tie: Joomla keeps a single $latest per feed
+         * and replaces it only on a strictly greater version, so at equal
+         * versions the first block parsed wins. A project asserting on ordering
+         * cannot recover the position afterwards, so it is returned.
+         */
+        $entries = UpdateStreamVerifier::entriesFor($this->feed('two-entries.xml'), '1.3.0');
+
+        self::assertSame(['com_example', 'pkg_example'], array_column($entries, 'element'));
+        self::assertSame([1, 2], array_column($entries, 'position'));
+    }
+
+    #[Test]
+    public function two_entries_at_one_version_are_not_themselves_a_problem(): void
+    {
+        // Whether a second entry is expected is the project's business, not
+        // this class's. Reporting it generically would fail every Proclaim
+        // release, which serves a legacy component entry on purpose.
+        $entries = UpdateStreamVerifier::entriesFor($this->feed('two-entries.xml'), '1.3.0');
+
+        self::assertSame([], UpdateStreamVerifier::findings($entries, '1.3.0'));
+    }
+
+    #[Test]
+    public function unparseable_xml_yields_no_entries_rather_than_an_error(): void
+    {
+        // An ARS error page is HTML, not XML. The caller reports "no entry",
+        // which is the true statement about what sites will be offered.
+        self::assertSame([], UpdateStreamVerifier::entriesFor('<html>500</html>', '1.3.0'));
+        self::assertSame([], UpdateStreamVerifier::entriesFor('', '1.3.0'));
+    }
+
+    #[Test]
+    public function reads_the_stream_url_from_the_package_manifest(): void
+    {
+        // From the manifest, not from separate config: a manifest pointing at
+        // the wrong stream is a real failure, and a separately configured URL
+        // would verify a stream the shipped package never consults.
+        self::assertSame(
+            'https://example.test/updates.xml',
+            UpdateStreamVerifier::streamUrlFromManifest(__DIR__ . '/../fixtures/updates/manifest-with-server.xml')
+        );
+    }
+
+    #[Test]
+    public function a_manifest_with_no_update_server_reads_as_null(): void
+    {
+        self::assertNull(
+            UpdateStreamVerifier::streamUrlFromManifest(__DIR__ . '/../fixtures/updates/manifest-no-server.xml')
+        );
+        self::assertNull(UpdateStreamVerifier::streamUrlFromManifest(__DIR__ . '/../fixtures/updates/nope.xml'));
+    }
+}

--- a/tests/fixtures/updates/manifest-no-server.xml
+++ b/tests/fixtures/updates/manifest-no-server.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extension type="package" method="upgrade">
+    <name>pkg_example</name>
+    <version>1.3.0</version>
+</extension>

--- a/tests/fixtures/updates/manifest-with-server.xml
+++ b/tests/fixtures/updates/manifest-with-server.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extension type="package" method="upgrade">
+    <name>pkg_example</name>
+    <version>1.3.0</version>
+    <updateservers>
+        <server type="collection" priority="1" name="Example">https://example.test/updates.xml</server>
+    </updateservers>
+</extension>

--- a/tests/fixtures/updates/missing-metadata.xml
+++ b/tests/fixtures/updates/missing-metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<updates>
+    <update>
+        <element>pkg_example</element>
+        <type>package</type>
+        <version>1.3.0</version>
+    </update>
+</updates>

--- a/tests/fixtures/updates/sound.xml
+++ b/tests/fixtures/updates/sound.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<updates>
+    <update>
+        <name>Example Package</name>
+        <element>pkg_example</element>
+        <type>package</type>
+        <version>1.3.0</version>
+        <php_minimum>8.1</php_minimum>
+        <targetplatform name="joomla" version="5\.[0-9]+"/>
+        <downloads><downloadurl type="full" format="zip">https://example.test/pkg-1.3.0.zip</downloadurl></downloads>
+    </update>
+    <update>
+        <name>Example Package</name>
+        <element>pkg_example</element>
+        <type>package</type>
+        <version>1.2.0</version>
+        <php_minimum>8.1</php_minimum>
+        <targetplatform name="joomla" version="5\.[0-9]+"/>
+    </update>
+</updates>

--- a/tests/fixtures/updates/two-entries.xml
+++ b/tests/fixtures/updates/two-entries.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<updates>
+    <update>
+        <element>com_example</element>
+        <type>component</type>
+        <version>1.3.0</version>
+        <php_minimum>8.1</php_minimum>
+        <targetplatform name="joomla" version="5\.[0-9]+"/>
+    </update>
+    <update>
+        <element>pkg_example</element>
+        <type>package</type>
+        <version>1.3.0</version>
+        <php_minimum>8.1</php_minimum>
+        <targetplatform name="joomla" version="5\.[0-9]+"/>
+    </update>
+</updates>


### PR DESCRIPTION
Closes #106.

## The gap

The pipeline had nine steps and **no verification after publishing**, so the one class of failure that only exists post-publish had nowhere to be caught: the release goes out, the feed stays valid, and some population of sites is never offered the update. Null ARS environments mis-shipped three Proclaim releases that way — published fine, offered to nobody.

## What it checks

Three assertions, each silent in production if broken:

- an `<update>` entry exists at the released version;
- it carries `<php_minimum>` — Joomla filters on it, and absent is not "any version" on every code path;
- it carries `<targetplatform version="...">` — same shape, served and matching nobody.

The stream URL comes from the package manifest's `<updateservers>`, not separate config, so a manifest pointing at the wrong stream is caught by the same check. A separately configured URL would verify a stream the shipped package never consults.

## It reports; it never fails the release

`release.sh` gains a post-flight block. Nothing it finds can be undone by exiting non-zero at that point — the tag is pushed, the GitHub release is out, ARS has the item. A red pipeline would imply the release did not happen, and would teach people to ignore the one check that runs *after* it did. A check whose result is easy to misread is the whole subject of #101.

Verified directly rather than assumed — with a failing check, the script still reaches the end and exits 0:

```
[post-flight] Verifying the published update stream...
  WARNING: the update stream does not serve 1.2.3 usably.
=== Release complete! ===
SCRIPT REACHED THE END, exit=0
```

Skipped under `--dry-run`, where nothing was published and the stream still describes the previous release.

## The split this issue asked for

Proclaim's legacy `com_proclaim` entry, its required sort order before the package entry, and `COMPONENT_ENTRY_SUNSET` encode **one extension's migration history** — not something an extension-agnostic tool should assert.

So `entriesFor()` returns the parsed rows in document order **with their positions**, and a project asserts on top rather than forking the fetcher to reach them. Position is kept because it is what decides a tie: Joomla holds one `$latest` per feed and replaces it only on a strictly greater version, so at equal versions the first block parsed wins — and that cannot be recovered after the fact.

Two entries at one version is deliberately **not** reported as a problem; doing so generically would fail every Proclaim release.

## Tests

`composer test` green — 518 PHPUnit / 1177 assertions, 141 shell assertions.

Parsing is split from fetching so both halves run against committed fixture feeds, **including wrong ones**: missing metadata, a version with no entry at all, two entries at one version, and an HTML error page where XML was expected. A post-publish check only ever run against a healthy production stream is a check nobody knows can fail.

Also exercised end to end via `--url` against those fixtures — sound feed exits 0, both broken feeds exit 1 with the specific finding named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)