### PR TITLE
feat(cli): every command answers --help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Every `cwm-*` command now answers `--help`.** The last eight did not: the
+  four `cwm-ars-*`, `cwm-article`, `cwm-changelog`, `cwm-release` and
+  `cwm-sync-languages`.
+
+  Three different reasons, none of them "nobody wrote the text":
+  `cwm-release`'s help existed but its `bin/` wrapper checked for
+  `cwm-build.config.json` first; the ARS and changelog scripts loaded config
+  before parsing arguments; `cwm-ars-reorder` printed its own header with `sed`,
+  whose first line was blank; and `cwm-sync-languages` passed `--help` to a
+  Python script that parses `sys.argv` by hand and ignored it — exit 0, no
+  output, which reads as success.
+
+  The suite-wide test that tracked the gap now expects the list to be **empty**,
+  so a new command shipping without help fails it.
+
+### Added
+
 - **`cwm-sync-configs --check`** — preview only, exit 1 if any managed config is
   out of date. For CI, alongside the lints.
 

--- a/bin/cwm-article
+++ b/bin/cwm-article
@@ -19,6 +19,15 @@ set -euo pipefail
 PROJECT_ROOT="$(pwd)"
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# --help must work outside a configured project: the whole point of asking a
+# command what it does is that you may not have set it up yet. Answer before the
+# precondition below, and let the script print its own text.
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h) exec bash "${TOOLS_DIR}/scripts/cwm-article.sh" "$@" ;;
+    esac
+done
+
 if [ ! -f "${PROJECT_ROOT}/cwm-build.config.json" ]; then
     echo "Error: cwm-build.config.json not found in $PROJECT_ROOT"
     echo "Run 'cwm-init' to scaffold one, or see"

--- a/bin/cwm-release
+++ b/bin/cwm-release
@@ -15,6 +15,15 @@ set -euo pipefail
 PROJECT_ROOT="$(pwd)"
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# --help must work outside a configured project: the whole point of asking a
+# command what it does is that you may not have set it up yet. Answer before the
+# precondition below, and let the script print its own text.
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h) exec bash "${TOOLS_DIR}/scripts/release.sh" "$@" ;;
+    esac
+done
+
 if [ ! -f "${PROJECT_ROOT}/cwm-build.config.json" ]; then
     echo "Error: cwm-build.config.json not found in $PROJECT_ROOT"
     echo "Run 'cwm-init' to scaffold one, or see"

--- a/bin/cwm-sync-languages
+++ b/bin/cwm-sync-languages
@@ -19,4 +19,39 @@ set -euo pipefail
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# sync-languages.py parses sys.argv by hand and has no argparse, so --help
+# reached it and was silently ignored -- exit 0, no output, which reads as
+# success. Answered here instead.
+case "${1:-}" in
+    -h|--help)
+        cat <<'CWM_HELP'
+cwm-sync-languages — mirror and translate the project's Joomla language files.
+
+WHAT IT DOES
+  Copies every key from the source language into the other locales the project
+  ships, and fills anything missing using Google Translate. Existing
+  translations are left alone unless --force is given.
+
+  Translations are checked before they are accepted: placeholders, format
+  specifiers and HTML tags must survive intact, because a translated
+  placeholder never substitutes at runtime.
+
+PREREQUISITES
+  - python3
+  - A Google Translate API key, from 1Password or GOOGLE_TRANSLATE_API_KEY.
+
+USAGE
+  composer sync-languages                    # mirror keys, fill the gaps
+  composer sync-languages -- --force         # re-translate everything
+  composer sync-languages -- setup           # store the API key in 1Password
+
+OPTIONS
+  --force                  Re-translate keys that already have a translation.
+  --project-root <path>    Operate on another project. Defaults to $PWD.
+  -h, --help               This text.
+CWM_HELP
+        exit 0
+        ;;
+esac
+
 exec python3 "${TOOLS_DIR}/scripts/sync-languages.py" "$@"

--- a/scripts/ars-create-stream.sh
+++ b/scripts/ars-create-stream.sh
@@ -39,6 +39,38 @@
 #
 set -euo pipefail
 
