### PR TITLE
fix(cli): --help must print help, and must work before setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`--help` now works outside a configured project, for the commands that had
+  a help text all along.** `cwm-build`, `cwm-install-zip`, `cwm-link`,
+  `cwm-link-check`, `cwm-package`, `cwm-verify` and `cwm-bump` checked for
+  `cwm-build.config.json` in their `bin/` wrapper *before* reaching the script
+  that handles `--help` — so reading what a command does required already
+  having set it up, which is the wrong way round.
+
+  `cwm-bump` also gained the help text it never had.
+
+  A suite-wide test now asserts two things for **every** `cwm-*` binary at
+  once: none writes anything when asked for `--help`, and the set that still
+  lacks a help text is exactly the expected list — so fixing one without
+  updating the list fails, and so does a regression that adds one.
+
 - **`cwm-sync-configs --help` wrote to your project instead of printing help.**
   `getopt()` ignores an unrecognised flag, so `--help` fell straight through to
   the sync and rewrote `.gitignore`, `build.dist.properties`, `.editorconfig`,

--- a/bin/cwm-build
+++ b/bin/cwm-build
@@ -17,6 +17,15 @@ set -euo pipefail
 PROJECT_ROOT="$(pwd)"
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# --help must work outside a configured project: the whole point of asking a
+# command what it does is that you may not have set it up yet. Answer before the
+# precondition below, and let the script print its own text.
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h) exec php "${TOOLS_DIR}/scripts/build.php" "$@" ;;
+    esac
+done
+
 if [ ! -f "${PROJECT_ROOT}/cwm-build.config.json" ]; then
     echo "Error: cwm-build.config.json not found in $PROJECT_ROOT"
     echo "Run 'cwm-init' to scaffold one, or see"

--- a/bin/cwm-bump
+++ b/bin/cwm-bump
@@ -15,6 +15,15 @@ set -euo pipefail
 PROJECT_ROOT="$(pwd)"
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# --help must work outside a configured project: the whole point of asking a
+# command what it does is that you may not have set it up yet. Answer before the
+# precondition below, and let the script print its own text.
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h) exec php "${TOOLS_DIR}/scripts/bump.php" "$@" ;;
+    esac
+done
+
 if [ ! -f "${PROJECT_ROOT}/cwm-build.config.json" ]; then
     echo "Error: cwm-build.config.json not found in $PROJECT_ROOT"
     exit 1

--- a/bin/cwm-install-zip
+++ b/bin/cwm-install-zip
@@ -15,6 +15,15 @@ set -euo pipefail
 PROJECT_ROOT="$(pwd)"
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# --help must work outside a configured project: the whole point of asking a
+# command what it does is that you may not have set it up yet. Answer before the
+# precondition below, and let the script print its own text.
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h) exec php "${TOOLS_DIR}/scripts/install-zip.php" "$@" ;;
+    esac
+done
+
 if [ ! -f "${PROJECT_ROOT}/cwm-build.config.json" ]; then
     echo "Error: cwm-build.config.json not found in $PROJECT_ROOT"
     exit 1

--- a/bin/cwm-link
+++ b/bin/cwm-link
@@ -16,6 +16,15 @@ set -euo pipefail
 PROJECT_ROOT="$(pwd)"
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# --help must work outside a configured project: the whole point of asking a
+# command what it does is that you may not have set it up yet. Answer before the
+# precondition below, and let the script print its own text.
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h) exec php "${TOOLS_DIR}/scripts/link.php" "$@" ;;
+    esac
+done
+
 if [ ! -f "${PROJECT_ROOT}/cwm-build.config.json" ]; then
     echo "Error: cwm-build.config.json not found in $PROJECT_ROOT"
     exit 1

--- a/bin/cwm-link-check
+++ b/bin/cwm-link-check
@@ -12,6 +12,15 @@ set -euo pipefail
 PROJECT_ROOT="$(pwd)"
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# --help must work outside a configured project: the whole point of asking a
+# command what it does is that you may not have set it up yet. Answer before the
+# precondition below, and let the script print its own text.
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h) exec php "${TOOLS_DIR}/scripts/link-check.php" "$@" ;;
+    esac
+done
+
 if [ ! -f "${PROJECT_ROOT}/cwm-build.config.json" ]; then
     echo "Error: cwm-build.config.json not found in $PROJECT_ROOT"
     exit 1

