### PR TITLE
feat(dev): add cwm-lint-workflows, finding path filters that guard nothing (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`cwm-lint-workflows` — find CI path filters that guard nothing.** A `paths:`
+  entry naming a file that has moved or been deleted stops guarding anything,
+  and in review it is indistinguishable from one that works: the job does not
+  run, the pull request is green, and nothing reports that a check was skipped.
+  That is the #101 shape, except the gate never starts. (#129)
+
+  It happened five times across two consumer repositories before this existed.
+  Proclaim's `e2e.yml` carries comments recording two of them; a third was an
+  entry for `build/reset-testsite.php` that outlived the file by a day, after
+  the shared command replaced it.
+
+  **A stale `paths-ignore` is a notice, not a failure.** It fails *open* — it
+  excludes nothing, so the job merely runs more often — and it is not reliably
+  wrong either: excluding a gitignored directory like `.claude/**` is deliberate
+  and invisible to a check that reads tracked files. Reporting those as errors
+  is how a linter starts crying wolf and gets switched off. Dogfooding found
+  exactly that case and the distinction was added because of it.
+
+  Patterns are compiled to regular expressions rather than passed to `glob()`,
+  which has no `**` — and `**` is most of what these filters use — then matched
+  against `git ls-files`, so a pattern covering only ignored build output is
+  correctly reported as covering nothing.
+
+  It does **not** catch the expensive half: a filter too *narrow*, where the job
+  that should have run did not because nobody listed the path. No static check
+  can see that. `--help` says so, and names the two habits that do cover it.
+
 ## [1.23.2] - 2026-08-17
 
 ### Fixed

--- a/bin/cwm-lint-workflows
+++ b/bin/cwm-lint-workflows
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# cwm-lint-workflows — find CI path filters that guard nothing.
+#
+# A `paths:` entry naming a file that has moved or been deleted silently stops
+# guarding anything, and reads in review exactly like one that works: the job
+# does not run, the pull request is green, and nothing says a check was skipped.
+#
+# Usage from a consuming project:
+#   composer lint-workflows
+#   composer lint-workflows -- --warn
+#   composer lint-workflows -- --help
+#
+set -euo pipefail
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec php "${TOOLS_DIR}/scripts/lint-workflows.php" "$@"

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
         "bin/cwm-baseline",
         "bin/cwm-lint-queries",
         "bin/cwm-lint-comments",
+        "bin/cwm-lint-workflows",
         "bin/cwm-reset-testsite",
         "bin/cwm-verify-update-stream"
     ],

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -70,6 +70,7 @@ ARS endpoint, category, and stream IDs come from the `ars` block in
 | Command | What it does |
 |---|---|
 | `cwm-lint-queries` | Enforce `$db->createQuery()` over `$db->getQuery(true)`. A consistency guard, not a correctness one — both return the same `DatabaseQuery`. **Exit 1** on findings; `--warn` to report without failing. The no-argument `$db->getQuery()` is a different operation and is never flagged. |
