### PR TITLE
fix(dev): escape LIKE wildcards when matching table prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`cwm-reset-testsite` matched table prefixes with `_` treated as a
+  wildcard.** `_` is a single-character wildcard in `LIKE`, so the pattern for
+  prefix `bsms_` on a site prefixed `jos_` was `jos_bsms_%` — which also matches
+  `josXbsmsY…`. That list is handed to `DROP TABLE`. The hand-rolled script this
+  replaced escaped the underscores; the extraction did not carry that across.
+
+  No real site was at risk — verified against a populated test site, where the
+  loose pattern matched exactly the same 27 tables and nothing else — but a
+  latent over-match in a command that drops tables is not worth keeping.
+
+  The literal part is now escaped with `!` as the `ESCAPE` character rather than
+  the conventional backslash: `ESCAPE '\'` reaches MySQL as an unterminated
+  string literal, and `!` needs no quoting on either MySQL or PostgreSQL.
+
 ## [1.23.1] - 2026-08-17
 
 ### Fixed

--- a/src/Dev/TestSiteReset.php
+++ b/src/Dev/TestSiteReset.php
@@ -216,8 +216,12 @@ final class TestSiteReset
         $params  = [$this->schemaName()];
 
         foreach ($prefixes as $prefix) {
-            $clauses[] = 'table_name LIKE ?';
-            $params[]  = $this->site->prefix() . $prefix . '%';
+            // Escape the LIKE metacharacters in the literal part. `_` matches
+            // any single character, so an unescaped `jos_bsms_%` also matches
+            // `josXbsmsY...` — and this list is handed to DROP TABLE. The
+            // script this replaced escaped it for the same reason.
+            $clauses[] = "table_name LIKE ? ESCAPE '!'";
+            $params[]  = self::escapeLike($this->site->prefix() . $prefix) . '%';
         }
 
         $stmt = $this->site->db()->prepare(
@@ -525,6 +529,21 @@ final class TestSiteReset
         }
 
         return $removed;
+    }
+
+    /**
+     * Escape `_` and `%` so a literal is matched literally by LIKE.
+     *
+     * `!` is the escape character rather than the conventional backslash,
+     * because a backslash has to survive both PHP's string handling and the
+     * server's: `ESCAPE '\'` reaches MySQL as an unterminated string literal.
+     * `!` needs no quoting anywhere and means the same on MySQL and
+     * PostgreSQL. It is escaped first, or it would escape the escapes added
+     * after it.
+     */
+    private static function escapeLike(string $literal): string
+    {
+        return str_replace(['!', '_', '%'], ['!!', '!_', '!%'], $literal);
     }
 
     /** Whether any extension row holds this element, of any type. */

--- a/tests/Dev/TestSiteResetTest.php
+++ b/tests/Dev/TestSiteResetTest.php
@@ -34,6 +34,10 @@ final class TestSiteResetTest extends TestCase
         );
         $this->pdo->exec('CREATE TABLE jos_schemas (extension_id INTEGER, version_id TEXT)');
         $this->pdo->exec('CREATE TABLE jos_modules (id INTEGER PRIMARY KEY, module TEXT)');
+        // A table an unescaped `jos_bsms_%` would wrongly match: `_` is a LIKE
+        // wildcard, so it also matches any single character in those positions.
+        $this->pdo->exec('CREATE TABLE josXbsmsY_decoy (id INTEGER)');
+        $this->pdo->exec('CREATE TABLE jos_bsms_studies (id INTEGER)');
         $this->pdo->exec('CREATE TABLE jos_modules_menu (moduleid INTEGER, menuid INTEGER)');
         $this->pdo->exec('CREATE TABLE jos_update_sites (update_site_id INTEGER PRIMARY KEY, name TEXT)');
         $this->pdo->exec('CREATE TABLE jos_update_sites_extensions (update_site_id INTEGER, extension_id INTEGER)');
@@ -219,6 +223,31 @@ final class TestSiteResetTest extends TestCase
             ['com_proclaim'],
             array_column($this->reset(['elements' => ['com_proclaim']], ['nope'])->familyRows(), 'element')
         );
+    }
+
+    #[Test]
+    public function table_matching_treats_underscores_literally(): void
+    {
+        /*
+         * `_` is a single-character wildcard in LIKE, so an unescaped
+         * `jos_bsms_%` also matches `josXbsmsY_decoy`. This list is handed
+         * straight to DROP TABLE, so the literal part must be escaped — the
+         * script this replaced did exactly that.
+         *
+         * `!` is the escape character rather than a backslash: `ESCAPE '\'`
+         * reaches MySQL as an unterminated string literal, which is how the
+         * first attempt at this broke the query while this test still passed —
+         * it exercised the pure function and not the SQL. SQLite has no
+         * information_schema, so the query itself is verified against live
+         * MySQL rather than here.
+         */
+        $reset = $this->reset(['tablePrefixes' => ['bsms_']]);
+
+        $method = new \ReflectionMethod($reset, 'escapeLike');
+
+        self::assertSame('jos!_bsms!_', $method->invoke(null, 'jos_bsms_'));
+        self::assertSame('a!%b', $method->invoke(null, 'a%b'));
+        self::assertSame('a!!b', $method->invoke(null, 'a!b'), 'the escape char is escaped first');
     }
 
     #[Test]


### PR DESCRIPTION
Found by running `cwm-reset-testsite --dry-run` against a **real populated test site** — the verification step that CI cannot provide, since CI always starts from a fresh Joomla with nothing installed.

## The bug

`_` is a single-character wildcard in `LIKE`. The pattern built for prefix `bsms_` on a site prefixed `jos_` was `jos_bsms_%`, which also matches `josXbsmsY…`. **That list is handed straight to `DROP TABLE`.**

The hand-rolled script this replaced escaped the underscores deliberately (`bsms\\_%`). The extraction did not carry that across.

No site was at risk in practice — on the live site the loose pattern matched exactly the same 27 tables and nothing else — but a latent over-match in a command that drops tables is not worth keeping.

## What the dry-run also confirmed

The migration is faithful. Comparing the new config's selection against the deleted script's clause, on a site with Proclaim actually installed:

| | |
|---|---|
| old script selects | **16** extension rows |
| new config selects | **16** extension rows |
| identical | **yes** |
| tables, old vs new | **27 vs 27, identical** |
| site total / untouched | 301 / **285** |

## The escape character is , not a backslash

The first attempt used `ESCAPE '\\'`, which reaches MySQL as an unterminated string literal and **broke the query outright** — while the unit test still passed, because it exercised the pure escaping function and not the SQL.

That is the same split that shipped the v1.23.0 fatal: the pure half correct, the integration wrong, and only a live run able to tell. `!` needs no quoting on either MySQL or PostgreSQL.

Verified against live MySQL after the fix: the escaped pattern returns the same 27 tables, and a wildcard-style name matches 0.

## Tests

`composer test` green — 526 PHPUnit / 1197 assertions, 166 shell assertions. The unit test pins the escaping; the query itself is verified against live MySQL, since SQLite has no `information_schema`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)