### PR TITLE
fix(release): an unrecognised pre-release suffix is not stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **An unrecognised pre-release suffix no longer publishes to ARS as stable.**
+  `cwm_maturity_for_version()` matched `-alpha`, `-beta` and `-rc` and fell
+  through to `stable` for everything else, so `10.5.11-dev` was marked
+  pre-release on GitHub and handed to ARS as a normal update.
+
+  Maturity is not a label, it is the distribution gate: Joomla hides anything
+  below stable from sites that have not opted into pre-release updates. An edge
+  build cut to keep it out of public hands was therefore offered to every site
+  that checked for an update, and the publish succeeded and looked correct
+  (#155).
+
+  Any hyphenated suffix now reads as `alpha`. Guessing too low costs a build
+  fewer people see; guessing too high ships an edge build to everyone.
+
+  Three components read the same version string and one disagreed:
+  `cwm_is_prerelease()` tests `*-*`, `VersionTracker` tests
+  `/^\d+\.\d+\.\d+-/`, and both called `-dev` a pre-release while this
+  called it stable. `tests/shell/version.test.sh` now pins the invariant across
+  a table of suffixes rather than the three named cases — whatever
+  `cwm_is_prerelease()` calls a pre-release, this must not call stable.
+
+  Two paths reached it. `cwm-release` refuses a `-dev` version outright via
+  `cwm_validate_release_version`, so that path was already closed for `-dev` in
+  particular — but not for `-edge`, `-nightly` or anything else unrecognised;
+  and `ars-publish.sh` sources `lib/version.sh` without ever calling the
+  validator, so a direct `cwm-ars-publish` of a `-dev` version reached ARS as
+  stable.
+
 ## [1.32.0] - 2026-08-19
 
 ### Changed

--- a/scripts/lib/version.sh
+++ b/scripts/lib/version.sh
@@ -119,6 +119,21 @@ cwm_prerelease_flag() {
 # ARS classifies each release as alpha / beta / rc / stable, and the
 # version's own suffix already says which it is.
 #
+# Maturity is not a label — it is the distribution gate. Joomla hides anything
+# below stable from sites that have not opted into pre-release updates, so
+# "stable" is the answer that offers a build to every site that checks for an
+# update.
+#
+# So a suffix nobody here recognises reads as `alpha`, not `stable`. This used
+# to fall through to stable, which meant `10.5.11-dev` was marked pre-release on
+# GitHub and published to ARS as a normal update — the reverse of what the
+# suffix is for, with nothing in the run reporting a problem (#155). Guessing
+# too low costs a build fewer people see; guessing too high ships an edge build
+# to everyone.
+#
+# The invariant, pinned in tests/shell/version.test.sh: anything
+# cwm_is_prerelease() calls a pre-release, this must not call stable.
+#
 # Arguments:
 #   $1  version
 #
@@ -131,6 +146,7 @@ cwm_maturity_for_version() {
         *-alpha*) echo "alpha" ;;
         *-beta*)  echo "beta" ;;
         *-rc*)    echo "rc" ;;
+        *-*)      echo "alpha" ;;
         *)        echo "stable" ;;
     esac
 }

--- a/tests/shell/version.test.sh
+++ b/tests/shell/version.test.sh
@@ -50,6 +50,33 @@ assert_equals "beta" "$(cwm_maturity_for_version 10.4.0-beta1)" "beta maturity"
 assert_equals "rc" "$(cwm_maturity_for_version 10.4.0-rc1)" "rc maturity"
 assert_equals "stable" "$(cwm_maturity_for_version 10.3.6)" "no suffix is stable"
 