+# ⚠️ Before the config check below. Asking a command what it does must work
+# outside a configured project -- that is exactly when someone reads help.
+case "${1:-}" in
+    -h|--help)
+        cat <<'CWM_HELP'
+cwm-ars-create-stream — create an ARS update stream under a category.
+
+WHAT IT DOES
+  Creates the update stream a Joomla extension's <updateservers> block points
+  at, under an existing ARS category. One stream per extension; a release then
+  publishes into it.
+
+PREREQUISITES
+  - cwm-build.config.json with an `ars.endpoint` and the category id.
+  - An ARS API token, from 1Password or ARS_API_TOKEN.
+
+USAGE
+  composer ars-create-stream -- --name "Proclaim" --category 5
+
+OPTIONS
+  --name <name>       Stream name, as it appears in ARS.
+  --category <id>     Category to create it under.
+  -h, --help          This text.
+
+RELATED
+  composer ars-list        # find the category id
+  composer ars-publish     # publish into the stream once it exists
+CWM_HELP
+        exit 0
+        ;;
+esac
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/optoken.sh
 source "${SCRIPT_DIR}/lib/optoken.sh"

--- a/scripts/ars-list.sh
+++ b/scripts/ars-list.sh
@@ -16,6 +16,41 @@
 #
 set -euo pipefail
 
+# ⚠️ Before the config check below. Asking a command what it does must work
+# outside a configured project -- that is exactly when someone reads help.
+case "${1:-}" in
+    -h|--help)
+        cat <<'CWM_HELP'
+cwm-ars-list — list ARS categories, update streams and releases.
+
+WHAT IT DOES
+  Reads the Akeeba Release System behind the endpoint in
+  cwm-build.config.json and prints what is there. Use it to find the
+  categoryId and updateStreamId a new project needs, and to check what a
+  release actually published.
+
+PREREQUISITES
+  - cwm-build.config.json with an `ars.endpoint`.
+  - An ARS API token, from 1Password (ars.tokenItem / ars.tokenVault) or
+    ARS_API_TOKEN in the environment.
+
+USAGE
+  composer ars-list                    # categories and update streams
+  composer ars-list -- categories      # categories only
+  composer ars-list -- streams         # update streams only
+  composer ars-list -- releases 3      # releases in category 3
+
+OPTIONS
+  -h, --help   This text.
+
+RELATED
+  composer ars-publish     # push a built artifact to ARS
+  composer ars-reorder     # space out a category's ordering
+CWM_HELP
+        exit 0
+        ;;
+esac
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/optoken.sh
 source "${SCRIPT_DIR}/lib/optoken.sh"

--- a/scripts/ars-publish.sh
+++ b/scripts/ars-publish.sh
@@ -52,6 +52,44 @@
 #
 set -euo pipefail
 
+# ⚠️ Before the config check below. Asking a command what it does must work
+# outside a configured project -- that is exactly when someone reads help.
+case "${1:-}" in
+    -h|--help)
+        cat <<'CWM_HELP'
+cwm-ars-publish — push a built artifact to Akeeba Release System.
+
+WHAT IT DOES
+  Creates the ARS release and its download item, pointing at the GitHub release
+  asset rather than uploading the file again. Verifies the local artifact and
+  the published asset are the same bytes before writing anything, so a release
+  cannot advertise a file that differs from the one that was tested.
+
+  Refuses when the category has no room below its lowest ordering: ARS reads
+  "latest" as the lowest value, and a tie there is what makes the Latest
+  Releases page stick on an old version. Run cwm-ars-reorder and try again.
+
+PREREQUISITES
+  - cwm-build.config.json with the `ars` block.
+  - A GitHub release carrying the artifact.
+  - An ARS API token, from 1Password or ARS_API_TOKEN.
+
+USAGE
+  composer ars-publish -- -v 1.2.3 -f build/dist/pkg_x-1.2.3.zip
+
+OPTIONS
+  -v <version>   Version being published.
+  -f <file>      The built artifact.
+  -h, --help     This text.
+
+RELATED
+  composer release         # the whole pipeline, which calls this
+  composer ars-reorder     # fix an ordering collision this refuses on
+CWM_HELP
+        exit 0
+        ;;
+esac
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(pwd)"
 

