### PR TITLE
feat(dev): add hasIndex() and schemaVersion(), the last two harness primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`TestSite::hasIndex()` and `ExtensionQuery::schemaVersion()`** — the last
+  two primitives a migration harness needs before it can drop hand-rolled
+  `mysqli`. (#102)
+
+  `hasIndex()` answers the question no other check can: a migration that adds
+  an index leaves the table and every column exactly as they were, so a harness
+  verifying only those passes whether or not the index landed. Unlike
+  `hasTable()`/`hasColumn()` it is **MySQL/MariaDB only** —
+  `information_schema.STATISTICS` is not standard and PostgreSQL uses
+  `pg_indexes` — so it returns false on Postgres and says so in its docblock,
+  per the MySQL/MariaDB-only decision.
+
+  `schemaVersion()` reads `#__schemas`: the highest schema file Joomla actually
+  executed, as against `version()`, which reads `manifest_cache` — what the
+  package claimed. The two disagree in exactly the case a migration harness
+  exists to catch: an update that copies files but whose SQL never ran moves
+  the first forward and leaves the second behind. A harness asking only
+  `version()` reports that as a clean upgrade.
+
 ### Changed
 
 - **Artifacts are now reproducible: the same source tree produces the same

--- a/src/Dev/ExtensionQuery.php
+++ b/src/Dev/ExtensionQuery.php
@@ -128,6 +128,39 @@ final class ExtensionQuery
     }
 
     /**
+     * The schema version Joomla recorded for this extension, from `#__schemas`.
+     *
+     * Distinct from {@see version()} and the two disagree in the case that
+     * matters. `version()` reads `manifest_cache` — what the package said it
+     * was. This reads the highest schema file Joomla actually executed. An
+     * update that copies files but whose SQL never ran leaves the first moved
+     * forward and this one behind, which is precisely the failure a migration
+     * harness exists to catch, and it is invisible if you only ask one of them.
+     *
+     * Null when the extension is absent or has no schema row — the second is
+     * normal for anything shipping no SQL, so callers should not read null as
+     * failure without checking {@see exists()} first.
+     */
+    public function schemaVersion(string $type, string $element, ?string $folder = null, ?int $clientId = null): ?string
+    {
+        $id = $this->id($type, $element, $folder, $clientId);
+
+        if ($id === null) {
+            return null;
+        }
+
+        $stmt = $this->site->db()->prepare(
+            'SELECT version_id FROM ' . $this->site->table('#__schemas')
+            . ' WHERE extension_id = ?'
+        );
+        $stmt->execute([$id]);
+
+        $version = $stmt->fetchColumn();
+
+        return $version === false ? null : (string) $version;
+    }
+
+    /**
      * Every registered extension whose element matches, across all groups.
      *
      * The "which of these did we actually install" question, and the one that

--- a/src/Dev/TestSite.php
+++ b/src/Dev/TestSite.php
@@ -326,6 +326,35 @@ final class TestSite
     }
 
     /**
+     * Whether an index exists on a table.
+     *
+     * The one introspection here that is **MySQL/MariaDB only**:
+     * `information_schema.STATISTICS` is not part of the SQL standard and
+     * PostgreSQL exposes indexes through `pg_indexes` instead, so this returns
+     * false on Postgres rather than answering. {@see hasTable()} and
+     * {@see hasColumn()} are portable; this one is not, which is why it says so.
+     * Per the MySQL/MariaDB-only decision that is a limitation, not a gap.
+     *
+     * A migration that adds an index is otherwise unverifiable — the table and
+     * every column exist either way, so a harness checking only those passes
+     * whether or not the index landed.
+     */
+    public function hasIndex(string $token, string $index): bool
+    {
+        if ($this->isPostgres()) {
+            return false;
+        }
+
+        $stmt = $this->db()->prepare(
+            'SELECT 1 FROM information_schema.statistics '
+            . 'WHERE table_schema = ? AND table_name = ? AND index_name = ?'
+        );
+        $stmt->execute([$this->schemaName(), $this->table($token), $index]);
+
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
      * Read the database settings out of `<path>/configuration.php`.
      *
      * Pure: it takes a path and returns values, so it is tested against fixture

--- a/tests/Dev/ExtensionQueryTest.php
+++ b/tests/Dev/ExtensionQueryTest.php
@@ -53,6 +53,14 @@ final class ExtensionQueryTest extends TestCase
             $stmt->execute($row);
         }
 
