### PR TITLE
feat(build): make artifacts reproducible by fixing zip entry timestamps (#134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Artifacts are now reproducible: the same source tree produces the same
+  bytes.** `ZipArchive` records each entry's filesystem mtime, so a rebuild that
+  changed nothing but timestamps produced a different artifact — at the *same
+  size*, which is why it stayed invisible. Every entry is now written at a fixed
+  timestamp through `Build\ZipEntry`. (#134)
+
+  This is the cause behind #132. `pkg_licenseportal` 1.5.0 published a local
+  artifact and a GitHub asset of identical length, 389213 bytes, with different
+  hashes. It also explains the part of that report that had no explanation —
+  "the differences are entirely in built media" — because a rebuild regenerates
+  only `media/js/**`, so only those entries take new mtimes and the diff follows
+  what was rebuilt rather than what changed.
+
+  Worth knowing when comparing releases: **artifact bytes change with this
+  release** even for unchanged sources, because timestamps that used to vary are
+  now fixed. Nothing reads an artifact's mtimes — Joomla reads the manifest and
+  the files — so no consumer behaviour changes.
+
+  Adding an entry and normalising its timestamp are one operation rather than
+  two calls, and a test asserts no writer in `src/Build` calls `addFile()`
+  directly: the alternative rots the first time someone adds a call site, and
+  the symptom is invisible until two artifacts are hashed by hand.
+
+  #132's fix stands and is still what protects a publish — it hashes the asset
+  that is actually served. This removes the cause rather than the symptom, and
+  makes "was this built from this tag?" answerable by rebuilding.
+
 ### Fixed
 
 - **`cwm-ars-publish` advertised the checksums of a local file, not of the bytes

--- a/scripts/build.php
+++ b/scripts/build.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  * pruning, auto-run pre-build, and the 3-way version prompt.
  */
 
+require_once __DIR__ . '/../src/Build/ZipEntry.php';
 require_once __DIR__ . '/../src/Build/BuildConfig.php';
 require_once __DIR__ . '/../src/Build/ManifestReader.php';
 require_once __DIR__ . '/../src/Build/Prompt.php';

--- a/scripts/package.php
+++ b/scripts/package.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 // any project with a subBuild include while the unit tests stayed green:
 // they run under Composer's autoloader, which this does not have.
 // `tests/Cli/PackageCliTest.php` runs this file for real to catch that.
+require_once __DIR__ . '/../src/Build/ZipEntry.php';
 require_once __DIR__ . '/../src/Build/BuildConfig.php';
 require_once __DIR__ . '/../src/Build/ManifestReader.php';
 require_once __DIR__ . '/../src/Build/Prompt.php';

--- a/src/Build/PackageBuilder.php
+++ b/src/Build/PackageBuilder.php
@@ -111,7 +111,7 @@ final class PackageBuilder
         }
 
         $manifestEntry = basename($this->config->manifest);
-        $zip->addFile($manifestPath, $manifestEntry);
+        ZipEntry::add($zip, $manifestPath, $manifestEntry);
         $this->log("  + $manifestEntry");
 
         if ($this->config->scriptFile !== null) {
@@ -119,7 +119,7 @@ final class PackageBuilder
 
             if (is_file($scriptAbs)) {
                 $scriptEntry = basename($this->config->scriptFile);
-                $zip->addFile($scriptAbs, $scriptEntry);
+                ZipEntry::add($zip, $scriptAbs, $scriptEntry);
                 $this->log("  + $scriptEntry");
             }
         }
@@ -552,7 +552,7 @@ final class PackageBuilder
 
             $entryPath = $zipPrefix === '' ? $relativePath : rtrim($zipPrefix, '/') . '/' . $relativePath;
 
-            $zip->addFile($filePath, $entryPath);
+            ZipEntry::add($zip, $filePath, $entryPath);
             $this->log("  + $entryPath");
         }
     }

--- a/src/Build/Packager.php
+++ b/src/Build/Packager.php
@@ -340,7 +340,7 @@ final class Packager
         }
 
         $manifestEntry = basename($this->config->manifest);
-        $zip->addFile($manifestPath, $manifestEntry);
+        ZipEntry::add($zip, $manifestPath, $manifestEntry);
         $this->log("  + $manifestEntry");
 
         if ($this->config->installer !== null) {
@@ -348,7 +348,7 @@ final class Packager
 
             if (is_file($installerAbs)) {
                 $entry = basename($this->config->installer);
-                $zip->addFile($installerAbs, $entry);
+                ZipEntry::add($zip, $installerAbs, $entry);
                 $this->log("  + $entry");
             }
         }
@@ -360,7 +360,7 @@ final class Packager
                 throw new \RuntimeException("package.languageFiles: source not found: {$lang['from']}");
             }
 
