### PR TITLE
feat(setup): add cwm-sync-configs --check for CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`cwm-sync-configs --check`** — preview only, exit 1 if any managed config is
+  out of date. For CI, alongside the lints.
+
+  A managed block that has quietly fallen behind is invisible: it gets found
+  when someone happens to run a sync. That is how Proclaim's `.gitignore`
+  drifted unnoticed, and running `--check` across the four consumers today found
+  three stale files that nothing was reporting.
+
+  ⚠️ Only files the tool **maintains** count. `phpunit.xml` and
+  `docker-compose.databases.yml` are seeded once and never updated — they are an
+  offer, and a project that has not taken one up is not out of date. Advisory
+  lines (a locally-owned `.editorconfig`, a customised `.php-cs-fixer.dist.php`,
+  the `package.json` lint hint) describe a deliberate choice, not decay, and do
+  not affect the exit code. A check that always fails is one people learn to
+  ignore, which is the failure this exists to prevent rather than cause.
+
 ## [1.27.1] - 2026-08-18
 
 ### Fixed

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -18,7 +18,7 @@ matching Composer script (`composer cwm-init` → `vendor/bin/cwm-init`).
 |---|---|
 | `cwm-init` | Scaffold a `cwm-build.config.json` and run an initial config sync. Detects extension type/layout and pre-fills every prompt. Idempotent. |
 | `cwm-setup` | Interactive wizard that writes **`build.properties`** (your local Joomla install paths, URLs, DB/admin creds). Per-developer; never committed. |
-| `cwm-sync-configs` | Refresh managed config blocks in the consuming project — the `.gitignore` managed block and `eslint.config.mjs`. Only touches text between explicit markers. |
+| `cwm-sync-configs` | Refresh managed config blocks in the consuming project — the `.gitignore` managed block and `eslint.config.mjs`. Only touches text between explicit markers. `--check` previews and **exits 1** on drift, for CI — only maintained files count, not the seeded-once ones. |
 
 ## Local dev environment
 

--- a/scripts/sync-configs.php
+++ b/scripts/sync-configs.php
@@ -81,6 +81,12 @@ USAGE
 
 OPTIONS
   --dry-run    Preview only.
+  --check      Preview only, and exit 1 if any managed file is out of date.
+               For CI. Only files this tool maintains count -- phpunit.xml and
+               docker-compose.databases.yml are seeded once and never updated,
+               so not taking them up is not drift. The advisory lines about a
+               locally-owned .editorconfig or a customised .php-cs-fixer.dist.php
+               are choices, not decay, and do not affect the exit code.
   -h, --help   This text.
 
 RELATED
@@ -92,8 +98,41 @@ CWM_HELP;
     exit(0);
 }
 
-$opts   = getopt('', ['dry-run']);
-$dryRun = isset($opts['dry-run']);
+$opts   = getopt('', ['dry-run', 'check']);
+$check  = isset($opts['check']);
+
+// --check never writes. It answers "is anything out of date" and says so in the
+// exit code, so CI can gate on it the way it gates on the lints.
+$dryRun = $check || isset($opts['dry-run']);
+
+/**
+ * Managed files this run would have changed.
+ *
+ * ⚠️ Only files this tool *maintains* count. `phpunit.xml` and
+ * `docker-compose.databases.yml` are seeded once and never updated -- they are
+ * an offer, not a managed file, and a project that has not taken them up is not
+ * out of date. Failing CI over that would train people to ignore the check,
+ * which is the failure this exists to prevent rather than cause.
+ *
+ * The advisory lines are excluded for the same reason: `.editorconfig: locally
+ * owned`, a customised `.php-cs-fixer.dist.php`, and the `package.json`
+ * lint:js hint all describe a deliberate local choice, not decay.
+ *
+ * @var list<string>
+ */
+$GLOBALS['cwmSyncDrift'] = [];
+
+/**
+ * Record that a managed file is out of date.
+ *
+ * @param   string  $file  The file, as the reader would name it.
+ *
+ * @return  void
+ */
+function recordDrift(string $file): void
+{
+    $GLOBALS['cwmSyncDrift'][] = $file;
+}
 
 $configFile    = $projectRoot . '/cwm-build.config.json';
 $projectConfig = is_file($configFile) ? json_decode(file_get_contents($configFile), true) : [];
@@ -111,6 +150,33 @@ syncDatabaseComposeFile($projectRoot, $templates, $dryRun);
 syncEslint($projectRoot, $templates, $projectConfig, $dryRun);
 checkEslintInvocation($projectRoot);
 checkProfileHints($projectConfig, $toolsRoot);
