### PR TITLE
test(dev): cover hasTable, hasColumn and hasIndex against a real database

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,25 @@ jobs:
     name: PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
 
+    services:
+      # tests/Dev/TestSiteIntrospectionTest.php reads information_schema, which
+      # the in-memory SQLite the rest of the suite uses does not have. Without a
+      # real server those tests skip, and hasTable/hasColumn/hasIndex go back to
+      # having no coverage while the suite still reports green -- so the test
+      # fails rather than skips when CI is set and this service is missing.
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: cwm_build_tools_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
     strategy:
       fail-fast: false
       matrix:
@@ -55,7 +74,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: json, simplexml, zip
+          extensions: json, simplexml, zip, pdo_mysql
           coverage: none
           tools: composer:v2
 
@@ -80,6 +99,62 @@ jobs:
       - name: Run tests
         # composer test runs PHPUnit and the Python suite.
         run: composer test
+        env:
+          CWM_TEST_MYSQL_DSN: 'mysql:host=127.0.0.1;port=3306;dbname=cwm_build_tools_test'
+          CWM_TEST_MYSQL_USER: root
+          CWM_TEST_MYSQL_PASSWORD: root
+
+  mariadb:
+    # The same introspection tests against the other engine our users actually
+    # run. One PHP version is enough: what is being checked is the server's
+    # information_schema, not the language binding. Kept as its own job rather
+    # than a matrix dimension because a service container cannot be selected
+    # per-entry, and crossing three PHP versions with two engines would triple
+    # the suite to cover a difference that lives entirely in the server.
+    name: MariaDB introspection
+    runs-on: ubuntu-latest
+
+    services:
+      mariadb:
+        image: mariadb:11.4
+        env:
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_DATABASE: cwm_build_tools_test
+        ports:
+          - 3307:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: json, simplexml, zip, pdo_mysql
+          coverage: none
+          tools: composer:v2
+
+      - name: Cache Composer packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/composer
+          key: composer-8.4-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-8.4-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Run introspection tests
+        run: vendor/bin/phpunit tests/Dev/TestSiteIntrospectionTest.php --testdox
+        env:
+          CWM_TEST_MYSQL_DSN: 'mysql:host=127.0.0.1;port=3307;dbname=cwm_build_tools_test'
+          CWM_TEST_MYSQL_USER: root
+          CWM_TEST_MYSQL_PASSWORD: root
 
   lint:
     name: Coding standards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Real-database coverage for `TestSite`'s introspection methods.**