-            $zip->addFile($fromAbs, $lang['to']);
+            ZipEntry::add($zip, $fromAbs, $lang['to']);
             $this->log("  + {$lang['to']}");
         }
 
@@ -368,7 +368,7 @@ final class Packager
 
         foreach ($stagedChildren as $child) {
             $entry = $prefix . $child['outputName'];
-            $zip->addFile($child['path'], $entry);
+            ZipEntry::add($zip, $child['path'], $entry);
             $this->log("  + $entry");
         }
 

--- a/src/Build/ZipEntry.php
+++ b/src/Build/ZipEntry.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Build;
+
+use ZipArchive;
+
+/**
+ * Adds a file to a zip with a fixed timestamp, so artifacts are reproducible.
+ *
+ * `ZipArchive` records each entry's filesystem mtime in the zip headers. Two
+ * builds from an identical source tree therefore produce different bytes
+ * whenever a file has merely been rewritten — same content, different
+ * timestamp — and the artifact's size does not change, so nothing looks wrong.
+ *
+ * That is not hypothetical. `pkg_licenseportal` 1.5.0 published a local
+ * artifact and a GitHub asset of identical length, 389213 bytes, with different
+ * hashes, and the update stream advertised the checksums of the file users did
+ * not receive. It went unnoticed across two releases (#132), and the cause was
+ * this (#134): a rebuild regenerated `media/js/**`, only those entries got
+ * fresh mtimes, and the diff followed what had been rebuilt rather than what
+ * had changed.
+ *
+ * ## Every entry goes through here
+ *
+ * A `setMtimeName()` call after each `addFile()` would work and would rot: the
+ * next call site added elsewhere silently reintroduces the problem, and the
+ * symptom is invisible until someone hashes two artifacts by hand. So adding an
+ * entry and normalising it are one operation, and a test asserts no raw
+ * `addFile()` survives in this namespace.
+ */
+final class ZipEntry
+{
+    /**
+     * The timestamp every entry is recorded with.
+     *
+     * Epoch, the conventional choice for reproducible archives. Nothing
+     * consumes an artifact's mtimes — Joomla reads the manifest and the files,
+     * and unzip does not care — so the value only has to be constant.
+     */
+    public const FIXED_MTIME = 0;
+
+    /**
+     * Add a file to the archive, recorded at a fixed timestamp.
+     *
+     * @param  ZipArchive  $zip    Open archive.
+     * @param  string      $path   Absolute path to the file on disk.
+     * @param  string      $entry  Path the file takes inside the archive.
+     *
+     * @return bool  Whether the file was added. A failed `setMtimeName` is not
+     *               treated as failure: the entry is present and correct, and
+     *               only its reproducibility is lost — worth not aborting a
+     *               release over.
+     */
+    public static function add(ZipArchive $zip, string $path, string $entry): bool
+    {
+        if (!$zip->addFile($path, $entry)) {
+            return false;
+        }
+
+        $zip->setMtimeName($entry, self::FIXED_MTIME);
+
+        return true;
+    }
+}