+| `cwm-lint-workflows` | Flag CI `paths:` filters that match no tracked file. A filter decides whether a job runs; an entry naming a deleted file guards nothing and reads in review exactly like one that works. **Exit 1** on stale `paths`; a stale `paths-ignore` is a notice only, since it fails open and may be a deliberate exclusion of a gitignored directory. |
 | `cwm-lint-comments` | Flag issue references written inside code comments — git blame already connects a line to its issue, so the citation adds nothing and goes stale. Only the comment part of a line is searched, so a hex colour or a number in a string is safe. `owner/repo#123` is allowed. **Exit 1** on findings; `--warn` to report without failing. |
 | `cwm-lint-deprecations` | Flag Joomla 6/7 upgrade blockers (`bootstrap.modal`, `data-bs-toggle=modal`, iframe modal handlers, `Joomla.Modal`, jQuery globals). **Exit 1** on findings; `--warn` to report without failing. See the [JS guide](javascript-and-joomladialog.md#71-cwm-lint-deprecations-find-j67-blockers). |
 | `cwm-sync-languages` | Sync and translate Joomla language files for the project. |

--- a/scripts/lint-workflows.php
+++ b/scripts/lint-workflows.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Flag workflow path filters that no longer match anything, and exit non-zero
+ * so CI can gate on it.
+ */
+
+require_once __DIR__ . '/../src/Dev/WorkflowPathScanner.php';
+
+use CWM\BuildTools\Dev\WorkflowPathScanner;
+
+$projectRoot = getcwd() ?: '.';
+
+if (in_array('--help', $argv, true) || in_array('-h', $argv, true)) {
+    echo <<<CWM_HELP
+cwm-lint-workflows — find CI path filters that guard nothing.
+
+WHAT IT DOES
+  Reads every `paths:` and `paths-ignore:` entry in .github/workflows and
+  reports the ones that match no tracked file.
+
+  A path filter decides whether a job runs. When an entry names a file that has
+  moved or been deleted, the entry silently guards nothing — and in review it
+  is indistinguishable from one that works. The job does not run, the pull
+  request is green, and nothing says a check was skipped.
+
+  That has happened five times across the CWM repositories. The most recent:
+  a `paths:` entry for build/reset-testsite.php outlived the file by a day,
+  after the shared cwm-reset-testsite command replaced it.
+
+PREREQUISITES
+  A git repository — the file list comes from `git ls-files`, so a pattern
+  matching only ignored build output is correctly reported as matching nothing.
+
+USAGE
+  composer lint-workflows             # scan, exit 1 on findings
+  composer lint-workflows -- --warn   # report but always exit 0
+  composer lint-workflows -- path/    # scan a different workflows directory
+
+OPTIONS
+  -w, --warn       Report findings but exit 0.
+  <path>           Workflows directory. Defaults to .github/workflows.
+
+WHAT IT DOES NOT CATCH
+  A filter that is too NARROW — the job that should have run and did not
+  because nobody listed the path. That is the expensive half and no static
+  check can see it: nothing here knows that test-install.sh reaches into
+  cwm/build-tools, or that an API suite runs admin models.
+
+  Two habits cover that better than a linter can. Treat the filter as part of
+  any change that gives a job a new dependency, the same reflex as adding a
+  require_once when a class gains a collaborator. And comment WHY each path is
+  listed, so the next reader can tell a deliberate entry from an accident.
+
+PATHS VS PATHS-IGNORE
+  Only a stale `paths` entry fails the run. It fails CLOSED: the job never
+  triggers and the pull request is green anyway.
+
+  A stale `paths-ignore` is reported as a notice and does not fail. It fails
+  OPEN — it excludes nothing, so the job merely runs more often — and it is
+  not reliably wrong: excluding a gitignored directory like .claude/** is
+  deliberate, and invisible to a check that reads tracked files.
+
+EXIT CODE
+  0  no stale `paths` entry (or --warn). Notices may still be printed.
+  1  one or more `paths` entries match nothing
+
+RELATED
+  composer lint-queries        # \$db->createQuery() over \$db->getQuery(true)
+  composer lint-comments       # issue references in code comments
+  composer lint-deprecations   # Joomla 6/7 upgrade blockers
+
+CWM_HELP;
+
+    exit(0);
+}
+
+$warnOnly = false;
+$dir      = null;
+
+foreach (array_slice($argv, 1) as $arg) {
+    if ($arg === '-w' || $arg === '--warn') {
+        $warnOnly = true;
+
+        continue;
+    }
+
+    if (!str_starts_with($arg, '-')) {
+        $dir = $arg;
+    }
+}
+
+$dir ??= '.github/workflows';
+$absolute = str_starts_with($dir, '/') ? $dir : $projectRoot . '/' . $dir;
+
+if (!is_dir($absolute)) {
+    echo "No workflows directory at {$dir} — nothing to check.\n";
+
+    exit(0);
+}
+
+// Tracked files, not the filesystem: a pattern matching only gitignored build
+// output is not coverage, and reporting it as fine would be the same false
+// reassurance this command exists to remove.
+exec('git -C ' . escapeshellarg($projectRoot) . ' ls-files 2>/dev/null', $files, $status);
+
+if ($status !== 0 || $files === []) {
+    fwrite(STDERR, "Error: could not list tracked files (is this a git repository?).\n");
+    fwrite(STDERR, "  Without the file list every pattern would look stale, which is worse\n");
+    fwrite(STDERR, "  than not checking.\n");
+
+    exit(1);
+}
+
+$workflows = glob($absolute . '/*.{yml,yaml}', GLOB_BRACE) ?: [];
+
+if ($workflows === []) {
+    echo "No workflow files in {$dir} — nothing to check.\n";
+
+    exit(0);
+}
+
+$findings = 0;
+$notices  = 0;
+$checked  = 0;
+
+foreach ($workflows as $workflow) {
+    $yaml    = (string) file_get_contents($workflow);
+    $entries = WorkflowPathScanner::extractPatterns($yaml);
+
+    if ($entries === []) {
+        continue;
+    }
+
+    $checked++;
+    $stale = WorkflowPathScanner::stalePatterns($yaml, $files);
+
+    if ($stale === []) {
+        continue;
+    }
+
+    $relative = str_replace($projectRoot . '/', '', $workflow);
+
+    foreach ($stale as $entry) {
+        /*
+         * Only a stale `paths` entry fails the run. It fails CLOSED — the job
+         * never triggers and the pull request is green anyway. A stale
+         * `paths-ignore` fails OPEN: it excludes nothing, so the job merely
+         * runs more often, and it is not reliably wrong either, because
+         * excluding a gitignored directory is both deliberate and invisible to
+         * a tracked-file check.
+         */
+        if ($entry['key'] === 'paths-ignore') {
+            printf("%s:%d\n    notice: paths-ignore '%s' matches no tracked file — harmless, and expected if the path is gitignored\n", $relative, $entry['line'], $entry['pattern']);
+            $notices++;
+
+            continue;
+        }
+
+        printf("%s:%d\n    %s: '%s' matches no tracked file\n", $relative, $entry['line'], $entry['key'], $entry['pattern']);
+        $findings++;
+    }
+}
+
+// Name what was examined even on success: a linter reporting "no findings"
+// over a directory whose filters it never parsed reads identically to one that
+// did the work.
+echo "Checked {$checked} workflow(s) with path filters against " . count($files) . " tracked files.\n";
+
+if ($findings === 0) {
+    echo $notices === 0
+        ? "Every filter entry matches something.\n"
+        : "No stale `paths` entry. {$notices} paths-ignore notice(s) above, which do not fail the run.\n";
+
+    exit(0);
+}
+
+fwrite(STDERR, "\nFound {$findings} filter entr" . ($findings === 1 ? 'y' : 'ies') . " matching nothing.\n");
+fwrite(STDERR, "Either the file moved and the filter should follow, or it was deleted and\n");
+fwrite(STDERR, "the entry should go. An entry that matches nothing guards nothing, and it\n");
+fwrite(STDERR, "reads in review exactly like one that works.\n");
+
+exit($warnOnly ? 0 : 1);

