### PR TITLE
docs(dev): record why TestSite and Joomla's driver do not bridge

### DIFF
--- a/src/Dev/TestSite.php
+++ b/src/Dev/TestSite.php
@@ -32,6 +32,30 @@ use RuntimeException;
  * PDO from `InstallConfig`; this class is specifically "the database this site
  * is using".
  *
+ * ## When to use Joomla's driver instead
+ *
+ * Two kinds of script touch a site's database, and they want different things.
+ *
+ * A script that only needs to *ask questions* — is this extension registered,
+ * does that table exist, how many rows — wants this class: no Joomla boot, no
+ * JPATH constants, and the parsing half is unit-testable without a site.
+ *
+ * A script that needs to *run Joomla's own logic* must boot Joomla and use
+ * `Joomla\Database\DatabaseInterface`, because that machinery resolves its
+ * driver through `Factory`. `verify-schema-check.php` is the example: `ChangeSet`
+ * and `ChangeItem` read `Factory::$database`, so nothing else will do. A test
+ * bootstrap pretending to be Joomla is the same case — there, `require`-ing
+ * `configuration.php` is the point, because defining `JConfig` is how Joomla's
+ * Config provider gets credentials.
+ *
+ * The two do not bridge. Joomla's default driver is mysqli-backed
+ * (`MysqliDriver` sets `$connection = mysqli_init()`), and this class is PDO, so
+ * there is no `fromJoomla()` to wrap one in the other. A script that has already
+ * booted Joomla and also wants {@see ExtensionQuery} simply calls
+ * {@see fromPath()} as well: a second, read-only connection to the same
+ * database, which costs little and keeps both surfaces honest about what they
+ * are.
+ *
  * ## Parsing is separate from connecting
  *
  * {@see readConfig()} is pure and takes a path, so it is tested against fixture


### PR DESCRIPTION
Two of the twelve files in #102 resisted migration to `TestSite`, both for the
same reason, and I rediscovered it by tripping over it rather than by reading
anything. This puts the reason where the next person will hit it.

`verify-schema-check.php` needs `Factory::$database` because `ChangeSet` and
`ChangeItem` resolve their driver through it. `tests/unit/bootstrap.php` needs
to `require` `configuration.php` because defining `JConfig` is how Joomla's
Config provider gets credentials. Neither is a hand-roll; both were on the list
because the survey matched on filename.

## Why there is no `fromJoomla()`

It was requested, and it cannot be written honestly. Joomla's default driver is
mysqli-backed — `MysqliDriver` sets `$this->connection = mysqli_init()` — while
`TestSite` is PDO, so there is nothing to wrap. A method accepting a
`DatabaseInterface` and quietly opening its own connection would be a lie in
the signature, and `joomla/database` is not a dependency of this package to
type-hint against in the first place.

A script that has booted Joomla and also wants `ExtensionQuery` calls
`fromPath()` as well: a second read-only connection to the same database, which
costs little and keeps both surfaces honest. No new API required.

Docblock only — no behaviour change. Full file-by-file status recorded on #102.

Refs #102