--- a/bin/cwm-package
+++ b/bin/cwm-package
@@ -18,6 +18,15 @@ set -euo pipefail
 PROJECT_ROOT="$(pwd)"
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# --help must work outside a configured project: the whole point of asking a
+# command what it does is that you may not have set it up yet. Answer before the
+# precondition below, and let the script print its own text.
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h) exec php "${TOOLS_DIR}/scripts/package.php" "$@" ;;
+    esac
+done
+
 if [ ! -f "${PROJECT_ROOT}/cwm-build.config.json" ]; then
     echo "Error: cwm-build.config.json not found in $PROJECT_ROOT"
     echo "Run 'cwm-init' to scaffold one, or see"

--- a/bin/cwm-verify
+++ b/bin/cwm-verify
@@ -19,6 +19,15 @@ set -euo pipefail
 PROJECT_ROOT="$(pwd)"
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# --help must work outside a configured project: the whole point of asking a
+# command what it does is that you may not have set it up yet. Answer before the
+# precondition below, and let the script print its own text.
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h) exec php "${TOOLS_DIR}/scripts/verify.php" "$@" ;;
+    esac
+done
+
 if [ ! -f "${PROJECT_ROOT}/cwm-build.config.json" ]; then
     echo "Error: cwm-build.config.json not found in $PROJECT_ROOT"
     exit 1

--- a/scripts/bump.php
+++ b/scripts/bump.php
@@ -32,6 +32,45 @@ require_once __DIR__ . '/../src/Build/ManifestVersionWriter.php';
 require_once __DIR__ . '/../src/Release/VersionTracker.php';
 require_once __DIR__ . '/../src/Config/ProfileResolver.php';
 
+// Before the config check: asking a command what it does must work outside a
+// configured project, which is exactly where someone reads help from.
+if (in_array('--help', $argv, true) || in_array('-h', $argv, true)) {
+    echo <<<CWM_HELP
+cwm-bump — write a new version into every manifest this project ships.
+
+WHAT IT DOES
+  Reads cwm-build.config.json and writes the version into every manifest under
+  manifests.extensions[], plus manifests.package when one is declared. Also
+  syncs versions.json and package.json where the profile asks for it, so the
+  version a build labels itself with and the version its manifests carry cannot
+  drift apart.
+
+  The creation date defaults to today; -d overrides it for a reproducible build.
+
+PREREQUISITES
+  - cwm-build.config.json in the current directory.
+
+USAGE
+  composer cwm-bump -- -v 1.2.3
+  composer cwm-bump -- -v 1.2.3 --component plugin
+  composer cwm-bump -- -v 1.2.3 -d "2026-05-15"
+
+OPTIONS
+  -v <version>          Required. The version to write.
+  --component <type>    Bump only one component type (component, plugin,
+                        module, library, package).
+  -d <date>             Override the creationDate written into manifests.
+  -h, --help            This text.
+
+RELATED
+  composer cwm-build      # build the zip once the version is written
+  composer cwm-release    # the full pipeline, which bumps for you
+
+CWM_HELP;
+
+    exit(0);
+}
+
 $projectRoot = getcwd();
 $configFile  = $projectRoot . '/cwm-build.config.json';
 

