### PR TITLE
fix(vendor-check): do not fail on updates the repository cannot make

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`vendor:check` no longer fails on updates the repository cannot make.**
+  A nested Composer project that is a **git submodule** belongs to another
+  repository: its `composer.json` is committed there, and its dependencies move
+  when that project updates and releases.
+
+  Proclaim's weekly report failed on six such rows — `lib_cwmscripture` and
+  `scripturelinks` dev dependencies — none of which could be actioned from that
+  checkout. A report full of un-actionable rows is one people stop reading.
+
+  Those rows are still shown, as `ℹ submodule`, with a line saying why they do
+  not count. Nested projects that are plain subdirectories are unaffected and
+  still fail the check, because they *are* this repository's to update.
+
+  ⚠️ **Security advisories are deliberately not scoped this way** and still fail
+  for every scope. A vulnerable bundled package ships to end users whoever owns
+  the manifest.
+
 ## [1.28.0] - 2026-08-18
 
 ### Added

--- a/templates/vendor-check.js
+++ b/templates/vendor-check.js
@@ -25,6 +25,13 @@
  *
  * If vendors[] is empty or missing, only sections 2-4 are reported.
  *
+ * ⚠️ Nested projects that are git submodules are reported but do not affect the
+ * exit code for *updates*: their composer.json lives in another repository and
+ * moves when that project releases, so failing here asks for work this checkout
+ * cannot do. Security advisories are different and still fail for every scope --
+ * a vulnerable bundled package ships to end users no matter which repository
+ * owns the manifest.
+ *
  * Why nested projects matter: an extension may bundle its own Composer project
  * (its vendor/ tree committed and shipped to end users). Those dependencies are
  * invisible to a root-level `composer outdated`, so a vulnerable bundled package