+        // #__schemas holds the highest schema file Joomla actually ran. Row 1 is
+        // deliberately behind its manifest_cache version (10.5.9 vs 10.5.7):
+        // files copied, SQL did not run. Row 2 has no schema row at all, which
+        // is normal for an extension shipping no SQL and must not read as
+        // failure.
+        $pdo->exec('CREATE TABLE jos_schemas (extension_id INTEGER, version_id TEXT)');
+        $pdo->exec("INSERT INTO jos_schemas VALUES (1, '10.5.7'), (3, '2.1.0')");
+
         $this->query = new ExtensionQuery(TestSite::fromPdo($pdo, 'jos_'));
     }
 
@@ -130,5 +138,44 @@ final class ExtensionQueryTest extends TestCase
 
         self::assertCount(2, $rows);
         self::assertSame(['system', 'task'], array_column($rows, 'folder'));
+    }
+
+    #[Test]
+    public function reads_the_schema_version_joomla_recorded(): void
+    {
+        self::assertSame('10.5.7', $this->query->schemaVersion('component', 'com_proclaim'));
+    }
+
+    #[Test]
+    public function schema_version_and_manifest_version_can_disagree(): void
+    {
+        // The whole reason this method exists. manifest_cache says the package
+        // is 10.5.9; #__schemas says the SQL only ever ran up to 10.5.7. A
+        // harness reading version() alone reports a clean upgrade here.
+        self::assertSame('10.5.9', $this->query->version('component', 'com_proclaim'));
+        self::assertSame('10.5.7', $this->query->schemaVersion('component', 'com_proclaim'));
+    }
+
+    #[Test]
+    public function an_extension_with_no_schema_row_reads_as_null(): void
+    {
+        // Registered, but ships no SQL — null is "nothing recorded", not "absent".
+        self::assertTrue($this->query->exists('library', 'cwmscripture'));
+        self::assertNull($this->query->schemaVersion('library', 'cwmscripture'));
+    }
+
+    #[Test]
+    public function an_absent_extension_has_no_schema_version(): void
+    {
+        self::assertNull($this->query->schemaVersion('component', 'com_nothing'));
+    }
+
+    #[Test]
+    public function schema_version_honours_the_folder_that_disambiguates(): void
+    {
+        // Both plugins share the element; only the system one ran schema SQL.
+        // Resolving through id() is what keeps these apart.
+        self::assertSame('2.1.0', $this->query->schemaVersion('plugin', 'cwmscripture', 'system'));
+        self::assertNull($this->query->schemaVersion('plugin', 'cwmscripture', 'task'));
     }
 }


### PR DESCRIPTION
Unblocks the `verify-migrations.php` migrations in both consumers (#102). Those
two files are the largest divergence pair in that issue — 608 vs 388 lines —
and two of their checks had nothing on `TestSite`/`ExtensionQuery` to move to.

## `TestSite::hasIndex()`

The check that is otherwise unverifiable. A migration adding an index leaves
the table and every column exactly as they were, so a harness verifying only
those passes whether or not the index landed.

**MySQL/MariaDB only**, unlike its two siblings. `information_schema.STATISTICS`
is not standard and PostgreSQL exposes indexes through `pg_indexes`, so this
returns false on Postgres — stated in the docblock so it does not read as "no
index" per [the MySQL/MariaDB-only decision](https://github.com/Joomla-Bible-Study/cwm-build-tools/issues/114).

## `ExtensionQuery::schemaVersion()`

Reads `#__schemas` — the highest schema file Joomla actually executed — as
against `version()`, which reads `manifest_cache`, i.e. what the package
claimed. They disagree in precisely the case a migration harness exists to
catch: **an update that copies files but whose SQL never ran** moves one
forward and leaves the other behind. A harness asking only `version()` reports
that as a clean upgrade. A test pins the divergence rather than trusting them
to agree.

Signature matches every other method on the class — `type`/`element`/`folder`/
`clientId` — rather than the hardcoded `com_proclaim`/`component` shape it
replaces, so the `folder` that disambiguates two plugins sharing an element
still applies. A test covers that.

## Verified

`information_schema` does not exist in the in-memory SQLite the unit tests use,
which is why `hasTable()`/`hasColumn()` have no coverage either. `hasIndex()`
was checked against the live `j6-test` MySQL instead, including the cases that
catch a too-generous query:

```
table   #__bsms_admin      index   idx_access
PRIMARY on that table  : true
the real index         : true
an index that is absent: false
real index, wrong table: false     <-- table_schema/table_name both bind
index on absent table  : false
```

`schemaVersion()` is fully unit-tested (5 tests). Both new assertions were
mutation-checked: dropping `folder`/`clientId` from the id lookup fails, and
short-circuiting the schema read fails.

That `hasTable`/`hasColumn`/`hasIndex` have no automated coverage is a real gap
and the right home for it is #124, the MySQL/MariaDB test bed.

Refs #102