--- a/tests/shell/help-is-inert.test.sh
+++ b/tests/shell/help-is-inert.test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# `--help` must print help and change nothing.
+#
+# cwm-sync-configs --help used to run the whole sync, rewriting .gitignore,
+# build.dist.properties, .editorconfig and phpunit.xml in whatever directory it
+# was called from. It was found by running --help across every cwm-* binary as
+# a post-upgrade smoke test and watching four working trees go dirty.
+#
+# Two properties are checked here, for every command at once:
+#
+#   1. nothing is written  — the defect above, for all of them, not just the
+#      one that had it
+#   2. help works outside a configured project — several wrappers checked for
+#      cwm-build.config.json before reaching the script that handles --help, so
+#      you had to already be set up to find out what a command did
+#
+# Commands still missing a --help text are listed in KNOWN_MISSING rather than
+# silently tolerated: the list is asserted to be exactly what is expected, so
+# fixing one without updating it fails, and so does a regression that adds one.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+# An empty directory: no config, no properties. Nothing here can act even if a
+# command wanted to, which is what makes running all of them safe.
+PROJECT="${WORK}/empty"
+mkdir -p "${PROJECT}"
+
+# Commands that do not yet print help. Each exits non-zero with its own usage
+# or a missing-prerequisite error — none of them writes — but they do not meet
+# the documented shape yet.
+KNOWN_MISSING="cwm-ars-create-stream cwm-ars-list cwm-ars-publish cwm-ars-reorder cwm-article cwm-changelog cwm-release cwm-sync-languages"
+
+MISSING_FOUND=""
+WROTE=""
+
+for BIN in "${ROOT}"/bin/cwm-*; do
+    NAME="$(basename "${BIN}")"
+
+    BEFORE="$(cd "${PROJECT}" && ls -a | sort | tr '\n' ' ')"
+    OUT="$(cd "${PROJECT}" && "${BIN}" --help 2>&1 </dev/null | head -1)"
+    AFTER="$(cd "${PROJECT}" && ls -a | sort | tr '\n' ' ')"
+
+    if [ "${BEFORE}" != "${AFTER}" ]; then
+        WROTE="${WROTE} ${NAME}"
+    fi
+
+    # A help text names its own command on the first line: "cwm-x — does y".
+    case "${OUT}" in
+        "${NAME} — "*) : ;;
+        *) MISSING_FOUND="${MISSING_FOUND} ${NAME}" ;;
+    esac
+done
+
+assert_equals "" "${WROTE}" "no command may write anything when asked for --help"
+
+# Compared as sorted sets so the assertion does not depend on glob order.
+EXPECTED="$(echo ${KNOWN_MISSING} | tr ' ' '\n' | sort | tr '\n' ' ')"
+ACTUAL="$(echo ${MISSING_FOUND} | tr ' ' '\n' | sed '/^$/d' | sort | tr '\n' ' ')"
+
+assert_equals "${EXPECTED}" "${ACTUAL}" "exactly the known commands lack a --help text"
+
+finish


### PR DESCRIPTION
Follows #144. Running `--help` across every `cwm-*` binary to verify that fix
turned up a second, quieter problem in seven more commands.

## `--help` required the project to already exist

`cwm-build`, `cwm-install-zip`, `cwm-link`, `cwm-link-check`, `cwm-package`,
`cwm-verify` and `cwm-bump` check for `cwm-build.config.json` in their `bin/`
wrapper **before** `exec`-ing the script — and the script is what handles
`--help`:

```
$ cwm-build --help
Error: cwm-build.config.json not found in /some/dir
```

So finding out what a command is for required already having set it up. That is
backwards: the moment you most need help is before the project exists.

The wrappers now answer `--help` ahead of the precondition:

```
$ cwm-build --help
cwm-build — build an installable extension zip from cwm-build.config.json.
```

A real invocation still refuses without a config — verified, not assumed.

`bump.php` had no `--help` at all, so passing the flag through just moved the
same error one layer down. It has a help text now.

## A test for all of them, not just the one that broke

```
assert_equals "" "${WROTE}" "no command may write anything when asked for --help"
assert_equals "${EXPECTED}" "${ACTUAL}" "exactly the known commands lack a --help text"
```

The first is #144's defect checked across **every** binary rather than the one
that had it. The second keeps the remaining gap honest: the set without help
text is asserted to be exactly the expected list, so fixing one without
updating the list fails — and so does a regression that adds one.

Both mutation-checked: reintroducing the sync-configs bug fails the first;
removing an entry from the list fails the second.

The whole audit runs against an empty temp directory, so no command can act
even if it wanted to.

## Still missing help text — deliberately listed, not hidden

`cwm-ars-create-stream`, `cwm-ars-list`, `cwm-ars-publish`, `cwm-ars-reorder`,
`cwm-article`, `cwm-changelog`, `cwm-release`, `cwm-sync-languages`.

**None writes on `--help`** — each hits an argument or environment guard and
exits non-zero with its own usage. `cwm-release` is safe because
`cwm_validate_release_version "--help"` rejects it before anything mutates,
which is safe by accident rather than by design, and worth knowing.

Full suite green: 559 PHPUnit, 35 Python, 13 shell files.