@@ -116,6 +123,43 @@ function renderTable(headers, rows) {
     console.log(sep);
     rows.forEach(r => console.log(fmt(r)));
     console.log(sep);
+}
+
+/**
+ * Paths listed as git submodules, relative to ROOT.
+ *
+ * ⚠️ Used to decide what this repository can act on. A nested Composer project
+ * that is a submodule belongs to another repository: its composer.json is
+ * committed there, and its dependencies move when *that* project updates and
+ * releases. Reporting those as "updates available" here asks for work that
+ * cannot be done from this checkout, and a report full of un-actionable rows is
+ * one people stop reading.
+ *
+ * Read from .gitmodules rather than by shelling out, so this works in a plain
+ * export with no git available. A missing or unreadable file simply means no
+ * submodules.
+ */
+function submodulePaths() {
+    const file = path.join(ROOT, '.gitmodules');
+
+    if (!fs.existsSync(file)) {
+        return [];
+    }
+
+    let text;
+
+    try {
+        text = fs.readFileSync(file, 'utf8');
+    } catch {
+        return [];
+    }
+
+    return text
+        .split('\n')
+        .map(line => line.trim())
+        .filter(line => line.startsWith('path'))
+        .map(line => line.slice(line.indexOf('=') + 1).trim())
+        .filter(Boolean);
 }
 
 /**
@@ -231,17 +275,36 @@ function composerOutdated(cwd) {
 function checkPhpDependencies(nestedProjects) {
     console.log('\nPHP Dependencies (composer)');
 
-    const scopes = [{ label: '(root)', cwd: ROOT }].concat(
-        nestedProjects.map(p => ({ label: p, cwd: path.join(ROOT, p) }))
+    const submodules = submodulePaths();
+    const scopes     = [{ label: '(root)', cwd: ROOT, owned: true }].concat(
+        nestedProjects.map(p => ({
+            label: p,
+            cwd:   path.join(ROOT, p),
+            owned: !submodules.includes(p),
+        }))
     );
 
-    let hasUpdates = false;
-    const rows = [];
+    let hasUpdates   = false;
+    let hasSubmodule = false;
+    const rows       = [];
 
     for (const scope of scopes) {
         for (const p of composerOutdated(scope.cwd)) {
-            hasUpdates = true;
-            rows.push([scope.label, p.name, p.version || '?', p.latest || '?', '✗ Update']);
+            // Only an update this repository can actually make sets the exit
+            // code. A submodule's dependencies update when that project does.
+            if (scope.owned) {
+                hasUpdates = true;
+            } else {
+                hasSubmodule = true;
+            }
+
+            rows.push([
+                scope.label,
+                p.name,
+                p.version || '?',
+                p.latest || '?',
+                scope.owned ? '✗ Update' : 'ℹ submodule',
+            ]);
         }
     }
 
@@ -250,6 +313,12 @@ function checkPhpDependencies(nestedProjects) {
     }
 
     renderTable(['Scope', 'Package', 'Current', 'Latest', 'Status'], rows);
+
+    if (hasSubmodule) {
+        console.log('  ℹ submodule rows belong to another repository. They move when that');
+        console.log('    project updates and releases, and do not affect this exit code.');
+    }
+
     return hasUpdates;
 }
 

--- a/tests/shell/vendor-check-scope.test.sh
+++ b/tests/shell/vendor-check-scope.test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# vendor:check must not report work the repository cannot do.
+#
+# A nested Composer project that is a git submodule belongs to another
+# repository. Its composer.json is committed there and its dependencies move
+# when *that* project updates and releases. Proclaim's weekly report failed on
+# six such rows -- lib_cwmscripture and scripturelinks dev dependencies -- none
+# of which could be actioned from that checkout.
+#
+# A report full of un-actionable rows is one people stop reading, which is the
+# same failure this toolchain keeps finding elsewhere: a check whose output does
+# not mean what it says.
+#
+# ⚠️ Security advisories are deliberately NOT scoped this way. A vulnerable
+# bundled package ships to end users whoever owns the manifest.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CHECK="${ROOT}/templates/vendor-check.js"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+# --- submodulePaths() reads .gitmodules -------------------------------------
+#
+# Evaluated out of the file rather than mocked: the script is a program, not a
+# module, so it cannot be required without running. Pulling the one function out
+# tests the real parser.
+
+probe() {
+    ROOT_DIR="$1" node -e '
+        const fs   = require("fs");
+        const path = require("path");
+        const ROOT = process.env.ROOT_DIR;
+        const src  = fs.readFileSync(process.argv[1], "utf8");
+        const from = src.indexOf("function submodulePaths");
+        const to   = src.indexOf("\n}", from) + 2;
+        eval(src.slice(from, to));
+        console.log(JSON.stringify(submodulePaths()));
+    ' "${CHECK}"
+}
+
+mkdir -p "${WORK}/none"
+assert_equals "[]" "$(probe "${WORK}/none")" "no .gitmodules means no submodules"
+
+mkdir -p "${WORK}/two"
+cat > "${WORK}/two/.gitmodules" <<'GITMODULES'
+[submodule "libraries/lib_cwmscripture"]
+	path = libraries/lib_cwmscripture
+	url = https://github.com/Joomla-Bible-Study/lib_cwmscripture.git
+[submodule "plugins/content/scripturelinks"]
+	path = plugins/content/scripturelinks
+	url = git@github.com:Joomla-Bible-Study/CWMScriptureLinks.git
+GITMODULES
+
+assert_equals \
+    '["libraries/lib_cwmscripture","plugins/content/scripturelinks"]' \
+    "$(probe "${WORK}/two")" \
+    "both submodule paths are read, tabs and all"
+
+# A path= inside a url or name must not be picked up, and neither must a blank.
+mkdir -p "${WORK}/odd"
+printf '[submodule "a"]\n\tpath = vendor/a\n\turl = https://example.test/path=notthis.git\n' \
+    > "${WORK}/odd/.gitmodules"
+assert_equals '["vendor/a"]' "$(probe "${WORK}/odd")" "only the path key is read"
+
+# --- the exit code is scoped to what this repository owns --------------------
+#
+# Source-inspected: exercising the real decision needs installed Composer
+# projects with outdated dependencies, which is a network fixture rather than a
+# unit test. What is checkable is that a submodule scope does not set the flag
+# the exit code reads.
+
+BODY="$(sed -n '/function checkPhpDependencies/,/^}/p' "${CHECK}")"
+
+assert_contains "${BODY}" "submodulePaths()" "the check consults the submodule list"
+assert_contains "${BODY}" "owned: !submodules.includes(p)" "nested scopes are marked by ownership"
+assert_contains "${BODY}" "if (scope.owned)" "only an owned scope may set hasUpdates"
+assert_contains "${BODY}" "ℹ submodule" "submodule rows are still shown, with their own status"
+
+# The root is always owned; a bug there would silence real updates.
+assert_contains "${BODY}" "label: '(root)', cwd: ROOT, owned: true" "the root scope is always actionable"
+
+# --- advisories are NOT scoped this way --------------------------------------
+
+SEC="$(sed -n '/function checkSecurity/,/^}/p' "${CHECK}")"
+
+if echo "${SEC}" | grep -q 'owned'; then
+    assert_equals "unscoped" "scoped" "security must fail for every scope, submodule or not"
+else
+    assert_equals "unscoped" "unscoped" "security still fails for every scope"
+fi
+
+finish


### PR DESCRIPTION
Proclaim's weekly vendor report exits 1 on six rows it can do nothing about: dev
dependencies of `libraries/lib_cwmscripture` and `plugins/content/scripturelinks`.
Both are git submodules. Their `composer.json` is committed in another repository
and their dependencies move when *that* project updates and releases — so the
report asks, every week, for work that checkout cannot do.

A report full of un-actionable rows is one people stop reading, which is the same
failure this toolchain kept finding elsewhere this cycle: a check whose output
does not mean what it says.

## The distinction is ownership, not nesting

A nested Composer project that is a plain tracked subdirectory **is** this
repository's to update, and still fails the check. Proclaim's
`admin/src/Addons/Servers/Youtube` is exactly that — verified with `git ls-files`
— and is unaffected by this change.

Submodule paths are read out of `.gitmodules` directly rather than by shelling
out to `git`, so this behaves the same in an export with no git present.

## The rows are still shown

They render as `ℹ submodule` with a line under the table explaining why they do
not count toward the exit code. Hiding them would answer a different question —
"is anything out of date?" is still worth an answer, it just is not this
repository's to action.

## Security advisories are deliberately not scoped this way

`checkSecurity()` still fails for every scope. A vulnerable bundled package ships
to end users whoever owns the manifest. A test asserts `checkSecurity()` has no
notion of ownership, so that stays true if someone later refactors the scoping.

## Verification

Run live against Proclaim: exit 1 from a genuine root update
(`roave/security-advisories`), six rows marked `ℹ submodule`.

`tests/shell/vendor-check-scope.test.sh` — 9 assertions. The parser is exercised
for real (pulled out of the file and evaluated, since the script is a program
rather than a module), including a `.gitmodules` whose `url` contains `path=`,
which a looser filter would misread as a submodule path.

Both mutations checked, each fails as it should:
- making submodule rows count toward the exit code again
- loosening the `.gitmodules` filter to a substring match

Full suite green: 559 PHPUnit, 35 Python, 15 shell files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6R7PVoGnXK93SRiMUHntV