--- a/src/Dev/WorkflowPathScanner.php
+++ b/src/Dev/WorkflowPathScanner.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Dev;
+
+/**
+ * Finds workflow path filters that no longer match anything.
+ *
+ * A `paths:` filter decides whether a job runs. When an entry names a file that
+ * has moved or been deleted, the entry silently guards nothing — and in review
+ * it is indistinguishable from one that works, which is how a filter rots into
+ * false coverage. The job does not run, the pull request is green, and nothing
+ * reports that a check was skipped.
+ *
+ * That has happened five times across two CWM repositories. Proclaim's own
+ * `e2e.yml` carries comments recording two of them; a third was a `paths:` entry
+ * left behind after `build/reset-testsite.php` was deleted in favour of the
+ * shared command, and it sat there until this check was written.
+ *
+ * ## Why not a YAML parser
+ *
+ * This package has no YAML dependency and adding one for a single lint would put
+ * a runtime dependency into every consumer's tree. The block being read is
+ * highly regular — a `paths:` key followed by a `- 'pattern'` list — so it is
+ * extracted directly, and the extractor is a pure function tested against
+ * fixture workflows including the awkward shapes (comments between entries,
+ * unquoted and double-quoted values, several filters in one file).
+ *
+ * ## Why not glob()
+ *
+ * PHP's `glob()` has no `**`, which is most of what these filters use. Patterns
+ * are translated to regular expressions and matched against the repository's
+ * tracked files, which is also more accurate than the filesystem: a pattern
+ * matching only ignored build output is not real coverage.
+ */
+final class WorkflowPathScanner
+{
+    /**
+     * Every path pattern a workflow filters on, with the key it came from.
+     *
+     * Both `paths` and `paths-ignore` are read, but they are not the same
+     * defect and the caller is expected to treat them differently.
+     *
+     * A stale `paths` entry fails CLOSED: the job it should have triggered does
+     * not run and the pull request is green. A stale `paths-ignore` entry fails
+     * OPEN: it excludes nothing, so the job merely runs more often than needed.
+     *
+     * The second is also not reliably a defect at all. Excluding a directory
+     * that is gitignored — `.claude/**`, say — is deliberate and correct, and
+     * indistinguishable here from an exclusion whose target was deleted, because
+     * neither appears in the tracked file list. Reporting those as errors is how
+     * a linter starts crying wolf and gets switched off.
+     *
+     * @return list<array{key: string, pattern: string, line: int}>
+     */
+    public static function extractPatterns(string $yaml): array
+    {
+        $found  = [];
+        $key    = null;
+        $indent = 0;
+
+        foreach (explode("\n", $yaml) as $index => $raw) {
+            $line = rtrim($raw);
+
+            if (trim($line) === '' || str_starts_with(trim($line), '#')) {
+                continue;
+            }
+
+            $lineIndent = \strlen($line) - \strlen(ltrim($line));
+
+            if (preg_match('/^\s*(paths|paths-ignore)\s*:\s*(.*)$/', $line, $m) === 1) {
+                $inline = trim($m[2]);
+
+                // Flow form: paths: [ 'a', 'b' ]
+                if ($inline !== '' && $inline !== '|' && $inline !== '>') {
+                    foreach (self::splitFlowSequence($inline) as $pattern) {
+                        $found[] = ['key' => $m[1], 'pattern' => $pattern, 'line' => $index + 1];
+                    }
+
+                    $key = null;
+
+                    continue;
+                }
+
+                $key    = $m[1];
+                $indent = $lineIndent;
+
+                continue;
+            }
+
+            if ($key === null) {
+                continue;
+            }
+
+            // A list item belonging to the filter, i.e. indented past its key.
+            if ($lineIndent > $indent && preg_match('/^\s*-\s*(.+)$/', $line, $m) === 1) {
+                $found[] = ['key' => $key, 'pattern' => self::unquote(trim($m[1])), 'line' => $index + 1];
+
+                continue;
+            }
+
+            // Anything at or left of the key's indentation ends the block.
+            if ($lineIndent <= $indent) {
+                $key = null;
+            }
+        }
+
+        return $found;
+    }
+
+    /**
+     * Whether a GitHub path pattern matches a repository-relative file.
+     *
+     * Translated to a regular expression rather than passed to `glob()`, which
+     * has no `**` — and `**` is most of what these filters use.
+     *
+     * A leading `!` is a negation in GitHub's syntax. For "does this still match
+     * anything" the negation is irrelevant, so it is stripped: an exclusion that
+     * excludes nothing is exactly as stale as an inclusion that includes
+     * nothing.
+     */
+    public static function matches(string $pattern, string $file): bool
+    {
+        return preg_match(self::toRegex($pattern), $file) === 1;
+    }
+
+    /**
+     * The patterns in $yaml that match none of $files.
+     *
+     * @param  list<string>  $files  Repository-relative paths, e.g. from `git ls-files`.
+     *
+     * @return list<array{key: string, pattern: string, line: int}>
+     */
+    public static function stalePatterns(string $yaml, array $files): array
+    {
+        $stale = [];
+
+        foreach (self::extractPatterns($yaml) as $entry) {
+            foreach ($files as $file) {
+                if (self::matches($entry['pattern'], $file)) {
+                    continue 2;
+                }
+            }
+
+            $stale[] = $entry;
+        }
+
+        return $stale;
+    }
+
+    /**
+     * Compile a GitHub path pattern to a PCRE.
+     *
+     * `**` crosses directory separators, `*` does not, `?` is one character
+     * other than a separator. A pattern with no wildcard matches the path itself
+     * or anything beneath it, which is how GitHub treats a bare directory.
+     */
+    private static function toRegex(string $pattern): string
+    {
+        $pattern = ltrim($pattern, '!');
+        $pattern = ltrim($pattern, '/');
+        $out     = '';
+        $length  = \strlen($pattern);
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $pattern[$i];
+
+            if ($char === '*') {
+                if ($i + 1 < $length && $pattern[$i + 1] === '*') {
+                    $out .= '.*';
+                    $i++;
+
+                    // `**/` should also match zero directories.
+                    if ($i + 1 < $length && $pattern[$i + 1] === '/') {
+                        $i++;
+                    }
+
+                    continue;
+                }
+
+                $out .= '[^/]*';
+
+                continue;
+            }
+
+            if ($char === '?') {
+                $out .= '[^/]';
+
+                continue;
+            }
+
+            $out .= preg_quote($char, '~');
+        }
+
+        // A bare path matches itself or anything under it: 'admin' covers
+        // 'admin/src/X.php', which is what GitHub does with a directory.
+        if (!str_contains($pattern, '*') && !str_contains($pattern, '?')) {
+            return '~^' . $out . '(?:/.*)?$~';
+        }
+
+        return '~^' . $out . '$~';
+    }
+
+    /** Split `[ 'a', "b", c ]` into its members. */
+    private static function splitFlowSequence(string $inline): array
+    {
+        $inline = trim($inline, "[] \t");
+
+        if ($inline === '') {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (string $part): string => self::unquote(trim($part)),
+            explode(',', $inline)
+        ), static fn (string $p): bool => $p !== ''));
+    }
+
+    /** Strip one layer of matching quotes, and any trailing comment. */
+    private static function unquote(string $value): string
+    {
+        if (preg_match('/^([\'"])(.*?)\1/', $value, $m) === 1) {
+            return $m[2];
+        }
+
+        // Unquoted scalar: a ` #` starts a comment.
+        $value = preg_replace('/\s+#.*$/', '', $value) ?? $value;
+
+        return trim($value);
+    }
+}

