### PR TITLE
fix(dev): require TestSite in verify.php, fatal in 1.23.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,6 +96,19 @@ jobs:
           coverage: none
           tools: composer:v2
 
+      # Same cache the test job has had all along. Without it this job pulled
+      # every dist archive from codeload on every run, which made it the only
+      # job that could not survive GitHub rate-limiting them: during the
+      # 2026-08-17 incident the three PHP jobs restored from cache and passed
+      # while this one failed four times on HTTP 429, before running a single
+      # check. The key matches the test job's 8.3 entry so either can warm it.
+      - name: Cache Composer packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/composer
+          key: composer-8.3-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-8.3-
+
       - name: Install dependencies
         run: composer install --no-interaction --no-progress --prefer-dist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.23.1] - 2026-08-17
+
+### Fixed
+
+- **`cwm-verify` was fatal in 1.23.0.** `Class "CWM\BuildTools\Dev\TestSite"
+  not found` on every run, from `ExtensionVerifier.php:64`.
+
+  `scripts/` has no autoloader — each entry point requires the `src` files it
+  needs by path. 1.23.0 refactored `ExtensionVerifier` onto the new `TestSite`
+  and never told `scripts/verify.php`, so the class graph was complete under
+  PHPUnit (which autoloads through Composer) and incomplete under the CLI. 525
+  unit tests passed and the command could not start.
+
+  CLAUDE.md warns about exactly this, and 1.18.0 shipped a fatal in
+  `cwm-package` the same way, so the fix is not only the missing require:
+  `tests/shell/cli-loads.test.sh` now loads each path-require CLI's declared
+  class files in a fresh process and asserts every CWM class those files
+  reference actually resolves. It is mutation-checked — with the require removed
+  it fails — and it emits an explicit verdict, so a harness that dies cannot be
+  read as a pass. Scripts that load through Composer's autoloader and guard with
+  `class_exists()` are exempt, since that is a different and valid strategy.
+
+  Only `cwm-verify` was affected; it is the one command that loads
+  `ExtensionVerifier`.
+
 ## [1.23.0] - 2026-08-17
 
 ### Added

--- a/scripts/verify.php
+++ b/scripts/verify.php
@@ -21,6 +21,7 @@ require_once __DIR__ . '/../src/Config/CwmPackage.php';
 require_once __DIR__ . '/../src/Config/InstalledPackageReader.php';
 require_once __DIR__ . '/../src/Dev/InstallConfig.php';
 require_once __DIR__ . '/../src/Dev/PropertiesReader.php';
+require_once __DIR__ . '/../src/Dev/TestSite.php';
 require_once __DIR__ . '/../src/Dev/ExtensionVerifier.php';
 require_once __DIR__ . '/../src/Dev/Linker.php';
 require_once __DIR__ . '/../src/Dev/LinkResolver.php';