+  `hasTable()`, `hasColumn()` and `hasIndex()` read `information_schema`, which
+  the in-memory SQLite the rest of the suite uses does not have — so all three
+  had **no tests at all**, while Proclaim and CWMLivingWord came to depend on
+  them for deciding whether a migration landed, whether a table survived an
+  uninstall, and whether an index was created. `hasIndex()` shipped in v1.25.0
+  verified only by hand against one live site. (#124)
+
+  14 tests against a real server, covering what a live site could not: a
+  composite index (two rows in `information_schema.statistics` for one index),
+  a unique index, an index name shared by two tables, and a decoy table proving
+  the check is an equality match rather than `SHOW TABLES LIKE` — the bug found
+  three times in consumers, where `_` in a Joomla prefix is a wildcard.
+
+  CI runs them against **MySQL 8.4** and **MariaDB 11.4**. Locally they skip
+  unless `CWM_TEST_MYSQL_DSN` is set; **in CI they fail rather than skip**,
+  because a suite that silently covers nothing reads exactly like one that
+  passes.
+
 ## [1.25.0] - 2026-08-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,21 @@ developer-supplied:
 
 Run commands are at the top of this file. Conventions worth knowing:
 
+- **`tests/Dev/TestSiteIntrospectionTest.php` needs a real MySQL.**
+  `hasTable`/`hasColumn`/`hasIndex` read `information_schema`, which SQLite
+  does not have. Set `CWM_TEST_MYSQL_DSN` (plus `CWM_TEST_MYSQL_USER` /
+  `CWM_TEST_MYSQL_PASSWORD`) to run them:
+
+  ```bash
+  CWM_TEST_MYSQL_DSN='mysql:host=127.0.0.1;port=8889;dbname=some_db' \
+    CWM_TEST_MYSQL_USER=root CWM_TEST_MYSQL_PASSWORD=root composer test
+  ```
+
+  They create tables under a `cwmtest_` prefix in the database the DSN names
+  and drop them in `tearDown()` — no `CREATE DATABASE`, so a mistake costs three
+  tables rather than a schema. Without the variable they skip locally; **in CI
+  they fail**, because a silently-skipping test leaves the suite green while
+  covering nothing.
 - Tests use **real fixture XML files** committed to
   `tests/fixtures/manifests/`. Don't generate fixtures on the fly —
   they're meant to be reviewable in PRs.

--- a/tests/Dev/TestSiteIntrospectionTest.php
+++ b/tests/Dev/TestSiteIntrospectionTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\BuildTools\Tests\Dev;
+
+use CWM\BuildTools\Dev\TestSite;
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * hasTable(), hasColumn() and hasIndex() against a real MySQL server.
+ *
+ * These three read `information_schema`, which the in-memory SQLite the rest of
+ * the suite uses does not have — so until this file they had no coverage at all,
+ * while Proclaim and CWMLivingWord came to depend on them for deciding whether a
+ * migration landed, whether a table survived an uninstall, and whether an index
+ * was created. `hasIndex()` shipped verified only by hand against one live site.
+ *
+ * ## Tables, not databases
+ *
+ * Everything is created inside whatever database the DSN names, under a
+ * `cwmtest_` prefix, and dropped again in tearDown(). Creating a database per
+ * run would need a privilege a developer's local root may not have, and would
+ * make a mistake in this file cost a schema rather than three tables.
+ *
+ * ## Skipping locally, failing in CI
+ *
+ * Without CWM_TEST_MYSQL_DSN this file skips, so `composer test` still works on
+ * a machine with no MySQL. In CI it fails instead: a suite that silently covers
+ * nothing reads exactly like one that passes, which is the defect this project
+ * has now found in five different harnesses.
+ */
+final class TestSiteIntrospectionTest extends TestCase
+{
+    private const PREFIX = 'cwmtest_';
+
+    private ?PDO $pdo = null;
+
+    private TestSite $site;
+
+    protected function setUp(): void
+    {
+        $dsn = getenv('CWM_TEST_MYSQL_DSN');
+
+        if ($dsn === false || $dsn === '') {
+            if (getenv('CI') !== false && getenv('CI') !== '') {
+                self::fail(
+                    'CWM_TEST_MYSQL_DSN is not set. In CI this is a failure rather than a skip: '
+                    . 'these are the only tests covering hasTable/hasColumn/hasIndex, and a silent '
+                    . 'skip would leave the suite green while covering nothing.'
+                );
+            }
+
+            self::markTestSkipped('Set CWM_TEST_MYSQL_DSN to run the MySQL introspection tests.');
+        }
+
+        $this->pdo = new PDO(
+            $dsn,
+            getenv('CWM_TEST_MYSQL_USER') ?: 'root',
+            getenv('CWM_TEST_MYSQL_PASSWORD') ?: '',
+            [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION],
+        );
+
+        $this->dropFixtures();
+
+        // The table under test.
+        $this->pdo->exec(
+            'CREATE TABLE ' . self::PREFIX . 'bsms_studies (
+                id INT PRIMARY KEY AUTO_INCREMENT,
+                title VARCHAR(100),
+                book_nr INT,
+                chapter INT,
+                reference VARCHAR(50),
+                INDEX idx_title (title),
+                INDEX idx_book_chapter (book_nr, chapter),
+                UNIQUE INDEX uniq_reference (reference)
+            )'
+        );
+
+        // A second table carrying an index of the SAME name, so a check that
+        // forgets to bind the table name resolves the wrong one and passes.
+        $this->pdo->exec(
+            'CREATE TABLE ' . self::PREFIX . 'other (
+                id INT PRIMARY KEY,
+                title VARCHAR(100),
+                INDEX idx_title (title)
+            )'
+        );
+
+        // ⚠️ A decoy: `SHOW TABLES LIKE 'cwmtest_bsms_studies'` matches this,
+        // because `_` is a single-character wildcard and the name is the same
+        // length. That is the bug hasTable() exists to not have.
+        $this->pdo->exec('CREATE TABLE cwmtestXbsmsXstudies (id INT PRIMARY KEY)');
+
+        $this->site = TestSite::fromPdo($this->pdo, self::PREFIX);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dropFixtures();
+        $this->pdo = null;
+    }
+
+    private function dropFixtures(): void
+    {
+        foreach ([self::PREFIX . 'bsms_studies', self::PREFIX . 'other', 'cwmtestXbsmsXstudies'] as $table) {
+            $this->pdo?->exec('DROP TABLE IF EXISTS `' . $table . '`');
+        }
+    }
+
+    #[Test]
+    public function finds_a_table_that_is_there(): void
+    {
+        self::assertTrue($this->site->hasTable('#__bsms_studies'));
+    }
+
+    #[Test]
+    public function does_not_find_a_table_that_is_not(): void
+    {
+        self::assertFalse($this->site->hasTable('#__no_such_table'));
+    }
+
+    #[Test]
+    public function matches_the_name_exactly_rather_than_as_a_like_pattern(): void
+    {
+        // The whole reason this is not `SHOW TABLES LIKE`. MySQL agrees the
+        // decoy matches the pattern; hasTable() must still say no.
+        $matches = $this->pdo->query(
+            "SELECT 'cwmtestXbsmsXstudies' LIKE '" . self::PREFIX . "bsms_studies'"
+        )->fetchColumn();
+
+        self::assertEquals(1, $matches, 'the decoy does match a LIKE pattern — otherwise this proves nothing');
+        self::assertTrue($this->site->hasTable('#__bsms_studies'));
+        self::assertFalse($this->site->hasTable('#__no_such_table'));
+
+        // And the decoy itself is not reachable through the prefixed token.
+        self::assertFalse($this->site->hasTable('#__bsmsXstudies'));
+    }
+
+    #[Test]
+    public function finds_a_column_that_is_there(): void
+    {
+        self::assertTrue($this->site->hasColumn('#__bsms_studies', 'title'));
+        self::assertTrue($this->site->hasColumn('#__bsms_studies', 'book_nr'));
+    }
+
+    #[Test]
+    public function does_not_find_a_column_that_is_not(): void
+    {
+        self::assertFalse($this->site->hasColumn('#__bsms_studies', 'no_such_column'));
+    }
+
+    #[Test]
+    public function a_column_is_scoped_to_its_table(): void
+    {
+        // book_nr exists on bsms_studies and not on other. A check that binds
+        // only the column name answers true for both.
+        self::assertTrue($this->site->hasColumn('#__bsms_studies', 'book_nr'));
+        self::assertFalse($this->site->hasColumn('#__other', 'book_nr'));
+    }
+
+    #[Test]
+    public function a_column_on_a_missing_table_is_absent_not_an_error(): void
+    {
+        self::assertFalse($this->site->hasColumn('#__no_such_table', 'id'));
+    }
+
+    #[Test]
+    public function finds_the_primary_key_and_a_single_column_index(): void
+    {
+        self::assertTrue($this->site->hasIndex('#__bsms_studies', 'PRIMARY'));
+        self::assertTrue($this->site->hasIndex('#__bsms_studies', 'idx_title'));
+    }
+
+    #[Test]
+    public function finds_a_composite_index(): void
+    {
+        // information_schema.statistics holds one row per column, so a
+        // multi-column index is two rows. The query has to answer "yes" from
+        // the first of them rather than tripping over the second.
+        $rows = $this->pdo->query(
+            "SELECT COUNT(*) FROM information_schema.statistics
+             WHERE table_schema = DATABASE()
+               AND table_name = '" . self::PREFIX . "bsms_studies'
+               AND index_name = 'idx_book_chapter'"
+        )->fetchColumn();
+
+        self::assertEquals(2, $rows, 'the composite index should be two rows — otherwise this proves nothing');
+        self::assertTrue($this->site->hasIndex('#__bsms_studies', 'idx_book_chapter'));
+    }
+
+    #[Test]
+    public function finds_a_unique_index(): void
+    {
+        // hasIndex() answers presence, not shape: UNIQUE is still an index.
+        self::assertTrue($this->site->hasIndex('#__bsms_studies', 'uniq_reference'));
+    }
+
+    #[Test]
+    public function does_not_find_an_index_that_is_not_there(): void
+    {
+        self::assertFalse($this->site->hasIndex('#__bsms_studies', 'idx_nothing'));
+    }
+
+    #[Test]
+    public function an_index_is_scoped_to_its_table(): void
+    {
+        // Both tables carry an index called idx_title; only bsms_studies
+        // carries idx_book_chapter. Without binding the table name, the second
+        // assertion answers true.
+        self::assertTrue($this->site->hasIndex('#__other', 'idx_title'));
+        self::assertFalse($this->site->hasIndex('#__other', 'idx_book_chapter'));
+    }
+
+    #[Test]
+    public function an_index_on_a_missing_table_is_absent_not_an_error(): void
+    {
+        self::assertFalse($this->site->hasIndex('#__no_such_table', 'PRIMARY'));
+    }
+
+    #[Test]
+    public function the_prefix_is_applied_to_every_introspection(): void
+    {
+        // Passing an already-expanded name resolves the same way a token does,
+        // which is what lets callers hold either.
+        self::assertTrue($this->site->hasTable(self::PREFIX . 'bsms_studies'));
+        self::assertTrue($this->site->hasColumn(self::PREFIX . 'bsms_studies', 'title'));
+        self::assertTrue($this->site->hasIndex(self::PREFIX . 'bsms_studies', 'idx_title'));
+    }
+}