+# Maturity is the distribution gate, not a label: Joomla hides anything below
+# stable from sites that have not opted into pre-release updates. A suffix
+# nobody recognises used to fall through to stable, so a -dev build was marked
+# pre-release on GitHub and published to ARS as a normal update, offered to
+# every site that checked (#155).
+assert_equals "alpha" "$(cwm_maturity_for_version 10.5.11-dev)" "-dev is not stable"
+assert_equals "alpha" "$(cwm_maturity_for_version 10.5.11-dev20260819)" "a dated -dev is not stable"
+assert_equals "alpha" "$(cwm_maturity_for_version 10.5.11-edge)" "an unrecognised suffix is not stable"
+assert_equals "alpha" "$(cwm_maturity_for_version 10.5.11-nightly)" "-nightly is not stable"
+
+# The invariant the three components disagreed on. cwm_is_prerelease,
+# VersionTracker and this function all read the same string; whenever the first
+# says pre-release, this one must not say stable, or a build hidden on GitHub
+# is offered to everyone by ARS. Asserted over a table rather than the three
+# named suffixes, so a fourth cannot reintroduce the disagreement.
+for _v in 10.3.6 10.5.11-dev 10.5.11-dev20260819 10.5.11-alpha1 10.5.11-beta1 \
+          10.5.11-rc1 10.5.11-edge 10.5.11-nightly 10.5.11-preview 1.0.0-x.7.z.92; do
+    if cwm_is_prerelease "$_v"; then
+        _m="$(cwm_maturity_for_version "$_v")"
+        assert_equals "not-stable" "$([ "$_m" = stable ] && echo stable || echo not-stable)" \
+            "pre-release ${_v} is not published as stable"
+    else
+        assert_equals "stable" "$(cwm_maturity_for_version "$_v")" \
+            "stable ${_v} is published as stable"
+    fi
+done
+
 # --- Version from a manifest -------------------------------------------------
 # A package manifest lists member extensions after its own header; only
 # the first <version> is the package's.


### PR DESCRIPTION
Refs #155.

## The bug

`cwm_maturity_for_version()` matched `-alpha`, `-beta` and `-rc`, and fell through to `stable` for everything else — so `10.5.11-dev` was marked pre-release on GitHub and handed to ARS as a normal update.

Maturity is not a label, it is the distribution gate. Joomla hides anything below stable from sites that have not opted into pre-release updates, so an edge build cut precisely to keep it out of public hands was offered to every site that checked. The publish succeeded and looked correct.

```console
$ source scripts/lib/version.sh
10.5.11-dev      github_prerelease=YES  ars_maturity=stable   # before
10.5.11-dev      github_prerelease=YES  ars_maturity=alpha    # after
```

Any hyphenated suffix now reads as `alpha`. Guessing too low costs a build fewer people see; guessing too high ships an edge build to everyone.

## Two corrections to the issue's account

Both worth recording, because they change where the exposure actually was.

**1. `cwm-release` already refuses a `-dev` version.** `scripts/release.sh:258` calls `cwm_validate_release_version`, which returns 2 for anything matching `*-dev*` ("Development versions cannot be released. Use -alpha, -beta, or -rc for testing."). So the headline path — cutting a `-dev` edge release through `cwm-release` — was already closed for `-dev` specifically.

**2. What was actually reachable:**

- **Any *other* unrecognised suffix via `cwm-release`.** The validator only blocks `-dev`, so `-edge`, `-nightly` or `-preview` passed validation and published as `stable`. This was live.
- **`-dev` via `cwm-ars-publish` invoked directly.** `scripts/ars-publish.sh:97` sources `lib/version.sh` but never calls the validator, then reads maturity at `:195`. This was live.

## Tests

`tests/shell/version.test.sh` goes from 24 to 38 assertions: the four suffix cases, plus the invariant the three components disagreed on, asserted over a table rather than named cases —

> whatever `cwm_is_prerelease()` calls a pre-release, `cwm_maturity_for_version()` must not call stable

so a fifth suffix cannot reintroduce the disagreement.

## Still open, and not decided here

The issue's context says Proclaim "wants `-dev` for edge builds held back from public release." That is in direct tension with `cwm_validate_release_version`, which says `-dev` is *never* releasable and names `-alpha` / `-beta` / `-rc` as the pre-release channels. This PR makes the maturity honest either way; whether `-dev` should become releasable at all is a policy call left for #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)