--- a/tests/Dev/WorkflowPathScannerTest.php
+++ b/tests/Dev/WorkflowPathScannerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Dev;
+
+use CWM\BuildTools\Dev\WorkflowPathScanner;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Extraction and matching, against committed fixture workflows.
+ *
+ * Both halves can be wrong quietly. An extractor that misses a block reports a
+ * clean filter for one it never read, and a matcher that is too generous reports
+ * every stale entry as fine — either way the check passes and proves nothing,
+ * which is the failure it exists to catch.
+ */
+final class WorkflowPathScannerTest extends TestCase
+{
+    private function fixture(string $name): string
+    {
+        return (string) file_get_contents(__DIR__ . '/../fixtures/workflows/' . $name);
+    }
+
+    #[Test]
+    public function reads_every_filter_in_a_file(): void
+    {
+        // Two blocks: push and pull_request. Reading only the first would
+        // report a clean filter for one it never opened.
+        $patterns = array_column(WorkflowPathScanner::extractPatterns($this->fixture('typical.yml')), 'pattern');
+
+        self::assertSame([
+            'admin/**',
+            'site/**',
+            'api/**',
+            'tests/e2e/**',
+            'build/test-install.sh',
+            'composer.lock',
+            'build/reset-testsite.php',
+            '.github/workflows/e2e.yml',
+        ], $patterns);
+    }
+
+    #[Test]
+    public function handles_the_shapes_real_workflows_use(): void
+    {
+        $entries = WorkflowPathScanner::extractPatterns($this->fixture('typical.yml'));
+
+        // Comments between entries are skipped, not read as patterns.
+        self::assertNotContains('# A comment between entries, as the real files carry.', array_column($entries, 'pattern'));
+
+        // Single-quoted, double-quoted and bare scalars all resolve to the value.
+        self::assertContains('tests/e2e/**', array_column($entries, 'pattern'), 'double-quoted');
+        self::assertContains('build/test-install.sh', array_column($entries, 'pattern'), 'unquoted');
+    }
+
+    #[Test]
+    public function reads_flow_sequences_and_paths_ignore(): void
+    {
+        $entries = WorkflowPathScanner::extractPatterns($this->fixture('flow-and-ignore.yml'));
+
+        self::assertSame(['src/**', 'docs/**', 'docs/legacy/**'], array_column($entries, 'pattern'));
+
+        // The key is kept: a stale paths-ignore excludes nothing, which is the
+        // same defect but reads differently in a report.
+        self::assertSame(['paths', 'paths', 'paths-ignore'], array_column($entries, 'key'));
+    }
+
+    #[Test]
+    public function a_workflow_with_no_filters_yields_nothing(): void
+    {
+        // 'paths:' appearing inside a run step must not be read as a filter.
+        self::assertSame([], WorkflowPathScanner::extractPatterns($this->fixture('no-filters.yml')));
+    }
+
+    #[Test]
+    public function double_star_crosses_directories_and_single_star_does_not(): void
+    {
+        self::assertTrue(WorkflowPathScanner::matches('admin/**', 'admin/src/Model/X.php'));
+        self::assertTrue(WorkflowPathScanner::matches('admin/**', 'admin/x.php'));
+        self::assertFalse(WorkflowPathScanner::matches('admin/*.php', 'admin/src/X.php'), 'single star stops at /');
+        self::assertTrue(WorkflowPathScanner::matches('admin/*.php', 'admin/X.php'));
+    }
+
+    #[Test]
+    public function a_bare_path_matches_itself_or_anything_beneath(): void
+    {
+        // GitHub treats a directory entry as covering its contents.
+        self::assertTrue(WorkflowPathScanner::matches('composer.lock', 'composer.lock'));
+        self::assertTrue(WorkflowPathScanner::matches('tests', 'tests/Dev/XTest.php'));
+        self::assertFalse(WorkflowPathScanner::matches('composer.lock', 'composer.json'));
+    }
+
+    #[Test]
+    public function a_negation_is_judged_on_whether_it_still_matches(): void
+    {
+        // An exclusion that excludes nothing is as stale as an inclusion that
+        // includes nothing, so the ! is stripped for this question.
+        self::assertTrue(WorkflowPathScanner::matches('!docs/**', 'docs/index.md'));
+    }
+
+    #[Test]
+    public function finds_the_entry_that_matches_nothing(): void
+    {
+        // The case this class exists for: build/reset-testsite.php was deleted
+        // when the shared command replaced it, and the filter entry outlived it.
+        $files = [
+            'admin/src/Model/X.php',
+            'site/view.php',
+            'api/src/X.php',
+            'tests/e2e/spec.js',
+            'build/test-install.sh',
+            'composer.lock',
+            '.github/workflows/e2e.yml',
+        ];
+
+        $stale = WorkflowPathScanner::stalePatterns($this->fixture('typical.yml'), $files);
+
+        self::assertCount(1, $stale);
+        self::assertSame('build/reset-testsite.php', $stale[0]['pattern']);
+        self::assertSame('paths', $stale[0]['key']);
+        self::assertGreaterThan(0, $stale[0]['line'], 'the line number locates it for the reader');
+    }
+
+    #[Test]
+    public function a_filter_that_all_resolves_reports_nothing(): void
+    {
+        $files = ['src/a.php', 'docs/index.md', 'docs/legacy/old.md'];
+
+        self::assertSame([], WorkflowPathScanner::stalePatterns($this->fixture('flow-and-ignore.yml'), $files));
+    }
+}

