### PR TITLE
docs(changelog): one Fixed heading under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   shape, in the tool written to fix #101; the two outcomes are now distinct, and
   `--help` says so. (#125)
 
-### Fixed
-
 - **`cwm-reset-testsite` matched table prefixes with `_` treated as a
   wildcard.** `_` is a single-character wildcard in `LIKE`, so the pattern for
   prefix `bsms_` on a site prefixed `jos_` was `jos_bsms_%` — which also matches


### PR DESCRIPTION
Prepending the #125/#126 entries added a **second** `### Fixed` under `[Unreleased]` rather than merging into the existing one, so the section heading appeared twice.

Worth fixing rather than leaving: `cwm-changelog` reads these headings to find section boundaries when generating the Joomla changelog XML, and a duplicated heading is exactly the kind of thing that produces a half-empty entry.

Content is unchanged — only the duplicate heading is removed. The four entries now sit under one `### Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)