### PR TITLE
feat(setup): distribute a disposable MySQL/MariaDB compose file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`templates/docker-compose.databases.yml`**, distributed by
+  `cwm-sync-configs` — a MySQL 8.4 and MariaDB 11.4 pair on non-default ports,
+  so schema work has a database that is *known empty*. A leftover table from
+  the previous attempt turns a real failure into a pass. (#124)
+
+  Created once and never updated: ports, and whether MariaDB is wanted at all,
+  are the developer's choices. Nothing in the toolchain reads the file — it does
+  nothing until someone runs `docker compose` against it.
+
+  ⚠️ The reset is **`down -v`**, not `down`: both images declare a VOLUME for
+  their data directory, so a plain `down` leaves an anonymous volume behind and
+  the next `up` inherits it — the exact failure the file exists to prevent. A
+  tmpfs data directory would remove the need for the flag and was tried first;
+  MySQL 8 defaults `innodb_flush_method` to `O_DIRECT`, which tmpfs does not
+  support, so the server does not start. A test asserts the documented reset
+  keeps the flag.
+
+  PostgreSQL is deliberately absent, per the MySQL/MariaDB-only decision.
+
 ## [1.26.0] - 2026-08-18
 
 ### Changed (breaking)

--- a/scripts/sync-configs.php
+++ b/scripts/sync-configs.php
@@ -58,6 +58,7 @@ syncBuildDistProperties($projectRoot, $templates, $dryRun);
 syncEditorConfig($projectRoot, $templates, $dryRun);
 syncPhpCsFixer($projectRoot, $dryRun);
 syncPhpunit($projectRoot, $templates, $dryRun);
+syncDatabaseComposeFile($projectRoot, $templates, $dryRun);
 syncEslint($projectRoot, $templates, $projectConfig, $dryRun);
 checkEslintInvocation($projectRoot);
 checkProfileHints($projectConfig, $toolsRoot);
@@ -427,6 +428,41 @@ function syncPhpCsFixer(string $projectRoot, bool $dryRun): void
 
     file_put_contents($target, $wrapper);
     echo '.php-cs-fixer.dist.php: ' . ($existing === '' ? 'created' : 'updated') . " wrapper\n";
+}
+
+/**
+ * Offer the disposable database compose file, once.
+ *
+ * Like phpunit.xml this never updates an existing copy: ports, and whether
+ * MariaDB is wanted at all, are the developer's own choices, and a "refresh"
+ * would overwrite them with a guess.
+ *
+ * Opt-in by nature -- the file does nothing until someone runs
+ * `docker compose` against it, and nothing in the toolchain reads it. It is
+ * here because schema work needs a database that is *known empty*, and every
+ * consumer would otherwise solve that separately.
+ */
+function syncDatabaseComposeFile(string $projectRoot, string $templates, bool $dryRun): void
+{
+    $source = $templates . '/docker-compose.databases.yml';
+    $target = $projectRoot . '/docker-compose.databases.yml';
+
+    if (!is_file($source)) {
+        return;
+    }
+
+    if (is_file($target)) {
+        return;
+    }
+
+    if ($dryRun) {
+        echo "docker-compose.databases.yml: would create from boilerplate (dry-run)\n";
+
+        return;
+    }
+
+    file_put_contents($target, (string) file_get_contents($source));
+    echo "docker-compose.databases.yml: created — `docker compose -f docker-compose.databases.yml up -d` for a known-empty MySQL/MariaDB\n";
 }
 
 /**

--- a/templates/docker-compose.databases.yml
+++ b/templates/docker-compose.databases.yml
@@ -1,0 +1,70 @@
+# Disposable MySQL and MariaDB for extension development.
+#
+# Databases only. Apache and PHP stay wherever you already have them (MAMP,
+# Herd, Valet, a system install) — this exists so schema work has a database
+# that is *known empty*, not to move your web stack.
+#
+# Why empty matters: a leftover table from the previous attempt turns a real
+# failure into a pass. That is the same defect this toolchain keeps finding
+# elsewhere — a check that reports success while testing something other than
+# what it claims.
+#
+#   docker compose -f docker-compose.databases.yml up -d       # start
+#   docker compose -f docker-compose.databases.yml down -v     # stop and wipe
+#
+# ⚠️ The reset is `down -v`, not `down`. Both images declare a VOLUME for their
+# data directory, so a plain `down` leaves an anonymous volume behind and the
+# next `up` inherits it — a leftover table from the previous attempt, which is
+# the exact failure this file exists to prevent.
+#
+# A tmpfs data directory would make that impossible, and was the first thing
+# tried here. It does not work: MySQL 8 defaults `innodb_flush_method` to
+# `O_DIRECT`, which tmpfs does not support, so the server fails to start.
+# Checked against MySQL 8.0.44 rather than assumed. `down -v` is the reset.
+#
+# Do not point anything you care about at these.
+#
+# Ports are deliberately not 3306: a developer's existing local MySQL keeps
+# running. Set them in .env if these clash.
+#
+#   CWM_MYSQL_PORT=3307   CWM_MARIADB_PORT=3308
+#
+# Point the test suite at one with:
+#
+#   CWM_TEST_MYSQL_DSN='mysql:host=127.0.0.1;port=3307;dbname=cwm_test' \
+#     CWM_TEST_MYSQL_USER=root CWM_TEST_MYSQL_PASSWORD=root composer test
+#
+# MariaDB is here because it is a real second engine our users run, not for
+# completeness. PostgreSQL is deliberately absent — this toolchain declares
+# MySQL/MariaDB only, and shipping a container for an engine we do not support
+# would imply otherwise.
+
+services:
+  mysql:
+    image: mysql:8.4
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: cwm_test
+    ports:
+      - "${CWM_MYSQL_PORT:-3307}:3306"
+    healthcheck:
+      # Same probe this project's CI uses for the same image.
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -uroot -proot"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  mariadb:
+    image: mariadb:11.4
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: cwm_test
+    ports:
+      - "${CWM_MARIADB_PORT:-3308}:3306"
+    healthcheck:
+      # MariaDB ships its own probe; mysqladmin ping reports healthy before
+      # InnoDB has finished coming up.
+      test: ["CMD-SHELL", "healthcheck.sh --connect --innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 10

--- a/tests/shell/sync-compose.test.sh
+++ b/tests/shell/sync-compose.test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Tests for the database compose file that cwm-sync-configs distributes.
+#
+# The file itself cannot be exercised here — starting a container is not
+# something a unit test should do, and the machine running this may have no
+# container runtime at all. What *is* checkable is the part that has bitten
+# this project before: a sync handler that overwrites something a developer
+# edited. Ports and whether MariaDB is wanted are their choices, and a
+# "refresh" that silently reverted them would be worse than not shipping the
+# file.
+#
+# The compose file is also parsed, so a broken template is caught here rather
+# than by a developer whose `docker compose up` fails for reasons that have
+# nothing to do with their machine.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TEMPLATE="${ROOT}/templates/docker-compose.databases.yml"
+SYNC="${ROOT}/scripts/sync-configs.php"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+# --- the template declares what it claims ------------------------------------
+#
+# Asserted against the file text rather than a YAML parser: pyyaml is not
+# guaranteed on a developer's machine or on a CI runner that only installed
+# Python, and a test that cannot run is worth less than one that checks a
+# little less.
+
+TPL="$(cat "$TEMPLATE")"
+
+assert_contains "$TPL" "  mysql:" "a mysql service is declared"
+assert_contains "$TPL" "  mariadb:" "a mariadb service is declared"
+assert_contains "$TPL" "image: mysql:8.4" "MySQL pinned to the version CI runs"
+assert_contains "$TPL" "image: mariadb:11.4" "MariaDB pinned to the version CI runs"
+
+# ⚠️ The invariant that matters, and the only part of this file a test can
+# actually guard.
+#
+# Both images declare a VOLUME for their data directory, so a plain `down`
+# leaves an anonymous volume behind and the next `up` inherits it — a leftover
+# table from the previous attempt, which is the exact failure this file exists
+# to prevent. The reset therefore has to be documented as `down -v`.
+#
+# A tmpfs data directory would remove the need for the flag, and was tried
+# first. MySQL 8 defaults innodb_flush_method to O_DIRECT, which tmpfs does not
+# support, so the server does not start. If someone reintroduces tmpfs, this
+# assertion is the wrong one — but it fails loudly rather than shipping a reset
+# command that does not reset.
+assert_equals "0" "$(grep -c '^    tmpfs:' "$TEMPLATE")" "no tmpfs data dir (MySQL 8 needs O_DIRECT)"
+assert_contains "$TPL" "down -v" "the documented reset uses -v, or it does not reset"
+assert_equals "0" "$(grep -E '^#   docker compose .*down' "$TEMPLATE" | grep -vc 'down -v')" "no bare 'down' offered as the reset"
+assert_equals "0" "$(grep -c '^volumes:' "$TEMPLATE")" "no named volumes, which down -v would not remove"
+
+assert_equals "2" "$(grep -c 'healthcheck:' "$TEMPLATE")" "both engines declare a healthcheck"
+
+# Not 3306: a developer's existing local MySQL has to keep running.
+assert_equals "0" "$(grep -c '"3306:3306"' "$TEMPLATE")" "default host ports avoid 3306"
+
+# --- the sync handler creates it, and never overwrites it --------------------
+
+PROJECT="${WORK}/project"
+mkdir -p "${PROJECT}"
+printf '{"name":"demo/x"}\n' > "${PROJECT}/composer.json"
+printf '{"extension":{"name":"demo","type":"component"}}\n' > "${PROJECT}/cwm-build.config.json"
+
+( cd "${PROJECT}" && php "${SYNC}" --dry-run >/dev/null 2>&1 )
+if [ -f "${PROJECT}/docker-compose.databases.yml" ]; then
+    assert_equals "absent" "present" "--dry-run must not write the compose file"
+else
+    assert_equals "absent" "absent" "--dry-run writes nothing"
+fi
+
+( cd "${PROJECT}" && php "${SYNC}" >/dev/null 2>&1 )
+if [ -f "${PROJECT}/docker-compose.databases.yml" ]; then
+    assert_equals "present" "present" "a real run creates the compose file"
+else
+    assert_equals "present" "absent" "a real run should create the compose file"
+fi
+
+printf '\n# edited by the developer\n' >> "${PROJECT}/docker-compose.databases.yml"
+EDITED="$(md5 -q "${PROJECT}/docker-compose.databases.yml" 2>/dev/null || md5sum "${PROJECT}/docker-compose.databases.yml" | cut -d' ' -f1)"
+
+( cd "${PROJECT}" && php "${SYNC}" >/dev/null 2>&1 )
+AFTER="$(md5 -q "${PROJECT}/docker-compose.databases.yml" 2>/dev/null || md5sum "${PROJECT}/docker-compose.databases.yml" | cut -d' ' -f1)"
+
+assert_equals "${EDITED}" "${AFTER}" "re-running must not overwrite a customised compose file"
+
+finish


### PR DESCRIPTION
The consumer-facing half of #124. Schema work needs a database that is *known
empty* — a leftover table from the previous attempt turns a real failure into a
pass — and every consumer would otherwise solve that separately.

`cwm-sync-configs` now offers `templates/docker-compose.databases.yml`: MySQL
8.4 and MariaDB 11.4 on non-default ports, created once and never updated.
Nothing in the toolchain reads it; it does nothing until someone runs
`docker compose` against it.

## ⚠️ I cannot run this

There is no container runtime on the machine this was written on. **The file
has never been started.** That is the honest state of it, and two things reduce
it to something worth shipping rather than a guess:

**Nothing in it is invented.** Every non-trivial element is copied from
configuration verified green in this project's own CI today — the images, the
environment variable names, and both healthcheck probes, including MariaDB's
`healthcheck.sh --connect --innodb_initialized` rather than `mysqladmin ping`,
which reports healthy before InnoDB has come up.

**The one part I did invent was wrong, and I caught it by looking again.** The
first draft put both data directories on `tmpfs`, so that a plain `down` could
not leave state behind. MySQL 8 defaults `innodb_flush_method` to `O_DIRECT`,
which tmpfs does not support — the server would not have started. Checked
against the local MySQL 8.0.44 rather than assumed:

```
server: 8.0.44
  innodb_flush_method      O_DIRECT
```

Removed, along with a `--skip-mysqlx` flag I had added for no benefit.

## The consequence, and the test that guards it

Without tmpfs the reset is **`down -v`**, not `down`: both images declare a
`VOLUME` for their data directory, so a plain `down` leaves an anonymous volume
behind and the next `up` inherits it.

A documented reset that does not reset would be the exact defect this file
exists to prevent. So the test asserts the file never offers a bare `down`:

```bash
assert_equals "0" "$(grep -E '^#   docker compose .*down' "$TEMPLATE" | grep -vc 'down -v')" \
  "no bare 'down' offered as the reset"
```

That is the one property about a container this repository can actually check
without a runtime. Mutation-tested: documenting a bare `down` fails it.

## Also tested

13 assertions covering the template's shape and the sync handler's behaviour:
`--dry-run` writes nothing, a real run creates the file, and **a second run
does not overwrite a developer's edit** — mutation-tested by removing the
`is_file()` guard.

The first version of this test used `pyyaml` and failed on a machine with two
`python3`s where only one has it. Replaced with text assertions: CI installs
Python without pyyaml, so it would have failed there too.

Full suite green: 559 PHPUnit, 35 Python, 12 shell files.

## What is left on #124

The **schema-replay harness**. The issue offers a working version that exists
elsewhere; it is not in any working copy here, so shipping it would mean
writing it from scratch rather than contributing what already works. Better as
its own change, by whoever has that code.

Refs #124