--- a/scripts/ars-reorder.sh
+++ b/scripts/ars-reorder.sh
@@ -49,7 +49,41 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -h|--help)
-            sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'
+            # ⚠️ A written text, not `sed` over this file's own header. That
+            # printed whatever happened to be on lines 2-24, which began with a
+            # bare `#` -- so the first line of help was blank, and anything
+            # checking that help names its command saw nothing.
+            cat <<'CWM_HELP'
+cwm-ars-reorder — space out an ARS category's ordering.
+
+WHAT IT DOES
+  ARS reads "latest" as the *lowest* `ordering` in a category, so a category
+  whose lowest value is already taken has no room for the next release, and a
+  tie there is what makes the Latest Releases page stick on an old version.
+
+  This renumbers the category with a stride, newest first, so the newest
+  release holds the lowest value and there is room to publish below it.
+
+  Plans by default and writes nothing. Pass --apply to make the change.
+
+PREREQUISITES
+  - cwm-build.config.json with an `ars.endpoint`.
+  - An ARS API token, from 1Password or ARS_API_TOKEN.
+
+USAGE
+  composer ars-reorder -- --category 5            # print the plan
+  composer ars-reorder -- --category 5 --apply    # make the change
+
+OPTIONS
+  --category <id>   The category to renumber.
+  --stride <n>      Gap between releases. Default 100.
+  --apply           Write the change. Without it, nothing is written.
+  -h, --help        This text.
+
+RELATED
+  composer ars-list       # find the category id
+  composer ars-publish    # what refuses when a category has no room
+CWM_HELP
             exit 0
             ;;
         *)

--- a/scripts/cwm-article.sh
+++ b/scripts/cwm-article.sh
@@ -64,6 +64,40 @@
 
 set -euo pipefail
 
+# ⚠️ Before the config check below. Asking a command what it does must work
+# outside a configured project -- that is exactly when someone reads help.
+case "${1:-}" in
+    -h|--help)
+        cat <<'CWM_HELP'
+cwm-article — post a release announcement article to christianwebministries.org.
+
+WHAT IT DOES
+  Publishes a "<Extension> X.Y.Z Released" article in the standard CWM format
+  and features it on the front page, un-featuring the previous release
+  announcement. Extension name, package manifest and GitHub repo come from
+  cwm-build.config.json.
+
+  ⚠️ This posts to the live CWM site.
+
+PREREQUISITES
+  - cwm-build.config.json with the announcement block.
+  - Joomla API credentials for christianwebministries.org, from 1Password.
+
+USAGE
+  composer article                              # version from the manifest
+  composer article -- 10.3.1                    # a specific version
+  composer article -- 10.3.1 path/to/bullets.txt
+
+OPTIONS
+  -h, --help   This text.
+
+RELATED
+  composer release     # the pipeline, which calls this last
+CWM_HELP
+        exit 0
+        ;;
+esac
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(pwd)"
 CONFIG_FILE="${PROJECT_ROOT}/cwm-build.config.json"

--- a/scripts/generate-changelog-entry.sh
+++ b/scripts/generate-changelog-entry.sh
@@ -26,6 +26,36 @@
 #
 set -euo pipefail
 
+# ⚠️ Before the config check below. Asking a command what it does must work
+# outside a configured project -- that is exactly when someone reads help.
+case "${1:-}" in
+    -h|--help)
+        cat <<'CWM_HELP'
+cwm-changelog — generate a Joomla changelog XML entry from a GitHub release.
+
+WHAT IT DOES
+  Reads the GitHub release notes for a version and writes the matching
+  <changelog> entry into the project's changelog XML — the file Joomla shows in
+  the update dialog. Existing entries are left alone.
+
+PREREQUISITES
+  - cwm-build.config.json naming the changelog file and the GitHub repo.
+  - `gh`, authenticated.
+  - A published GitHub release for that version.
+
+USAGE
+  composer changelog -- 1.2.3
+
+OPTIONS
+  -h, --help   This text.
+
+RELATED
+  composer release     # the pipeline, which calls this after tagging
+CWM_HELP
+        exit 0
+        ;;
+esac
+
 PROJECT_ROOT="$(pwd)"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_FILE="${PROJECT_ROOT}/cwm-build.config.json"

--- a/tests/shell/help-is-inert.test.sh
+++ b/tests/shell/help-is-inert.test.sh
@@ -35,10 +35,17 @@ trap 'rm -rf "${WORK}"' EXIT
 PROJECT="${WORK}/empty"
 mkdir -p "${PROJECT}"
 
