### PR TITLE
fix(setup): cwm-sync-configs --help wrote to the project instead of printing help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`cwm-sync-configs --help` wrote to your project instead of printing help.**
+  `getopt()` ignores an unrecognised flag, so `--help` fell straight through to
+  the sync and rewrote `.gitignore`, `build.dist.properties`, `.editorconfig`,
+  `phpunit.xml` and the rest.
+
+  Found by running `--help` across every `cwm-*` binary in four repositories as
+  a post-upgrade smoke test, and watching four working trees acquire changes
+  that had to be traced back by file timestamp. Asking a command what it does
+  must never be the thing that changes your tree.
+
+  `--help` and `-h` now print a real help text and exit 0. A test asserts both
+  leave the project byte-identical, and that a real run still syncs — so the
+  guard cannot be satisfied by breaking the command.
+
 ## [1.27.0] - 2026-08-18
 
 ### Added

--- a/scripts/sync-configs.php
+++ b/scripts/sync-configs.php
@@ -43,6 +43,55 @@ $projectRoot = getcwd();
 $toolsRoot   = realpath(__DIR__ . '/..');
 $templates   = $toolsRoot . '/templates';
 
+// ⚠️ Before anything else. getopt() ignores an unrecognised flag, so `--help`
+// used to fall straight through to the sync and write to the project —
+// .gitignore, build.dist.properties, .editorconfig, phpunit.xml and the rest.
+// Asking a command what it does must never be the thing that changes your
+// working tree.
+if (in_array('--help', $argv, true) || in_array('-h', $argv, true)) {
+    echo <<<CWM_HELP
+cwm-sync-configs — refresh the config files this toolchain manages.
+
+WHAT IT DOES
+  Writes the managed blocks and files each consuming project shares:
+
+    .gitignore              managed block only; lines outside the markers are
+                            never touched
+    build.dist.properties   full replace from the canonical template — this is
+                            the committed example, not the file you configure.
+                            Your own settings live in build.properties, which
+                            is gitignored and never written here.
+    .editorconfig           full replace, but only of a copy this tool wrote
+    .php-cs-fixer.dist.php  regenerates the wrapper unless you customised it
+    phpunit.xml             created once, never overwritten
+    eslint.config.mjs       starter wrapper when no config exists
+    docker-compose.databases.yml
+                            created once, never overwritten
+
+  The rule across all of them: a file you wrote is never silently replaced.
+  Either the tool can prove it wrote the file, or it leaves it alone and says
+  so.
+
+PREREQUISITES
+  - cwm-build.config.json in the current directory.
+
+USAGE
+  composer sync-configs              # apply
+  composer sync-configs -- --dry-run # print what would change, write nothing
+
+OPTIONS
+  --dry-run    Preview only.
+  -h, --help   This text.
+
+RELATED
+  composer setup        # write build.properties (your local installs)
+  composer cwm-init     # first-time scaffolding for a new consumer
+
+CWM_HELP;
+
+    exit(0);
+}
+
 $opts   = getopt('', ['dry-run']);
 $dryRun = isset($opts['dry-run']);
 

--- a/tests/shell/sync-compose.test.sh
+++ b/tests/shell/sync-compose.test.sh
@@ -93,4 +93,38 @@ AFTER="$(md5 -q "${PROJECT}/docker-compose.databases.yml" 2>/dev/null || md5sum 
 
 assert_equals "${EDITED}" "${AFTER}" "re-running must not overwrite a customised compose file"
 
+# --- asking for help must never write ----------------------------------------
+#
+# getopt() ignores an unrecognised flag, so `--help` fell through to the sync
+# and wrote .gitignore, build.dist.properties, .editorconfig, phpunit.xml and
+# the rest into the project. Found by running `--help` across every cwm-*
+# binary in four repositories as a smoke test, and watching four working trees
+# acquire changes.
+
+HELPPROJ="${WORK}/helpproject"
+mkdir -p "${HELPPROJ}"
+printf '{"name":"demo/x"}\n' > "${HELPPROJ}/composer.json"
+printf '{"extension":{"name":"demo","type":"component"}}\n' > "${HELPPROJ}/cwm-build.config.json"
+
+BEFORE="$(cd "${HELPPROJ}" && ls | sort | tr '\n' ' ')"
+
+for FLAG in --help -h; do
+    ( cd "${HELPPROJ}" && php "${SYNC}" "${FLAG}" >/dev/null 2>&1 )
+    AFTER="$(cd "${HELPPROJ}" && ls | sort | tr '\n' ' ')"
+    assert_equals "${BEFORE}" "${AFTER}" "${FLAG} must not write to the project"
+done
+
+HELP_OUT="$( cd "${HELPPROJ}" && php "${SYNC}" --help 2>&1 )"
+assert_contains "${HELP_OUT}" "cwm-sync-configs —" "--help prints help"
+assert_contains "${HELP_OUT}" "--dry-run" "--help documents the dry-run flag"
+
+# The sync itself still has to work, or the guard above could be satisfied by
+# breaking the command.
+( cd "${HELPPROJ}" && php "${SYNC}" >/dev/null 2>&1 )
+if [ -f "${HELPPROJ}/phpunit.xml" ]; then
+    assert_equals "syncs" "syncs" "a real run still writes"
+else
+    assert_equals "syncs" "did not sync" "a real run must still write"
+fi
+
 finish


### PR DESCRIPTION
`getopt()` ignores an unrecognised flag, so `--help` fell straight through to
the sync and rewrote `.gitignore`, `build.dist.properties`, `.editorconfig`,
`.php-cs-fixer.dist.php` and `phpunit.xml` in whatever directory it ran from.

```
$ php scripts/sync-configs.php --help
.gitignore: updated
build.dist.properties: created from template
.editorconfig: created from template
.php-cs-fixer.dist.php: created wrapper
phpunit.xml: created from boilerplate — point <directory> at the project's source
```

## How it was found

The expensive way. After bumping four repositories to v1.27.0 I ran `--help`
across every `cwm-*` binary as a smoke test — the kind that checks a command
still loads after an upgrade. Four working trees came back dirty, and the cause
had to be traced by comparing file timestamps against the order the loop
visited the repositories.

Asking a command what it does must never be the thing that changes your tree.

## The fix

`--help` and `-h` print help and exit 0, in the shape `CLAUDE.md` documents.

The text states plainly that `build.dist.properties` is a **full replace** and
that per-machine settings live in `build.properties` — that is the handler most
likely to surprise someone reading this output for the first time, and it is
working as designed.

## Tests

Four assertions:

- `--help` leaves the project byte-identical
- `-h` leaves the project byte-identical
- the text names the command and documents `--dry-run`
- **a real run still writes** — so the guard cannot be satisfied by breaking the
  command, which is the obvious wrong way to make the first two pass

Mutation-checked by removing the guard: 4 failures.

Full suite green — 559 PHPUnit, 35 Python, 12 shell files.