### PR DESCRIPTION
Closes the coverage half of #124. The scope I narrowed to, and what I left out,
is [recorded on the issue](https://github.com/Joomla-Bible-Study/cwm-build-tools/issues/124#issuecomment-5329720876).

## The gap

| method | tests before |
|---|---|
| `hasTable` | **0** |
| `hasColumn` | **0** |
| `hasIndex` | **0** |
| `schemaVersion` | 5 |

All three read `information_schema`, which the in-memory SQLite the suite uses
does not have — so they were never coverable there. Fine while nothing called
them. After #102 they decide whether a migration landed, whether a table
survived an uninstall, and whether an index was created, across **five consumer
files in two repos**. `hasIndex()` shipped in v1.25.0 verified only by hand
against a single live site.

## What the 14 tests cover that a live site couldn't

- **A composite index** — two rows in `information_schema.statistics` for one
  index, so the query must answer from the first rather than trip over the second
- **A unique index** — `hasIndex()` answers presence, and UNIQUE is still an index
- **An index name shared by two tables**, and a column on one table but not
  another — both pass if the table name isn't bound
- **A decoy table**, `cwmtestXbsmsXstudies`. The test first asserts MySQL agrees
  it *does* match the `LIKE` pattern for `cwmtest_bsms_studies`, then asserts
  `hasTable()` still says no:

```php
self::assertEquals(1, $matches, 'the decoy does match a LIKE pattern — otherwise this proves nothing');
```

That's the bug found three times in consumers, where the `_` ending every Joomla
prefix is a wildcard.

## Mutation-checked

| mutation | result |
|---|---|
| `hasTable` equality → `LIKE` | 1 failure |
| `hasColumn` stops binding the table name | 2 failures |
| `hasIndex` stops binding the table name | 2 failures |

## Skips locally, **fails** in CI

```
$ vendor/bin/phpunit tests/Dev/TestSiteIntrospectionTest.php
OK, but some tests were skipped!   Tests: 14, Skipped: 14.

$ CI=true vendor/bin/phpunit tests/Dev/TestSiteIntrospectionTest.php
CWM_TEST_MYSQL_DSN is not set. In CI this is a failure rather than a skip...
```

`composer test` still works on a machine with no MySQL. But a test that silently
skips in CI is the defect this project has now found in five separate harnesses
— it reads green while covering nothing — so the guard is structural, not a note.

CI gains a **MySQL 8.4** service on the existing PHP 8.3/8.4/8.5 matrix, plus a
**MariaDB 11.4** job. MariaDB is its own job rather than a matrix dimension
because a service container can't be selected per entry, and crossing three PHP
versions with two engines would triple the suite to cover a difference that
lives entirely in the server.

## Safety

Tables are created under a `cwmtest_` prefix **inside** the database the DSN
names, and dropped in `tearDown()`. No `CREATE DATABASE` — it needs a privilege
a developer's local root may not have, and it would make a mistake in this file
cost a schema rather than three tables. Verified locally against MySQL 8.0:
full suite green, **0 leftover fixture tables**.

`tests/` is already `export-ignore`d, so nothing here ships.

## Left open

#124 stays open for the two deferred halves — the `docker-compose` template for
consumers, and the schema-replay harness. Neither blocks this, and PostgreSQL is
excluded per the decision on #114.

Refs #124