### PR TITLE
fix(release): authenticate the release probe and stop discarding op's stderr (#125, #126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`cwm-ars-publish` could not publish from a private repository.** It verified
+  the GitHub release with an unauthenticated `curl` to `api.github.com`, which
+  answers 404 on a private repo whether or not the release exists — so
+  publishing stopped and told the reader to create a release that was already
+  there, with no flag to skip the check. (#125)
+
+  The check was redundant as well as broken: the next two statements already
+  read the same release through authenticated `gh`. One authenticated call now
+  does both, so there is no second way for the check and the read to disagree,
+  and `gh`'s own message is printed when it fails.
+
+- **1Password failures reported no cause, in four commands.**
+  `2>/dev/null || echo ""` discarded `op`'s stderr *and* its exit status,
+  collapsing every failure into `Could not retrieve API token` — a misnamed item
+  or vault, the field not being `credential`, a locked account, an
+  unauthorized invocation, or `op` not signed in. (#126)
+
+  It cost real time: a release stopped that way while the same `op item get` run
+  by hand returned the credential, and the visible evidence pointed at composer
+  hard enough that a bug report against composer was drafted before the cause
+  turned out to be a transient 1Password authorization state — which `op`'s own
+  stderr names.
+
+  Retrieval now lives in `lib/optoken.sh`, shared by `cwm-ars-publish`,
+  `cwm-ars-list`, `cwm-ars-create-stream` and `cwm-ars-reorder`. The credential
+  comes back on stdout and nothing else ever does; the cause, the exit status
+  and the item and vault looked up go to stderr; and the error names
+  `ARS_API_TOKEN` as the bypass, which the script has always supported and no
+  failure message mentioned.
+
+  The fifth copy, in `cwm-article.sh`, captured stderr with `2>&1` — into the
+  token, so any warning `op` writes on success was prepended to the credential
+  and sent to an API. That is why the shared helper keeps the streams apart.
+
+- **`cwm-baseline` reported an authentication failure as "no usable baseline".**
+  Same `2>/dev/null || true` shape: a `gh` failure — auth, an unreachable
+  network, a typo'd repo — produced an empty release list and **exit 3**, which
+  callers are told to read as *not applicable, not a failure*. An upgrade phase
+  would stand down silently on an error it could have named. That is the #101
+  shape, in the tool written to fix #101; the two outcomes are now distinct, and
+  `--help` says so. (#125)
+
+### Fixed
+
 - **`cwm-reset-testsite` matched table prefixes with `_` treated as a
   wildcard.** `_` is a single-character wildcard in `LIKE`, so the pattern for
   prefix `bsms_` on a site prefixed `jos_` was `jos_bsms_%` — which also matches

--- a/scripts/ars-create-stream.sh
+++ b/scripts/ars-create-stream.sh
@@ -39,6 +39,10 @@
 #
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/optoken.sh
+source "${SCRIPT_DIR}/lib/optoken.sh"
+
 PROJECT_ROOT="$(pwd)"
 CONFIG_FILE="${PROJECT_ROOT}/cwm-build.config.json"
 
@@ -88,19 +92,8 @@ TOKEN_VAULT="${TOKEN_VAULT:-CWM}"
 API_BASE="${SITE_URL%/}/api/index.php/v1/ars"
 
 # --- Token ---
-if [ -n "${ARS_API_TOKEN:-}" ]; then
-    TOKEN="$ARS_API_TOKEN"
-elif command -v op >/dev/null 2>&1; then
-    TOKEN=$(op item get "$TOKEN_ITEM" --vault "$TOKEN_VAULT" --fields label=credential --reveal 2>/dev/null || echo "")
-else
-    echo "Error: ARS_API_TOKEN not set and 1Password CLI (op) not installed."
-    exit 1
-fi
-
-if [ -z "$TOKEN" ]; then
-    echo "Error: Could not retrieve API token."
-    exit 1
-fi
+# Retrieval, and the reason when it fails, live in lib/optoken.sh (#126).
+TOKEN="$(cwm_op_token "$TOKEN_ITEM" "$TOKEN_VAULT")" || exit 1
 
 echo "Creating update stream:"
 echo "  name:        $NAME"

--- a/scripts/ars-list.sh
+++ b/scripts/ars-list.sh
@@ -16,6 +16,10 @@
 #
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/optoken.sh
+source "${SCRIPT_DIR}/lib/optoken.sh"
+
 PROJECT_ROOT="$(pwd)"
 CONFIG_FILE="${PROJECT_ROOT}/cwm-build.config.json"
 
@@ -43,19 +47,8 @@ fi
 API_BASE="${SITE_URL%/}/api/index.php/v1/ars"
 
 # --- Token ---
-if [ -n "${ARS_API_TOKEN:-}" ]; then
-    TOKEN="$ARS_API_TOKEN"
-elif command -v op >/dev/null 2>&1; then
-    TOKEN=$(op item get "$TOKEN_ITEM" --vault "$TOKEN_VAULT" --fields label=credential --reveal 2>/dev/null || echo "")
-else
-    echo "Error: ARS_API_TOKEN not set and 1Password CLI (op) not installed."
-    exit 1
-fi
-
-if [ -z "$TOKEN" ]; then
-    echo "Error: Could not retrieve API token."
-    exit 1
-fi
+# Retrieval, and the reason when it fails, live in lib/optoken.sh (#126).
+TOKEN="$(cwm_op_token "$TOKEN_ITEM" "$TOKEN_VAULT")" || exit 1
 
 MODE="${1:-all}"
 

--- a/scripts/ars-publish.sh
+++ b/scripts/ars-publish.sh
@@ -59,6 +59,8 @@ PROJECT_ROOT="$(pwd)"
 source "${SCRIPT_DIR}/lib/version.sh"
 # shellcheck source=lib/ars.sh
 source "${SCRIPT_DIR}/lib/ars.sh"
+# shellcheck source=lib/optoken.sh
+source "${SCRIPT_DIR}/lib/optoken.sh"
 
 CONFIG_FILE="${PROJECT_ROOT}/cwm-build.config.json"
 
@@ -161,34 +163,40 @@ echo "  artifact:      ${ZIP_NAME}"
 echo "  download URL:  ${GITHUB_DOWNLOAD_URL}"
 
 # --- Get API token ---
-if [ -n "${ARS_API_TOKEN:-}" ]; then
-    TOKEN="$ARS_API_TOKEN"
-    echo "Using ARS_API_TOKEN from environment."
-elif command -v op >/dev/null 2>&1; then
-    echo "Retrieving API token from 1Password (item: '${TOKEN_ITEM}', vault: '${TOKEN_VAULT}')..."
-    TOKEN=$(op item get "$TOKEN_ITEM" --vault "$TOKEN_VAULT" --fields label=credential --reveal 2>/dev/null || echo "")
-else
-    echo "Error: ARS_API_TOKEN not set and 1Password CLI (op) not installed."
-    exit 1
-fi
+# Retrieval, and the reason when it fails, live in lib/optoken.sh (#126).
+TOKEN="$(cwm_op_token "$TOKEN_ITEM" "$TOKEN_VAULT")" || exit 1
 
-if [ -z "$TOKEN" ]; then
-    echo "Error: Could not retrieve API token."
-    exit 1
-fi
-
-# --- Verify GitHub release exists ---
+# --- Verify GitHub release exists, and read what we need from it ---
+#
+# Through `gh`, not a bare curl to api.github.com. The unauthenticated call
+# this replaces answered 404 on a PRIVATE repository whether or not the release
+# existed, so publishing stopped and told the reader to create a release that
+# was already there — with no flag to skip it, which left private-repo
+# consumers unable to publish at all (#125).
+#
+# It was redundant as well as broken: the statements below already read the
+# same release through authenticated `gh`. One call now does both, so there is
+# no second way for the check and the read to disagree.
 echo "Verifying GitHub release ${TAG}..."
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/${GH_OWNER}/${GH_REPO}/releases/tags/${TAG}")
+GH_ERR="$(mktemp)"
 
-if [ "$HTTP_CODE" != "200" ]; then
-    echo "Error: GitHub release ${TAG} not found (HTTP ${HTTP_CODE})."
-    echo "Create the release first: gh release create ${TAG} ${ZIP_PATH}"
+if ! RELEASE_DATE=$(gh release view "$TAG" --repo "${GH_OWNER}/${GH_REPO}" \
+        --json publishedAt --jq '.publishedAt' 2>"$GH_ERR"); then
+    echo "Error: GitHub release ${TAG} not found in ${GH_OWNER}/${GH_REPO}."
+
+    if [ -s "$GH_ERR" ]; then
+        sed 's/^/  gh: /' "$GH_ERR"
+    fi
+
+    echo "  Create it first: gh release create ${TAG} ${ZIP_PATH}"
+    echo "  If the release does exist, check that gh is authenticated for this repo:"
+    echo "    gh auth status"
+    rm -f "$GH_ERR"
     exit 1
 fi
 
-# --- Get release date and asset info from GitHub ---
-RELEASE_DATE=$(gh release view "$TAG" --repo "${GH_OWNER}/${GH_REPO}" --json publishedAt --jq '.publishedAt' 2>/dev/null | sed 's/T/ /' | sed 's/Z//' || echo "")
+rm -f "$GH_ERR"
+RELEASE_DATE=$(printf '%s' "$RELEASE_DATE" | sed 's/T/ /' | sed 's/Z//')
 
 ASSET_INFO=$(gh release view "$TAG" --repo "${GH_OWNER}/${GH_REPO}" --json assets --jq ".assets[] | select(.name==\"${ZIP_NAME}\")")
 

--- a/scripts/ars-reorder.sh
+++ b/scripts/ars-reorder.sh
@@ -23,6 +23,10 @@
 #
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/optoken.sh
+source "${SCRIPT_DIR}/lib/optoken.sh"
+
 PROJECT_ROOT="$(pwd)"
 CONFIG_FILE="${PROJECT_ROOT}/cwm-build.config.json"
 
@@ -87,19 +91,8 @@ if [ -z "$CATEGORY_ID" ]; then
 fi
 
 # --- Token ---
-if [ -n "${ARS_API_TOKEN:-}" ]; then
-    TOKEN="$ARS_API_TOKEN"
-elif command -v op >/dev/null 2>&1; then
-    TOKEN=$(op item get "$TOKEN_ITEM" --vault "$TOKEN_VAULT" --fields label=credential --reveal 2>/dev/null || echo "")
-else
-    echo "Error: ARS_API_TOKEN not set and 1Password CLI (op) not installed." >&2
-    exit 1
-fi
-
-if [ -z "$TOKEN" ]; then
-    echo "Error: Could not retrieve API token." >&2
-    exit 1
-fi
+# Retrieval, and the reason when it fails, live in lib/optoken.sh (#126).
+TOKEN="$(cwm_op_token "$TOKEN_ITEM" "$TOKEN_VAULT")" || exit 1
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 

--- a/scripts/baseline.sh
+++ b/scripts/baseline.sh
@@ -73,7 +73,8 @@ CONFIGURATION
 
 EXIT CODE
   0  a baseline is present in the output directory
-  1  an error: bad config, gh missing or failing, asset not on the release
+  1  an error: bad config, gh missing or failing (including an auth failure,
+     which is deliberately NOT reported as 3), asset not on the release
   3  no usable baseline exists — the first release of a project, or every
      candidate below the floor. NOT a failure. A caller that treats this as
      fatal blocks the first release of every new project; one that treats it
@@ -165,13 +166,33 @@ else
         exit 1
     fi
 
-    RELEASES="$(gh release list --repo "$REPO" --limit 100 \
-        --json tagName,isPrerelease \
-        --jq '.[] | [.tagName, (.isPrerelease | tostring)] | @tsv' 2>/dev/null || true)"
+    # `2>/dev/null || true` here would report an auth failure, an unreachable
+    # network or a typo'd repo as "no releases" — and exit 3, which callers are
+    # told to read as "not applicable, not a failure". A gate standing down
+    # silently on an error it could have named is the #101 shape, in the tool
+    # written to fix #101. So the two outcomes are kept apart (#125).
+    GH_ERR="$(mktemp)"
+
+    if ! RELEASES="$(gh release list --repo "$REPO" --limit 100 \
+            --json tagName,isPrerelease \
+            --jq '.[] | [.tagName, (.isPrerelease | tostring)] | @tsv' 2>"$GH_ERR")"; then
+        echo "Error: could not list releases for ${REPO}." >&2
+
+        if [ -s "$GH_ERR" ]; then
+            sed 's/^/  gh: /' "$GH_ERR" >&2
+        fi
+
+        echo "  This is not the same as having no usable baseline: check that gh is" >&2
+        echo "  authenticated for this repo (gh auth status), or name one explicitly" >&2
+        echo "  with --version <ver>." >&2
+        rm -f "$GH_ERR"
+        exit 1
+    fi
+
+    rm -f "$GH_ERR"
 
     if [ -z "$RELEASES" ]; then
         echo "NOT APPLICABLE: ${REPO} has no releases to use as a baseline." >&2
-        echo "                GitHub must also be reachable to resolve one." >&2
         exit 3
     fi
 

--- a/scripts/lib/optoken.sh
+++ b/scripts/lib/optoken.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# API-token retrieval from 1Password, with the reason preserved when it fails.
+#
+# Five scripts needed this and four of them discarded `op`'s stderr with
+# `2>/dev/null || echo ""`, collapsing every failure into one line with no
+# cause: item or vault misnamed, the field not being `credential`, the account
+# locked, the desktop app not having authorized this invocation yet, or `op`
+# not signed in at all. The `|| echo ""` threw away the exit status too.
+#
+# That is not a cosmetic loss. A release stopped with "Could not retrieve API
+# token" while the same `op item get` run by hand in the same terminal returned
+# the credential — the visible evidence pointed at composer's environment, and
+# a bug report against composer was drafted before the cause turned out to be a
+# transient authorization state on the 1Password side, which is exactly what
+# `op`'s own stderr says when it happens (#126).
+#
+# The fifth copy, in cwm-article.sh, captured stderr with `2>&1` — into the
+# token. That reads better on failure and is worse on success: any warning `op`
+# writes ends up prepended to the credential, and the caller sends it to an API.
+#
+# So: the credential comes back on stdout and nothing else ever does;
+# diagnostics go to stderr; the exit status is preserved.
+
+# Fetch the API token, preferring an environment variable over 1Password.
+#
+# The environment variable is the reliable path in CI and any non-interactive
+# context, and it is not obvious from a failure message that it exists — so it
+# is named in the diagnostics rather than only in the docs.
+#
+# Arguments:
+#   $1  1Password item title.
+#   $2  1Password vault.
+#   $3  Environment variable to prefer. Optional, defaults to ARS_API_TOKEN.
+#
+# Outputs:
+#   The token on stdout. Diagnostics on stderr, never on stdout.
+#
+# Returns:
+#   0 with a token, 1 with a reason printed.
+cwm_op_token() {
+    local item="$1"
+    local vault="$2"
+    local envvar="${3:-ARS_API_TOKEN}"
+    local preset token errfile status=0
+
+    preset="$(printenv "$envvar" 2>/dev/null || true)"
+
+    if [ -n "$preset" ]; then
+        printf '%s\n' "$preset"
+
+        return 0
+    fi
+
+    if ! command -v op > /dev/null 2>&1; then
+        {
+            echo "Error: ${envvar} is not set and the 1Password CLI (op) is not installed."
+            echo "  Set ${envvar}, or install op: https://developer.1password.com/docs/cli/"
+        } >&2
+
+        return 1
+    fi
+
+    errfile="$(mktemp)"
+
+    # stderr to a file, never merged into the value: `op` writes the credential
+    # to stdout and diagnostics to stderr, so keeping them apart is both what
+    # makes the diagnostic printable and what stops a warning being sent to an
+    # API as if it were a token.
+    token="$(op item get "$item" --vault "$vault" --fields label=credential --reveal 2>"$errfile")" || status=$?
+
+    if [ "$status" -eq 0 ] && [ -n "$token" ]; then
+        rm -f "$errfile"
+        printf '%s\n' "$token"
+
+        return 0
+    fi
+
+    {
+        echo "Error: could not retrieve the API token from 1Password."
+        echo "  item:  '${item}'"
+        echo "  vault: '${vault}'"
+        echo "  field: 'credential'"
+
+        if [ "$status" -ne 0 ]; then
+            echo "  op exited ${status}."
+        fi
+
+        if [ -s "$errfile" ]; then
+            sed 's/^/  op: /' "$errfile"
+        fi
+
+        echo "  Set ${envvar} to bypass 1Password entirely — the reliable path in CI."
+    } >&2
+
+    rm -f "$errfile"
+
+    return 1
+}

--- a/tests/shell/baseline.test.sh
+++ b/tests/shell/baseline.test.sh
@@ -183,4 +183,33 @@ assert_contains "$(run_baseline)" "Already present" \
 run_baseline --target 0.5.0 --print > /dev/null
 assert_equals "3" "$?" "no usable baseline exits 3"
 
+# --- An error is not "not applicable" ------------------------------------------
+# gh failing -- auth, network, a typo'd repo -- must NOT come back as 3. A
+# caller is told 3 means "nothing to upgrade from, carry on", so reporting an
+# auth failure that way makes the upgrade phase stand down silently: the #101
+# shape, in the tool written to fix #101 (#125).
+cat > "${WORK}/bin/gh" <<'FAILSTUB'
+#!/usr/bin/env bash
+echo "gh: Could not resolve to a Repository with the name 'acme/smoke'." >&2
+exit 1
+FAILSTUB
+chmod +x "${WORK}/bin/gh"
+
+ERR="$(run_baseline --print 2>&1)"
+STATUS=$?
+
+assert_equals "1" "$STATUS" "a gh failure exits 1, not the not-applicable 3"
+assert_contains "$ERR" "Could not resolve to a Repository" "gh's reason is surfaced, not discarded"
+assert_contains "$ERR" "not the same as having no usable baseline" "the two outcomes are told apart in words"
+
+# And a gh that simply reports no releases is still the not-applicable case.
+cat > "${WORK}/bin/gh" <<'EMPTYSTUB'
+#!/usr/bin/env bash
+exit 0
+EMPTYSTUB
+chmod +x "${WORK}/bin/gh"
+
+run_baseline --print > /dev/null 2>&1
+assert_equals "3" "$?" "a repo with genuinely no releases still exits 3"
+
 finish

--- a/tests/shell/optoken.test.sh
+++ b/tests/shell/optoken.test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/lib/optoken.sh.
+#
+# A stub `op` on PATH, so the failure modes can be exercised without a vault.
+# The point of this function is what it says when it fails, so most of these
+# assert on the diagnostic rather than the happy path.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+# shellcheck source=../../scripts/lib/optoken.sh
+source "${SCRIPT_DIR}/../../scripts/lib/optoken.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "${WORK}/bin"
+PATH="${WORK}/bin:${PATH}"
+
+# `op` that succeeds, and writes a warning to stderr as the real one may.
+cat > "${WORK}/bin/op" <<'STUB'
+#!/usr/bin/env bash
+case "${OP_MODE:-ok}" in
+    ok)      echo "warning: using desktop app integration" >&2; echo "s3cr3t-token" ;;
+    locked)  echo "[ERROR] 2026/08/17 authorization prompt dismissed or timed out" >&2; exit 1 ;;
+    missing) echo "[ERROR] 2026/08/17 \"CWM ARS API Token\" isn't an item in the \"CWM\" vault" >&2; exit 1 ;;
+    empty)   exit 0 ;;
+esac
+STUB
+chmod +x "${WORK}/bin/op"
+
+# --- The happy path returns only the credential --------------------------------
+# The real `op` writes warnings to stderr on success. Merging them into the
+# value — which one caller did — sends them to an API as if they were a token.
+OUT="$(OP_MODE=ok cwm_op_token 'CWM ARS API Token' 'CWM' 2>/dev/null)"
+assert_equals "s3cr3t-token" "$OUT" "only the credential reaches stdout, never op's warnings"
+
+# --- The environment variable wins, and op is not consulted --------------------
+OUT="$(ARS_API_TOKEN=from-env OP_MODE=locked cwm_op_token 'x' 'y' 2>/dev/null)"
+assert_equals "from-env" "$OUT" "ARS_API_TOKEN short-circuits 1Password"
+
+# A caller may name a different variable.
+OUT="$(CWM_OTHER_TOKEN=other cwm_op_token 'x' 'y' CWM_OTHER_TOKEN 2>/dev/null)"
+assert_equals "other" "$OUT" "the environment variable to prefer is configurable"
+
+# --- A failure names the cause -------------------------------------------------
+# The whole point: "Could not retrieve API token" with no cause sent a
+# maintainer after composer for an hour when the answer was in op's stderr.
+ERR="$(OP_MODE=locked cwm_op_token 'CWM ARS API Token' 'CWM' 2>&1 >/dev/null)"
+assert_contains "$ERR" "authorization prompt dismissed" "op's stderr is surfaced, not discarded"
+assert_contains "$ERR" "op exited 1" "the exit status is preserved rather than swallowed"
+assert_contains "$ERR" "ARS_API_TOKEN" "the bypass is named in the error, not only in the docs"
+assert_contains "$ERR" "CWM ARS API Token" "the item that was looked up is named"
+
+# A different cause reads differently, which is the point of preserving it.
+ERR="$(OP_MODE=missing cwm_op_token 'CWM ARS API Token' 'CWM' 2>&1 >/dev/null)"
+assert_contains "$ERR" "isn't an item" "a misnamed item is distinguishable from a locked account"
+
+# --- A zero exit with no credential is still a failure -------------------------
+if OP_MODE=empty cwm_op_token 'x' 'y' > /dev/null 2>&1; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: an empty credential with exit 0 is treated as failure"
+else
+    PASS=$((PASS + 1))
+fi
+
+# --- Nothing leaks to stdout on failure ----------------------------------------
+# A caller does TOKEN="$(cwm_op_token ...)". If diagnostics went to stdout the
+# token would become the error text and be sent to the API.
+OUT="$(OP_MODE=locked cwm_op_token 'x' 'y' 2>/dev/null)"
+assert_equals "" "$OUT" "failure writes nothing to stdout"
+
+# --- op absent is its own message ----------------------------------------------
+ERR="$(PATH="${WORK}/empty:/usr/bin:/bin" cwm_op_token 'x' 'y' 2>&1 >/dev/null)"
+assert_contains "$ERR" "not installed" "a missing op is reported as such"
+assert_contains "$ERR" "ARS_API_TOKEN" "and still names the bypass"
+
+finish


