### PR TITLE
feat(ci): schema replay in the library workflow too

### DIFF
--- a/.github/workflows/joomla-library-ci.yml
+++ b/.github/workflows/joomla-library-ci.yml
@@ -86,6 +86,11 @@ on:
         required: false
         type: boolean
         default: false
+      run-schema-replay:
+        description: 'Whether to run composer schema-replay against a scratch MySQL. Off by default: it needs a schemaReplay block in cwm-build.config.json and a committed baseline, and a project without them would fail on it. Runs as its own job, so the MySQL service only starts for projects that opt in.'
+        required: false
+        type: boolean
+        default: false
       php-extensions:
         description: 'Extensions for setup-php'
         required: false
@@ -229,3 +234,61 @@ jobs:
           name: library
           path: ${{ inputs.package-glob }}
           retention-days: 7
+  # The only check that EXECUTES an extension's migration files.
+  #
+  # A fresh install applies install.sql and Joomla stamps #__schemas at the
+  # newest version without running a single update file -- so the tests in the
+  # job above prove the destination schema is right while the files that get a
+  # real site there have only ever run on a user's machine, mid-upgrade.
+  #
+  # Its own job rather than a step in `ci`, because a service container cannot
+  # be declared conditionally: putting MySQL on `ci` would start a database for
+  # every consumer, including the ones not replaying anything. A job that does
+  # not run starts no services.
+  schema-replay:
+    name: Schema replay
+    if: inputs.run-schema-replay
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: cwm_replay
+          MYSQL_DATABASE: cwm_replay
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -pcwm_replay"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          submodules: ${{ inputs.submodules }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          # pdo_mysql on top of the project's own list: the replay connects
+          # over PDO, and a project that never talks to a database would not
+          # otherwise ask for it.
+          extensions: ${{ inputs.php-extensions }}, pdo_mysql
+          coverage: none
+          tools: composer:v2
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      # Replays under its own table prefix inside the database named here, and
+      # drops those tables afterwards. No database is created or dropped.
+      - name: Replay every migration against a scratch schema
+        run: composer schema-replay
+        env:
+          CWM_TEST_MYSQL_DSN: 'mysql:host=127.0.0.1;port=3306;dbname=cwm_replay'
+          CWM_TEST_MYSQL_USER: root
+          CWM_TEST_MYSQL_PASSWORD: cwm_replay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`run-schema-replay` on the reusable `joomla-library-ci.yml` too.** 1.30.0
+  added it only to `joomla-package-ci.yml`, which left the one project on the
+  library variant — lib_cwmscripture — unable to turn it on.
+
+  The job is a copy rather than a nested reusable workflow: a local `uses:`
+  path inside a workflow that is itself being called resolves in a way that
+  cannot be verified without a consumer round-trip, and only one project uses
+  the library variant.
+
+  ⚠️ What copying costs is drift, so `tests/shell/reusable-replay-parity.test.sh`
+  asserts the job and the input are byte-identical in both files and that both
+  keep `default: false`. A fix applied to one and not the other fails there
+  rather than in the project still carrying the bug.
+
 ## [1.30.0] - 2026-08-19
 
 ### Added

--- a/tests/shell/reusable-replay-parity.test.sh
+++ b/tests/shell/reusable-replay-parity.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# The schema-replay job must be identical in both reusable CI workflows.
+#
+# joomla-package-ci.yml and joomla-library-ci.yml each carry their own copy.
+# Nesting one reusable workflow inside another would avoid the duplication, but
+# a local `uses:` path inside a workflow that is itself being called resolves in
+# a way that cannot be verified without a consumer round-trip, and only one
+# project uses the library variant. Copying was the cheaper certainty.
+#
+# What copying costs is drift: a fix applied to one and not the other is
+# invisible, and the project that noticed the bug is not the project still
+# carrying it. This test converts that into a failure — which is the whole
+# reason the duplication is acceptable.
+#
+# Compares the `schema-replay:` job and the `run-schema-replay:` input, not the
+# whole file: the two workflows differ everywhere else on purpose.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PKG="${ROOT}/.github/workflows/joomla-package-ci.yml"
+LIB="${ROOT}/.github/workflows/joomla-library-ci.yml"
+
+# Everything from the `schema-replay:` job header to end of file.
+extract_job() {
+    sed -n '/^  schema-replay:$/,$p' "$1"
+}
+
+# The input block, from its key to the next key at the same indent.
+extract_input() {
+    awk '
+        /^      run-schema-replay:$/ { grab = 1; print; next }
+        grab && /^      [a-z-]+:$/   { exit }
+        grab                          { print }
+    ' "$1"
+}
+
+PKG_JOB="$(extract_job "${PKG}")"
+LIB_JOB="$(extract_job "${LIB}")"
+
+# Guard against the extraction silently matching nothing, which would make the
+# comparison below pass by comparing two empty strings.
+if [ -z "${PKG_JOB}" ]; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: no schema-replay job found in joomla-package-ci.yml"
+else
+    PASS=$((PASS + 1))
+fi
+
+if [ -z "${LIB_JOB}" ]; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: no schema-replay job found in joomla-library-ci.yml"
+else
+    PASS=$((PASS + 1))
+fi
+
+assert_equals "${PKG_JOB}" "${LIB_JOB}" "the schema-replay job is identical in both reusable workflows"
+
+PKG_IN="$(extract_input "${PKG}")"
+LIB_IN="$(extract_input "${LIB}")"
+
+if [ -z "${PKG_IN}" ]; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: no run-schema-replay input found in joomla-package-ci.yml"
+else
+    PASS=$((PASS + 1))
+fi
+
+assert_equals "${PKG_IN}" "${LIB_IN}" "the run-schema-replay input is identical in both reusable workflows"
+
+# It must stay opt-in in both. A default of true would start a MySQL service on
+# every consumer's every pull request, including the ones replaying nothing.
+assert_contains "${PKG_IN}" "default: false" "package workflow keeps the input off by default"
+assert_contains "${LIB_IN}" "default: false" "library workflow keeps the input off by default"
+
+finish


### PR DESCRIPTION
1.30.0 added `run-schema-replay` to `joomla-package-ci.yml` only, which left the one project on the library variant — **lib_cwmscripture** — unable to turn it on. Same input, same job, now in both.

## Why a copy, not a nested workflow

A local `uses:` path inside a workflow that is itself being called resolves in a way I could not verify without a consumer round-trip, and exactly one project uses the library variant. Copying was the cheaper certainty.

## What the copy costs, and the guard for it

Drift: a fix applied to one and not the other is invisible — and the project that noticed the bug is not the project still carrying it.

`tests/shell/reusable-replay-parity.test.sh` converts that into a failure. The job and the input must be **byte-identical** in both files, and both must keep `default: false` — a default of `true` would start a MySQL service on every consumer's every pull request, including the ones replaying nothing.

Three mutations checked, all caught:

| mutation | caught |
|---|---|
| drift a value in one copy | ✅ |
| flip the default to `true` | ✅ |
| delete the job entirely | ✅ |

The empty-extraction guards matter more than they look — without them a deleted job would compare two empty strings and pass, which is the failure mode this whole test exists to prevent.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6R7PVoGnXK93SRiMUHntV