+
+if ($check) {
+    $drift = $GLOBALS['cwmSyncDrift'];
+
+    echo "\n";
+
+    if ($drift === []) {
+        echo "Managed config is up to date.\n";
+
+        exit(0);
+    }
+
+    // ⚠️ Exit 1, so CI can gate on this. A managed block that has silently
+    // fallen behind is invisible otherwise -- it is found by someone happening
+    // to run a sync, which is how Proclaim's .gitignore drifted unnoticed.
+    echo 'Managed config is out of date (' . \count($drift) . "):\n";
+
+    foreach ($drift as $file) {
+        echo "  - {$file}\n";
+    }
+
+    echo "\nRun `composer sync-configs` to bring them up to date.\n";
+    echo "Anything above this summary without a `would` is advice, not drift,\n";
+    echo "and does not affect this exit code.\n";
+
+    exit(1);
+}
 
 echo $dryRun ? "(dry-run; no files written)\n" : "Done.\n";
 
@@ -135,6 +201,7 @@ function syncGitignore(string $projectRoot, string $templates, array $config, bo
     }
 
     if ($dryRun) {
+        recordDrift('.gitignore');
         echo ".gitignore: would update (dry-run)\n";
         echo "  - existing length: " . \strlen($existing) . " bytes\n";
         echo "  - new length:      " . \strlen($newContent) . " bytes\n";
@@ -361,6 +428,7 @@ function syncBuildDistProperties(string $projectRoot, string $templates, bool $d
     }
 
     if ($dryRun) {
+        recordDrift('build.dist.properties');
         echo "build.dist.properties: would " . ($existing === '' ? 'create' : 'update') . " (dry-run)\n";
 
         return;
@@ -415,6 +483,7 @@ function syncEditorConfig(string $projectRoot, string $templates, bool $dryRun):
     }
 
     if ($dryRun) {
+        recordDrift('.editorconfig');
         echo '.editorconfig: would ' . ($existing === '' ? 'create' : 'update') . " (dry-run)\n";
 
         return;
@@ -470,6 +539,7 @@ function syncPhpCsFixer(string $projectRoot, bool $dryRun): void
     }
 
     if ($dryRun) {
+        recordDrift('.php-cs-fixer.dist.php');
         echo '.php-cs-fixer.dist.php: would ' . ($existing === '' ? 'create' : 'update') . " wrapper (dry-run)\n";
 
         return;

--- a/tests/shell/sync-check.test.sh
+++ b/tests/shell/sync-check.test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# `cwm-sync-configs --check`: is any managed config out of date?
+#
+# The point is CI. A managed block that has quietly fallen behind is invisible
+# otherwise -- it gets found when someone happens to run a sync, which is
+# exactly how Proclaim's .gitignore drifted without anyone noticing.
+#
+# ⚠️ The load-bearing distinction is *maintained* versus *seeded*. phpunit.xml
+# and docker-compose.databases.yml are created once and never updated: they are
+# an offer, and a project that has not taken one up is not out of date. If those
+# counted, every consumer would fail forever, and a check that always fails is
+# one people learn to ignore -- the failure this exists to prevent, caused by
+# the check itself.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SYNC="${ROOT}/scripts/sync-configs.php"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+PROJECT="${WORK}/project"
+mkdir -p "${PROJECT}"
+printf '{"name":"demo/x"}\n' > "${PROJECT}/composer.json"
+printf '{"extension":{"name":"demo","type":"component"}}\n' > "${PROJECT}/cwm-build.config.json"
+
+# --- a project that has never been synced is out of date ---------------------
+
+( cd "${PROJECT}" && php "${SYNC}" --check >/dev/null 2>&1 )
+assert_equals "1" "$?" "an unsynced project reports drift"
+
+BEFORE="$(cd "${PROJECT}" && ls -a | sort | tr '\n' ' ')"
+( cd "${PROJECT}" && php "${SYNC}" --check >/dev/null 2>&1 )
+AFTER="$(cd "${PROJECT}" && ls -a | sort | tr '\n' ' ')"
+assert_equals "${BEFORE}" "${AFTER}" "--check must never write"
+
+# --- after a real sync it is up to date --------------------------------------
+
+( cd "${PROJECT}" && php "${SYNC}" >/dev/null 2>&1 )
+( cd "${PROJECT}" && php "${SYNC}" --check >/dev/null 2>&1 )
+assert_equals "0" "$?" "a freshly synced project is up to date"
+
+# --- ⚠️ a seeded file that was never taken up is NOT drift --------------------
+#
+# Delete both seeded files. The sync would offer to create them again, and that
+# must not fail the check.
+
+rm -f "${PROJECT}/phpunit.xml" "${PROJECT}/docker-compose.databases.yml"
+
+OUT="$( cd "${PROJECT}" && php "${SYNC}" --check 2>&1 )"
+( cd "${PROJECT}" && php "${SYNC}" --check >/dev/null 2>&1 )
+assert_equals "0" "$?" "a missing seeded file is an un-taken offer, not drift"
+assert_contains "${OUT}" "would create from boilerplate" "the offer is still reported"
+assert_contains "${OUT}" "up to date" "but the verdict is clean"
+
+# --- a managed file that has drifted DOES fail -------------------------------
+
+# Drop the first real entry from inside the managed block. Found rather than
+# hardcoded: an earlier version of this test removed 'node_modules/' while the
+# block actually contains '/node_modules/', so it changed nothing, the check
+# correctly said "up to date", and the test blamed the code.
+python3 - "${PROJECT}/.gitignore" <<'DRIFT'
+import sys
+
+path  = sys.argv[1]
+lines = open(path).read().split('\n')
+
+start = next(i for i, l in enumerate(lines) if 'cwm-build-tools: managed' in l)
+end   = next(i for i, l in enumerate(lines) if 'end managed' in l)
+
+for i in range(start + 1, end):
+    entry = lines[i].strip()
+
+    if entry and not entry.startswith('#'):
+        lines.pop(i)
+        break
+else:
+    raise SystemExit('no entry inside the managed block to remove')
+
+open(path, 'w').write('\n'.join(lines))
+DRIFT
+
+OUT="$( cd "${PROJECT}" && php "${SYNC}" --check 2>&1 )"
+( cd "${PROJECT}" && php "${SYNC}" --check >/dev/null 2>&1 )
+assert_equals "1" "$?" "a drifted managed block fails the check"
+assert_contains "${OUT}" ".gitignore" "the drifted file is named"
+assert_contains "${OUT}" "composer sync-configs" "and the fix is given"
+
+# --- --check implies dry-run: it reports without repairing --------------------
+
+DRIFTED="$(md5 -q "${PROJECT}/.gitignore" 2>/dev/null || md5sum "${PROJECT}/.gitignore" | cut -d' ' -f1)"
+( cd "${PROJECT}" && php "${SYNC}" --check >/dev/null 2>&1 )
+STILL="$(md5 -q "${PROJECT}/.gitignore" 2>/dev/null || md5sum "${PROJECT}/.gitignore" | cut -d' ' -f1)"
+
+assert_equals "${DRIFTED}" "${STILL}" "--check must not repair the file it reports"
+
+# --- and a real sync does repair it ------------------------------------------
+#
+# Without this the assertion above is satisfied by a --check that does nothing
+# at all, including reporting.
+
+( cd "${PROJECT}" && php "${SYNC}" >/dev/null 2>&1 )
+( cd "${PROJECT}" && php "${SYNC}" --check >/dev/null 2>&1 )
+assert_equals "0" "$?" "a real sync clears the drift the check reported"
+
+finish


### PR DESCRIPTION
A managed config block that has quietly fallen behind is invisible. It gets
found when someone happens to run a sync — which is how Proclaim's `.gitignore`
drifted with nobody noticing.

Running this across the four consumers found **three stale files that nothing
was reporting**:

```
Proclaim           .gitignore
CWMLivingWord      build.dist.properties
lib_cwmscripture   .editorconfig
```

`--check` previews and **exits 1** on drift, so CI can gate on it the way it
already gates on `cwm-lint-queries` and `cwm-lint-comments`. It implies
`--dry-run` and never writes.

## ⚠️ Only *maintained* files count

`phpunit.xml` and `docker-compose.databases.yml` are seeded once and never
updated. They are an offer, and a project that has not taken one up is not out
of date. The advisory lines — a locally-owned `.editorconfig`, a customised
`.php-cs-fixer.dist.php`, the `package.json` lint hint — describe a deliberate
choice rather than decay.

That distinction is the whole design. Counting the offers would fail every
consumer forever, and **a check that always fails is one people learn to
ignore** — the exact failure this is meant to prevent, caused by the check
itself.

CWMScriptureLinks is the proof: clean at **exit 0**, while still being offered
the compose file in the same output.

## Tests

Eleven assertions, including that a missing seeded file does not fail and a
drifted managed block does. Three mutations checked — making `--check` exit 0,
counting a seeded file as drift, and letting `--check` write — each fails it.

⚠️ **Two of those tests were wrong first**, and both are worth recording:

- the drift simulation removed `node_modules/` while the block contains
  `/node_modules/`. It changed nothing, the check correctly said "up to date",
  and the test blamed the code. It now finds the first real entry in the block
  rather than hardcoding one.
- the final assertion grepped for that same literal to decide whether `--check`
  had repaired the file. It now compares the file's hash — and a following
  assertion proves a real sync *does* repair it, so the pair cannot both be
  satisfied by a `--check` that does nothing at all.

Full suite green: 559 PHPUnit, 35 Python, 14 shell files.

## Not included

Wiring `--check` into the consumers' CI. That is four separate PRs and each
would fail on the drift above until it is synced — worth doing deliberately,
repo by repo, rather than as a side effect of this.