### PR DESCRIPTION
Closes #125. Closes #126.

Three failures of the same kind: a command knew why it failed and threw the reason away.

## #125 — private repos could not publish at all

`cwm-ars-publish` verified the GitHub release with an **unauthenticated** `curl` to `api.github.com`, which answers 404 on a private repo whether or not the release exists. Publishing stopped and told the reader to create a release that was already there — with no flag to skip it.

The check was **redundant as well as broken**: the two statements below it already read the same release through authenticated `gh`. One authenticated call now does both, so the check and the read cannot disagree, and `gh`'s own message is printed on failure.

## #126 — every 1Password failure looked identical

`2>/dev/null || echo ""` discarded `op`'s stderr *and* its exit status, collapsing a misnamed item, a misnamed vault, a wrong field, a locked account, an unauthorized invocation and a signed-out `op` into one line with no cause.

It cost a real release: the same `op item get` run by hand returned the credential, the visible evidence pointed at composer, and a bug report against composer was drafted before the cause turned out to be a transient 1Password authorization state — which `op`'s stderr names when it happens.

Retrieval moves to `lib/optoken.sh`, shared by all four ARS commands:

- the credential comes back on **stdout and nothing else ever does**
- the cause, the exit status, and the item and vault looked up go to **stderr**
- the error names `ARS_API_TOKEN` — supported all along, mentioned in no failure message

