### PR TITLE
fix(release): publish the checksums of the served asset, not the local file (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`cwm-ars-publish` advertised the checksums of a local file, not of the bytes
+  users download.** An ARS `type: link` item points at the GitHub release asset,
+  so a site downloads *that* — not whatever sat in `build/dist` when publish
+  ran. When the two diverged, Joomla fetched the asset, compared it against the
+  advertised `sha512`, and refused the update, while the feed stayed valid and
+  ARS reported success. It went unnoticed across two consecutive
+  `pkg_licenseportal` releases. (#132)
+
+  The local file is now only trusted once it is *shown* to be the served bytes:
+  the asset's `size` and `sha256` digest come back from `gh release view`, and
+  when either disagrees — or no digest is reported — the asset itself is
+  downloaded and hashed. The common case still costs nothing, and the run says
+  which path it took.
+
+  If the asset cannot be downloaded to hash, publishing **stops**. Advertising
+  the local checksums there would break the integrity check on every site, which
+  is worse than not publishing.
+
+  The comparison is in `lib/ars.sh` and tested against both observed failures:
+  the 1.5.1 pair, which a size check alone would have caught, and the 1.5.0
+  pair, which had *identical* byte counts and different content — the case that
+  makes size alone insufficient.
+
 ## [1.24.0] - 2026-08-17
 
 ### Added

--- a/scripts/ars-publish.sh
+++ b/scripts/ars-publish.sh
@@ -206,14 +206,63 @@ if [ -z "$ASSET_INFO" ]; then
 fi
 
 FILESIZE=$(echo "$ASSET_INFO" | python3 -c "import json,sys; print(json.load(sys.stdin)['size'])" 2>/dev/null || echo "0")
+ASSET_DIGEST=$(echo "$ASSET_INFO" | python3 -c "import json,sys; print(json.load(sys.stdin).get('digest') or '')" 2>/dev/null || echo "")
 
-# --- Compute checksums from local file ---
+# --- Checksums must describe the bytes users download ---
+#
+# This item is `type: link`: it points at the GitHub asset, so a site downloads
+# THAT, not whatever is in build/dist right now. Publishing the local file's
+# checksums when the two differ makes Joomla fetch the asset, compare it
+# against the advertised sha512 and refuse the update — while the feed stays
+# valid and ARS reports success (#132).
+#
+# So the local file is only trusted once it is shown to be the served bytes.
+# When it is not, the asset itself is downloaded and hashed.
 echo "Computing checksums..."
-MD5=$(md5 -q "$ZIP_PATH" 2>/dev/null || md5sum "$ZIP_PATH" 2>/dev/null | cut -d' ' -f1 || echo "")
-SHA1=$(shasum -a 1 "$ZIP_PATH" 2>/dev/null | cut -d' ' -f1 || echo "")
-SHA256=$(shasum -a 256 "$ZIP_PATH" 2>/dev/null | cut -d' ' -f1 || echo "")
-SHA384=$(shasum -a 384 "$ZIP_PATH" 2>/dev/null | cut -d' ' -f1 || echo "")
-SHA512=$(shasum -a 512 "$ZIP_PATH" 2>/dev/null | cut -d' ' -f1 || echo "")
+HASH_SOURCE="$ZIP_PATH"
+LOCAL_SIZE=$(wc -c < "$ZIP_PATH" | tr -d ' ')
+LOCAL_SHA256=$(shasum -a 256 "$ZIP_PATH" 2>/dev/null | cut -d' ' -f1 || echo "")
+
+cwm_ars_local_matches_asset "$LOCAL_SIZE" "$LOCAL_SHA256" "$FILESIZE" "$ASSET_DIGEST"
+MATCH_STATUS=$?
+
+if [ "$MATCH_STATUS" -ne 0 ]; then
+    if [ "$MATCH_STATUS" -eq 1 ]; then
+        echo "  The local artifact is NOT the published asset:"
+        echo "    local: ${LOCAL_SIZE} bytes, sha256 ${LOCAL_SHA256}"
+        echo "    asset: ${FILESIZE} bytes, ${ASSET_DIGEST:-no digest reported}"
+        echo "  Hashing the asset instead, so the update stream advertises what sites receive."
+        echo "  (A rebuild between build and publish is the usual cause: gzip records an"
+        echo "   mtime, so .gz output differs from identical sources.)"
+    else
+        echo "  GitHub reported no digest for this asset, so the local file cannot be"
+        echo "  shown to be the served bytes. Hashing the asset to be certain."
+    fi
+
+    ASSET_DIR=$(mktemp -d)
+
+    if gh release download "$TAG" --repo "${GH_OWNER}/${GH_REPO}" \
+            --pattern "$ZIP_NAME" --dir "$ASSET_DIR" >/dev/null 2>&1 \
+        && [ -f "${ASSET_DIR}/${ZIP_NAME}" ]; then
+        HASH_SOURCE="${ASSET_DIR}/${ZIP_NAME}"
+    else
+        echo "Error: could not download ${ZIP_NAME} from ${TAG} to checksum it."
+        echo "  Publishing the local file's checksums would advertise bytes no site receives,"
+        echo "  and every update would fail its integrity check. Refusing to publish."
+        rm -rf "$ASSET_DIR"
+        exit 1
+    fi
+else
+    echo "  Local artifact matches the published asset (${LOCAL_SIZE} bytes, sha256 verified)."
+fi
+
+MD5=$(md5 -q "$HASH_SOURCE" 2>/dev/null || md5sum "$HASH_SOURCE" 2>/dev/null | cut -d' ' -f1 || echo "")
+SHA1=$(shasum -a 1 "$HASH_SOURCE" 2>/dev/null | cut -d' ' -f1 || echo "")
+SHA256=$(shasum -a 256 "$HASH_SOURCE" 2>/dev/null | cut -d' ' -f1 || echo "")
+SHA384=$(shasum -a 384 "$HASH_SOURCE" 2>/dev/null | cut -d' ' -f1 || echo "")
+SHA512=$(shasum -a 512 "$HASH_SOURCE" 2>/dev/null | cut -d' ' -f1 || echo "")
+
+[ -n "${ASSET_DIR:-}" ] && rm -rf "$ASSET_DIR"
 
 # --- Assemble the release notes ---
 #

--- a/scripts/lib/ars.sh
+++ b/scripts/lib/ars.sh
@@ -86,3 +86,58 @@ ok = isinstance(v, list) and len(v) > 0 \
 sys.exit(0 if ok else 1)
 " "$1" 2>/dev/null
 }
+
+# Whether a local artifact is byte-identical to the asset users will download.
+#
+# ARS items of `type: link` point at the GitHub release asset, so the bytes a
+# site downloads are the asset's — not the file that happened to be in
+# build/dist when publish ran. Publishing the local file's checksums when the
+# two differ makes Joomla download the asset, compare it against the advertised
+# sha512, and refuse the update. The feed stays valid and ARS reports success,
+# so the only place the mismatch shows is a site trying to update.
+#
+# It is not a rare accident. gzip stores an mtime in its header, so any project
+# whose build emits `.gz` — the shared rollup config does — produces different
+# bytes from identical sources. A rebuild anywhere between building and
+# publishing is enough.
+#
+# Compared here rather than by always downloading, so the common case stays
+# cheap: GitHub reports the asset's size and a sha256 digest, and when both
+# agree with the local file the local checksums are provably the served ones.
+#
+# Arguments:
+#   $1  Local file size in bytes.
+#   $2  Local sha256, lowercase hex.
+#   $3  Asset size in bytes, from `gh release view --json assets`.
+#   $4  Asset digest, e.g. `sha256:abc…`. May be empty on older releases.
+#
+# Returns:
+#   0  identical — the local checksums describe the served bytes
+#   1  different — the asset must be hashed instead
+#   2  undecidable — no digest to compare, so the asset must be hashed
+cwm_ars_local_matches_asset() {
+    local local_size="$1"
+    local local_sha256="$2"
+    local asset_size="$3"
+    local asset_digest="$4"
+
+    # Size is the cheap half and catches the common case on its own: it would
+    # have caught pkg_licenseportal 1.5.1 (392410 vs 388404 bytes) for free.
+    if [ -n "$asset_size" ] && [ "$asset_size" != "$local_size" ]; then
+        return 1
+    fi
+
+    # No digest — GitHub added the field relatively recently, and an older
+    # release will not carry one. Equal sizes are not proof: 1.5.0 had
+    # identical byte counts and different content, which is exactly the case
+    # that hid for two releases.
+    if [ -z "$asset_digest" ] || [ "$asset_digest" = "null" ]; then
+        return 2
+    fi
+
+    if [ "${asset_digest#sha256:}" = "$local_sha256" ]; then
+        return 0
+    fi
+
+    return 1
+}

--- a/tests/shell/ars.test.sh
+++ b/tests/shell/ars.test.sh
@@ -52,4 +52,35 @@ assert_equals "fail" "$(check_envs '{"45": true}')" "an object is refused"
 assert_equals "fail" "$(check_envs '["45", ""]')" "a blank id inside the array is refused"
 assert_equals "fail" "$(check_envs 'not json')" "malformed JSON is refused"
 
+# --- Local artifact vs the asset users download (#132) --------------------------
+# ARS `type: link` items point at the GitHub asset, so publishing the local
+# file's checksums when the two differ makes Joomla refuse the update while the
+# feed stays valid and ARS reports success.
+
+# Identical: the local checksums provably describe the served bytes.
+cwm_ars_local_matches_asset 389213 "abc123" 389213 "sha256:abc123"
+assert_equals "0" "$?" "same size and digest means the local file is the served bytes"
+
+# Different size — the cheap half. This is pkg_licenseportal 1.5.1: 392410
+# served against 388404 local, which a size check alone would have caught.
+cwm_ars_local_matches_asset 388404 "31d1fb0d6f36" 392410 "sha256:f7cf344d2a33"
+assert_equals "1" "$?" "a size difference is enough to know they differ"
+
+# Same size, different content. This is 1.5.0, and the reason size alone is not
+# enough: identical byte counts, different bytes, hidden for two releases.
+cwm_ars_local_matches_asset 389213 "72e5ae2db827" 389213 "sha256:b3c16981a684"
+assert_equals "1" "$?" "equal sizes with different digests still differ"
+
+# No digest: undecidable, not "fine". GitHub added the field recently, so an
+# older release carries none — and 1.5.0 proves equal sizes prove nothing.
+cwm_ars_local_matches_asset 389213 "72e5ae2db827" 389213 ""
+assert_equals "2" "$?" "a missing digest is undecidable rather than a match"
+
+cwm_ars_local_matches_asset 389213 "72e5ae2db827" 389213 "null"
+assert_equals "2" "$?" "gh's literal null is treated as no digest"
+
+# A size mismatch outranks a missing digest: already known to differ.
+cwm_ars_local_matches_asset 100 "aaa" 200 ""
+assert_equals "1" "$?" "a size difference decides even without a digest"
+
 finish


### PR DESCRIPTION
Closes #132.

## The fix

An ARS `type: link` item points at the GitHub release asset, so a site downloads **that**, not whatever sat in `build/dist` when publish ran. `ars-publish.sh` hashed the local file and published those checksums.

The local file is now trusted only once it is *shown* to be the served bytes. `gh release view --json assets` already returned the asset's `size`; it also returns a `sha256` **digest**. When either disagrees — or no digest is reported — the asset itself is downloaded and hashed.

The matching case costs nothing extra, and the run says which path it took:

```
Computing checksums...
  Local artifact matches the published asset (389213 bytes, sha256 verified).
```

or

```
  The local artifact is NOT the published asset:
    local: 388404 bytes, sha256 31d1fb0d6f36
    asset: 392410 bytes, sha256:f7cf344d2a33
  Hashing the asset instead, so the update stream advertises what sites receive.
```

**If the asset cannot be downloaded to hash, publishing stops.** Advertising the local checksums there would fail the integrity check on every site — worse than not publishing.

## Tests

`composer test` green — 535 PHPUnit / 1217 assertions, 184 shell assertions.

The comparison lives in `lib/ars.sh` and is tested against both observed failures:

| case | why it matters |
|---|---|
| 1.5.1 — 392410 vs 388404 bytes | a size check alone would have caught it |
| 1.5.0 — **identical** byte counts, different content | which is why size alone is not enough |
| no digest reported | returns *undecidable*, not "match" — 1.5.0 proves equal sizes prove nothing |

Mutation-checked: forcing the digest comparison to succeed fails an assertion.

## What I did **not** do, because the premise did not hold

The issue attributes the divergence to gzip storing an mtime, and suggests `mtime: 0` for `rollup-plugin-gzip`. I made that change, then checked it:

```
default identical: true
mtime bytes (4..8): 00000000 vs 00000000
```

Node's `zlib` already writes that field as zero, and `rollup-plugin-gzip` passes `gzipOptions` straight to `zlib.gzip`, defaulting it to `{}`. Two builds of identical input are byte-identical. So the change would have been a no-op that implied a fix, and I reverted it.

That leaves the real cause open. The issue reports plain `.js` and `.min.js` differing too — so the gzip **input** differed, meaning the JS build itself emitted different bytes. A rebuild at a different `__DEPLOY_VERSION__` substitution state is the most likely candidate, since `cwm-release` substitutes tokens at step 2 and builds at step 3. Worth its own investigation rather than a guess.

**The checksum fix stands regardless of the cause**, because it hashes what is actually served.