--- a/tests/Build/ZipEntryTest.php
+++ b/tests/Build/ZipEntryTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Build;
+
+use CWM\BuildTools\Build\ZipEntry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ZipArchive;
+
+/**
+ * Reproducibility of the artifacts this toolchain writes.
+ *
+ * The failure being pinned is silent: an entry's mtime changes, the archive's
+ * bytes change, its size does not, and the only symptom is an update stream
+ * advertising checksums for a file nobody receives (#132, #134).
+ */
+final class ZipEntryTest extends TestCase
+{
+    private string $tmp;
+
+    protected function setUp(): void
+    {
+        $this->tmp = sys_get_temp_dir() . '/cwm-zipentry-' . bin2hex(random_bytes(6));
+        mkdir($this->tmp, 0o777, true);
+        file_put_contents($this->tmp . '/a.js', "identical content\n");
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->tmp . '/*') ?: [] as $f) {
+            unlink($f);
+        }
+
+        rmdir($this->tmp);
+    }
+
+    private function pack(string $out): void
+    {
+        $zip = new ZipArchive();
+        $zip->open($out, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        ZipEntry::add($zip, $this->tmp . '/a.js', 'a.js');
+        $zip->close();
+    }
+
+    #[Test]
+    public function identical_sources_produce_identical_bytes_despite_mtimes(): void
+    {
+        $this->pack($this->tmp . '/one.zip');
+
+        // Same content, rewritten at a different time — the state a rebuild
+        // leaves behind, and the whole cause of #134.
+        touch($this->tmp . '/a.js', time() - 9999);
+
+        $this->pack($this->tmp . '/two.zip');
+
+        self::assertSame(
+            hash_file('sha256', $this->tmp . '/one.zip'),
+            hash_file('sha256', $this->tmp . '/two.zip'),
+            'a rebuild must not change the artifact when the sources did not'
+        );
+    }
+
+    #[Test]
+    public function raw_addFile_is_recorded_at_the_files_mtime(): void
+    {
+        /*
+         * The behaviour being defended against, asserted directly so the test
+         * above cannot pass for the wrong reason. Note the sizes match: this is
+         * why the divergence was invisible for two releases.
+         */
+        $pack = function (string $out): void {
+            $zip = new ZipArchive();
+            $zip->open($out, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+            $zip->addFile($this->tmp . '/a.js', 'a.js');
+            $zip->close();
+        };
+
+        $pack($this->tmp . '/raw1.zip');
+        touch($this->tmp . '/a.js', time() - 9999);
+        $pack($this->tmp . '/raw2.zip');
+
+        self::assertSame(
+            filesize($this->tmp . '/raw1.zip'),
+            filesize($this->tmp . '/raw2.zip'),
+            'identical size is what made this hard to see'
+        );
+        self::assertNotSame(
+            hash_file('sha256', $this->tmp . '/raw1.zip'),
+            hash_file('sha256', $this->tmp . '/raw2.zip'),
+            'raw addFile records the mtime, so the bytes differ'
+        );
+    }
+
+    #[Test]
+    public function the_entry_is_added_and_readable(): void
+    {
+        // Normalising the timestamp must not damage the entry itself.
+        $this->pack($this->tmp . '/x.zip');
+
+        $zip = new ZipArchive();
+        $zip->open($this->tmp . '/x.zip');
+
+        self::assertSame(1, $zip->numFiles);
+        self::assertSame("identical content\n", $zip->getFromName('a.js'));
+
+        $zip->close();
+    }
+
+    #[Test]
+    public function no_writer_in_the_build_namespace_bypasses_the_helper(): void
+    {
+        /*
+         * A setMtimeName() after each addFile() would rot: the next call site
+         * added elsewhere reintroduces the problem silently. Adding an entry
+         * and normalising it are one operation, and this is what keeps it that
+         * way.
+         */
+        $offenders = [];
+
+        foreach (glob(__DIR__ . '/../../src/Build/*.php') ?: [] as $file) {
+            if (basename($file) === 'ZipEntry.php') {
+                continue;
+            }
+
+            if (preg_match('/->addFile\s*\(/', (string) file_get_contents($file))) {
+                $offenders[] = basename($file);
+            }
+        }
+
+        self::assertSame([], $offenders, 'these call addFile directly; use ZipEntry::add()');
+    }
+}


### PR DESCRIPTION
Closes #134. This is the cause behind #132, whose fix removed the symptom.

## What was wrong

`ZipArchive` records each entry's filesystem mtime. Two builds from an identical source tree therefore produced different bytes whenever a file had merely been rewritten — **at the same size**, which is why it stayed invisible:

```
sizes:      124 vs 124
identical:  NO
```

That is exactly the `pkg_licenseportal` 1.5.0 signature: 389213 bytes both, different hashes, and the update stream advertising checksums for the file users did not receive.

It also explains the part of #132 that had no explanation — *"the differences are entirely in built media"*. A rebuild regenerates only `media/js/**`, so only those entries take new mtimes. **The diff follows what was rebuilt, not what changed.**

## What I ruled out first

The JS build. Two rollup runs over the same sources produced **288 byte-identical files**. And #132's suggested fix — `mtime: 0` for `rollup-plugin-gzip` — was the right idea one layer too low: Node's `zlib` already writes that field as zero, and the plugin passes `gzipOptions` straight through. The zip layer was the one that was not deterministic.

## The fix

`ZipEntry::add()` — one operation that adds the entry *and* fixes its timestamp, replacing seven `addFile()` call sites across `PackageBuilder` and `Packager`.

A `setMtimeName()` after each `addFile()` would work and would rot: the next call site added elsewhere reintroduces the problem, invisibly. So a test asserts no writer in `src/Build` calls `addFile()` directly. Mutation-checked — restoring one raw call fails it.

## Proven end to end

Same sources, files touched between builds:

```
size:     330 vs 330
sha256 1: dbc6b299ae04a83c
sha256 2: dbc6b299ae04a83c
✓ IDENTICAL — artifact is reproducible
```

`composer test`: **539 tests, 1223 assertions**, green.

## The repo's own guards caught a mistake in this change

`PackageBuilder` and `Packager` gained a class the path-require scripts did not load. Both `buildScriptResolvesAllRequiredClasses` and the CLI packaging test failed with `Class "CWM\BuildTools\Build\ZipEntry" not found` — the same defect class as the v1.23.0 fatal, stopped this time before leaving the branch. `scripts/build.php` and `scripts/package.php` now require it.

## Release note

**Artifact bytes change with this release**, even for unchanged sources, because timestamps that used to vary are now fixed. Nothing reads an artifact's mtimes — Joomla reads the manifest and the files — so no consumer behaviour changes. Worth a minor version rather than a patch.
