### PR TITLE
feat(ci): opt-in schema replay in the reusable workflow

### DIFF
--- a/.github/workflows/joomla-package-ci.yml
+++ b/.github/workflows/joomla-package-ci.yml
@@ -68,6 +68,11 @@ on:
         required: false
         type: boolean
         default: false
+      run-schema-replay:
+        description: 'Whether to run composer schema-replay against a scratch MySQL. Off by default: it needs a schemaReplay block in cwm-build.config.json and a committed baseline, and a project without them would fail on it. Runs as its own job, so the MySQL service only starts for projects that opt in.'
+        required: false
+        type: boolean
+        default: false
       php-extensions:
         description: 'Extensions for setup-php'
         required: false
@@ -214,3 +219,62 @@ jobs:
           name: package
           path: ${{ inputs.package-glob }}
           retention-days: 7
+
+  # The only check that EXECUTES an extension's migration files.
+  #
+  # A fresh install applies install.sql and Joomla stamps #__schemas at the
+  # newest version without running a single update file -- so the tests in the
+  # job above prove the destination schema is right while the files that get a
+  # real site there have only ever run on a user's machine, mid-upgrade.
+  #
+  # Its own job rather than a step in `ci`, because a service container cannot
+  # be declared conditionally: putting MySQL on `ci` would start a database for
+  # every consumer, including the ones not replaying anything. A job that does
+  # not run starts no services.
+  schema-replay:
+    name: Schema replay
+    if: inputs.run-schema-replay
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: cwm_replay
+          MYSQL_DATABASE: cwm_replay
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -pcwm_replay"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          submodules: ${{ inputs.submodules }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          # pdo_mysql on top of the project's own list: the replay connects
+          # over PDO, and a project that never talks to a database would not
+          # otherwise ask for it.
+          extensions: ${{ inputs.php-extensions }}, pdo_mysql
+          coverage: none
+          tools: composer:v2
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      # Replays under its own table prefix inside the database named here, and
+      # drops those tables afterwards. No database is created or dropped.
+      - name: Replay every migration against a scratch schema
+        run: composer schema-replay
+        env:
+          CWM_TEST_MYSQL_DSN: 'mysql:host=127.0.0.1;port=3306;dbname=cwm_replay'
+          CWM_TEST_MYSQL_USER: root
+          CWM_TEST_MYSQL_PASSWORD: cwm_replay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`run-schema-replay` input on the reusable `joomla-package-ci.yml`.** Off by
+  default. Turning it on runs `composer schema-replay` against a scratch MySQL,
+  so the migration files are executed on every pull request rather than only on
+  a user's site during an upgrade.
+
+  It is a **separate job**, not a step on `ci`. A service container cannot be
+  declared conditionally, so putting MySQL on `ci` would start a database for
+  every consumer including the ones not replaying anything; a job that does not
+  run starts no services.
+
+  Needs a `schemaReplay` block and a committed baseline in the project, which
+  is why it is opt-in rather than on by default.
+
 ## [1.29.1] - 2026-08-19
 
 ### Fixed

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -39,6 +39,24 @@ matching Composer script (`composer cwm-init` → `vendor/bin/cwm-init`).
 See [How to use → everyday commands](how-to-use.md#3-everyday-commands) for the
 typical day-to-day loop.
 
+### Running it in CI
+
+The reusable `joomla-package-ci.yml` workflow takes `run-schema-replay: true`:
+
+```yaml
+jobs:
+  ci:
+    uses: Joomla-Bible-Study/cwm-build-tools/.github/workflows/joomla-package-ci.yml@v1
+    with:
+      run-schema-replay: true
+```
+
+It runs as its own job with its own MySQL service, so a project that does not
+opt in starts no database. A project whose CI is hand-written adds the step
+itself and points `CWM_TEST_MYSQL_DSN` at whatever service that job already
+has — the replay uses its own table prefix, so it can share a database with the
+test suite without touching its tables.
+
 ### The schema replay extension root
 
 Joomla resolves `<schemapath>` and `<sql><file>` against `extension_root`, not


### PR DESCRIPTION
CWMLivingWord's CI is one line — it delegates entirely to `joomla-package-ci.yml` — so there was nowhere to add a replay step without un-sharing its pipeline. Same for CWMScriptureLinks.

New **`run-schema-replay`** input, off by default:

```yaml
jobs:
  ci:
    uses: Joomla-Bible-Study/cwm-build-tools/.github/workflows/joomla-package-ci.yml@v1
    with:
      run-schema-replay: true
```

It needs a `schemaReplay` block and a committed baseline in the project, so a consumer that hasn't done that work would fail on it. Opt-in is the honest default.

## Its own job, not a step

A service container **cannot be declared conditionally**. Putting MySQL on the `ci` job would start a database on every consumer's every pull request, including the ones replaying nothing. A job that does not run starts no services, so the cost falls only on projects that opted in.

It also keeps a replay failure legible: **Schema replay** fails on its own rather than turning up inside a job named "PHP Lint, Tests, Build".

`pdo_mysql` is added *on top of* the project's `php-extensions` rather than replacing them — the replay connects over PDO, and a project that never talks to a database would not otherwise ask for it.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6R7PVoGnXK93SRiMUHntV