--- a/tests/fixtures/workflows/flow-and-ignore.yml
+++ b/tests/fixtures/workflows/flow-and-ignore.yml
@@ -1,0 +1,8 @@
+on:
+  pull_request:
+    paths: [ 'src/**', "docs/**" ]
+    paths-ignore:
+      - 'docs/legacy/**'
+jobs:
+  build:
+    runs-on: ubuntu-latest

--- a/tests/fixtures/workflows/no-filters.yml
+++ b/tests/fixtures/workflows/no-filters.yml
@@ -1,0 +1,7 @@
+on:
+  workflow_dispatch:
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "paths: not a filter, just output"

--- a/tests/fixtures/workflows/typical.yml
+++ b/tests/fixtures/workflows/typical.yml
@@ -1,0 +1,25 @@
+name: E2E
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'admin/**'
+      - 'site/**'
+  pull_request:
+    branches: [ "development" ]
+    paths:
+      # A comment between entries, as the real files carry.
+      - 'api/**'
+      - "tests/e2e/**"
+      - build/test-install.sh
+      - 'composer.lock'
+      # This one names a file that no longer exists.
+      - 'build/reset-testsite.php'
+      - '.github/workflows/e2e.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7


### PR DESCRIPTION
Closes the automatable half of #129.

## The problem