--- a/tests/shell/cli-loads.test.sh
+++ b/tests/shell/cli-loads.test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Every CLI in scripts/ must be able to load its own class graph.
+#
+# scripts/ has no autoloader — each entry point requires the src files it needs
+# by path. So a class that gains a new collaborator breaks every CLI that
+# loaded it, at runtime, on the one code path that reaches it. PHPUnit cannot
+# see this: it autoloads through Composer, so the class graph is always
+# complete under test and never under the CLI.
+#
+# That is not hypothetical. v1.23.0 shipped `cwm-verify` fatal with
+# "Class CWM\BuildTools\Dev\TestSite not found" because ExtensionVerifier was
+# refactored onto TestSite and scripts/verify.php was never told. 525 unit
+# tests passed. CLAUDE.md warns about exactly this, and 1.18.0 shipped a fatal
+# in cwm-package the same way.
+#
+# The check: require each script's declared class files in a fresh PHP process,
+# then confirm every CWM class those files reference actually resolves. No
+# behaviour is invoked, so it is safe to run anywhere.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+ROOT="${SCRIPT_DIR}/../.."
+
+for script in "${ROOT}"/scripts/*.php; do
+    name="$(basename "$script")"
+
+    # Scripts that load through Composer's autoloader use a different strategy
+    # and guard for the class themselves (render-notes.php checks class_exists
+    # and exits with a message). They are not path-require entry points, so
+    # this check does not apply to them.
+    if grep -q 'vendor/autoload.php' "$script"; then
+        continue
+    fi
+
+    missing=$(php -r '
+        $script = $argv[1];
+        $body   = (string) file_get_contents($script);
+
+        // Load exactly what the script declares, in its own order.
+        preg_match_all("~require(?:_once)?\s+__DIR__\s*\.\s*\x27([^\x27]+)\x27~", $body, $m);
+
+        $loaded = [];
+
+        foreach ($m[1] as $rel) {
+            $path = dirname($script) . $rel;
+
+            if (is_file($path)) {
+                require_once $path;
+                $loaded[] = realpath($path);
+            }
+        }
+
+        // Every CWM class referenced by the script or by anything it loaded.
+        $referenced = [];
+
+        foreach (array_merge([$script], $loaded) as $file) {
+            $src = (string) file_get_contents($file);
+
+            if (preg_match_all("~\b([A-Z][A-Za-z0-9_]+)::~", $src, $r)) {
+                $referenced = array_merge($referenced, $r[1]);
+            }
+
+            if (preg_match_all("~new\s+([A-Z][A-Za-z0-9_]+)\s*\(~", $src, $r)) {
+                $referenced = array_merge($referenced, $r[1]);
+            }
+        }
+
+        // Only judge names this package actually defines.
+        $ours = [];
+
+        foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator(dirname($script) . "/../src")) as $f) {
+            if ($f->getExtension() !== "php") {
+                continue;
+            }
+
+            if (preg_match("~^(?:final\s+|abstract\s+|readonly\s+)*(?:class|interface|trait|enum)\s+(\w+)~m", (string) file_get_contents($f->getPathname()), $c)) {
+                $ours[$c[1]] = true;
+            }
+        }
+
+        $missing = [];
+
+        foreach (array_unique($referenced) as $class) {
+            if (!isset($ours[$class])) {
+                continue;
+            }
+
+            foreach (["CWM\\BuildTools\\Dev\\", "CWM\\BuildTools\\Build\\", "CWM\\BuildTools\\Config\\",
+                      "CWM\\BuildTools\\Release\\", "CWM\\BuildTools\\Http\\", "CWM\\BuildTools\\Cli\\"] as $ns) {
+                if (class_exists($ns . $class, false) || interface_exists($ns . $class, false)
+                    || trait_exists($ns . $class, false) || enum_exists($ns . $class, false)) {
+                    continue 2;
+                }
+            }
+
+            $missing[] = $class;
+        }
+
+        echo $missing === [] ? "OK" : "MISSING:" . implode(", ", $missing);
+    ' "$script" 2>&1)
+
+    # Only the literal sentinel passes. Empty output means the harness itself
+    # died, which must not read as a clean result — that is how a check ends up
+    # proving nothing.
+    case "$missing" in
+        OK)
+            PASS=$((PASS + 1))
+            ;;
+        MISSING:*)
+            FAIL=$((FAIL + 1))
+            echo "  FAIL: ${name} references ${missing#MISSING:} but never requires it"
+            ;;
+        *)
+            FAIL=$((FAIL + 1))
+            echo "  FAIL: ${name} — loader check produced no verdict: ${missing:-(no output)}"
+            ;;
+    esac
+done
+
+finish


### PR DESCRIPTION
**`cwm-verify` cannot start in v1.23.0.** Caught by Proclaim's CI within minutes of the release:

```
PHP Fatal error: Uncaught Error: Class "CWM\BuildTools\Dev\TestSite" not found
  in src/Dev/ExtensionVerifier.php:64
  #0 scripts/verify.php(143): ExtensionVerifier->verify()
```

## Cause

`scripts/` has no autoloader — each entry point requires the `src` files it needs by path. The `TestSite` extraction refactored `ExtensionVerifier` onto the new class and never told `scripts/verify.php`.

So the class graph was complete under PHPUnit, which autoloads through Composer, and incomplete under the CLI. **525 unit tests passed against a command that could not run.**

CLAUDE.md warns about exactly this, and 1.18.0 shipped a fatal in `cwm-package` the same way. A one-line require is therefore not the whole fix.

## The guard

`tests/shell/cli-loads.test.sh` loads each path-require CLI's declared class files in a fresh process and asserts every CWM class those files reference resolves.

Getting it right took three attempts, and each failure has the same shape as the bug itself — worth recording rather than hiding:

1. **Empty output read as success.** Any error in the harness passed silently. It now emits an explicit `OK` / `MISSING:` verdict, and anything else — including no output — fails.
2. **The class-discovery regex matched the word "class" in docblock prose**, so it believed this package defined classes named `is`, `answers` and `refuses`, and never saw the real declarations. Now anchored to a line start with modifiers.
3. **`render-notes.php` was flagged wrongly** — it loads through Composer's autoloader and guards with `class_exists()`, a different and valid strategy. Autoloader-based scripts are exempt.

**Mutation-checked:** with the require removed the test fails and names the class. Also verified through the CLI, which is the only place this could have been caught.

## Blast radius

Only `cwm-verify` — it is the one command that loads `ExtensionVerifier`. Everything else in v1.23.0 is unaffected, including `cwm-reset-testsite`, which is why Proclaim's install reached step 4 before dying.

Needs a **v1.23.1** immediately after merge: `cwm-verify` is in both consumers' `test:install` harnesses, so v1.23.0 breaks their release gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)