The fifth copy, in `cwm-article.sh`, captured stderr with `2>&1` — **into the token**, so a warning `op` writes on success was prepended to the credential and sent to an API. Keeping the streams apart is the point.

## The same bug in code from this morning

#125 speculated that `cwm-baseline` might share the shape. **It did**, with worse consequences: a `gh` failure produced an empty release list and **exit 3**, which its own `--help` tells callers to read as *not applicable, not a failure*. An upgrade phase would stand down silently on an error it could have named.

That is the #101 shape, inside the tool written this morning to fix #101. Error and not-applicable are now distinct:

```
Error: could not list releases for acme/private-repo.
  gh: Could not resolve to a Repository with the name 'acme/private-repo'.
  This is not the same as having no usable baseline: check that gh is
  authenticated for this repo (gh auth status), or name one explicitly
  with --version <ver>.
EXIT=1
```

and a repo with genuinely no releases still exits 3.

## Tests

`composer test` green — 526 PHPUnit / 1197 assertions, 178 shell assertions including 12 new.

Stub `op` and stub `gh`. Notably: **nothing reaches stdout on failure** — the caller does `TOKEN="$(cwm_op_token ...)"`, so diagnostics on stdout would *become* the token. Mutation-checked: restoring the swallow to `baseline.sh` fails three assertions.

## One near-miss worth recording

The first pass replaced the four call sites **without sourcing the new lib**, so the scripts called a function that did not exist. Caught before commit by checking load order — the same defect class as the v1.23.0 fatal, which is why I now check it every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)