A `paths:` filter decides whether a job runs. When an entry names a file that has moved or been deleted it stops guarding anything — and in review it is indistinguishable from one that works. The job does not run, the pull request is green, and nothing reports that a check was skipped. That is the #101 shape, except the gate never starts.

Five instances across two consumer repositories before this existed. Proclaim's `e2e.yml` carries comments recording two of them; a third was an entry for `build/reset-testsite.php` that outlived the file by a day.

## The design decision came from dogfooding, not from planning

The first version treated `paths` and `paths-ignore` as the same defect — the class docblock said so explicitly. Running it against the consumers immediately flagged CWMLivingWord's `.claude/**` exclusion, which is **correct**: the directory exists, it is gitignored, and excluding it from triggering CI is deliberate. A tracked-file check cannot distinguish that from an exclusion whose target was deleted.

So the two are now separated by **how they fail**:

| key | failure mode | treatment |
|---|---|---|
| `paths` | fails **closed** — job never triggers | error, exit 1 |
| `paths-ignore` | fails **open** — job merely runs more often | notice, exit 0 |

Reporting the second as an error is how a linter starts crying wolf and gets switched off, which would have cost more than the decay it was reporting.

## Implementation notes

**No YAML dependency.** Adding one for a single lint would put a runtime dependency in every consumer's tree, and the block being read is regular enough to extract directly.

**No `glob()`.** It has no `**`, and `**` is most of what these filters use. Patterns compile to regular expressions and match against `git ls-files`, so a pattern covering only ignored build output is correctly reported as covering nothing.

## Tests

`composer test` green — 535 PHPUnit / 1217 assertions, 178 shell assertions.

Nine cases against committed fixture workflows carrying the awkward shapes: comments between entries, quoted and unquoted scalars, flow sequences, several filters in one file, and a `paths:` string inside a `run` step that must **not** be read as a filter.

**Mutation-checked against the real defect** — reintroducing `build/reset-testsite.php` into Proclaim's filter:

```
.github/workflows/e2e.yml:61
    paths: 'build/reset-testsite.php' matches no tracked file
exit=1
```

## What it does not do

It does not catch a filter that is too **narrow** — the job that should have run and did not because nobody listed the path. That is the expensive half, and no static check can see it. `--help` says so plainly and names the two habits that cover it: treat the filter as part of any change that gives a job a new dependency, and comment *why* each path is listed.

The other question #129 raises — whether `paths:` allow-lists are the right shape at all, given they fail closed on anything nobody thought of — is untouched here and still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