-# Commands that do not yet print help. Each exits non-zero with its own usage
-# or a missing-prerequisite error — none of them writes — but they do not meet
-# the documented shape yet.
-KNOWN_MISSING="cwm-ars-create-stream cwm-ars-list cwm-ars-publish cwm-ars-reorder cwm-article cwm-changelog cwm-release cwm-sync-languages"
+# ⚠️ Empty, and it should stay that way.
+#
+# This began as a list of eight -- the four cwm-ars-*, cwm-article,
+# cwm-changelog, cwm-release and cwm-sync-languages -- none of which printed
+# help. They all do now, so the assertion below reads "no command lacks a help
+# text" rather than "these ones are excused".
+#
+# A new command that ships without help fails here, which is the point: the list
+# existed so the gap could not be forgotten, and an empty list is the strongest
+# form of that.
+KNOWN_MISSING=""
 
 MISSING_FOUND=""
 WROTE=""
@@ -64,8 +71,15 @@ done
 assert_equals "" "${WROTE}" "no command may write anything when asked for --help"
 
 # Compared as sorted sets so the assertion does not depend on glob order.
-EXPECTED="$(echo ${KNOWN_MISSING} | tr ' ' '\n' | sort | tr '\n' ' ')"
-ACTUAL="$(echo ${MISSING_FOUND} | tr ' ' '\n' | sed '/^$/d' | sort | tr '\n' ' ')"
+# Blank lines are dropped on both sides and the result trimmed, so an empty list
+# compares equal to an empty list -- `echo "" | tr` yields a space, not nothing,
+# which made the two differ while both were empty.
+normalise() {
+    echo "$1" | tr ' ' '\n' | sed '/^$/d' | sort | tr '\n' ' ' | sed 's/ *$//'
+}
+
+EXPECTED="$(normalise "${KNOWN_MISSING}")"
+ACTUAL="$(normalise "${MISSING_FOUND}")"
 
 assert_equals "${EXPECTED}" "${ACTUAL}" "exactly the known commands lack a --help text"
 


### PR DESCRIPTION
The last eight did not: the four `cwm-ars-*`, `cwm-article`, `cwm-changelog`,
`cwm-release` and `cwm-sync-languages`. They were listed in
`help-is-inert.test.sh` so the gap could not be forgotten — **that list is now
empty**, and a new command shipping without help fails the test.

## None was simply missing the text

Four different causes, which is why this was worth doing rather than assuming:

| command | why `--help` did nothing |
|---|---|
| `cwm-release` | **had** help; its `bin/` wrapper checked for `cwm-build.config.json` before `exec`, so it never arrived — the same defect fixed in seven other wrappers earlier |
| `ars-list`, `ars-publish`, `ars-create-stream`, `cwm-changelog` | loaded config before parsing arguments |
| `cwm-ars-reorder` | printed its own header via `sed -n '2,24p' "$0"`. Line 2 is a bare `#`, so **the first line of help was blank** and anything checking that help names its command saw nothing |
| `cwm-sync-languages` | passed `--help` to a Python script that parses `sys.argv` by hand with no argparse. Silently ignored: **exit 0, no output** — which reads as success |

That last one is the one I'd flag: a command that exits 0 and prints nothing is
indistinguishable from one that worked.

## Verified from an empty directory

Which is where help matters most — you read it before the project exists:

```
29 of 29 commands print help naming themselves, exit 0, write nothing
```

Normal invocations are unchanged; I checked that a non-help argument is not
swallowed (`cwm-ars-list releases 3` still reaches the config check).

Texts follow the shape `CLAUDE.md` documents. `cwm-ars-publish`'s explains why
it refuses on an ordering collision — the thing that actually stopped a release
today — and `cwm-article`'s says plainly that it posts to the live site.

## A bug in the test itself

Its set comparison used `echo "" | tr ' ' '\n'`, which yields a space rather
than nothing — so an empty expected list did not equal an empty actual one, and
the assertion failed while both were empty. Both sides are normalised now, which
is what let the list reach zero rather than stalling at one.

Mutation-checked: stripping help from any one command fails it.

Full suite: 559 PHPUnit, 35 Python, 14 shell files.